### PR TITLE
:racehorse: :art: [cib/detail] Replace `type_pack_element` recursive …

### DIFF
--- a/include/cib/detail/type_pack_element.hpp
+++ b/include/cib/detail/type_pack_element.hpp
@@ -1,4 +1,5 @@
 #include <type_traits>
+#include <utility>
 
 
 #ifndef COMPILE_TIME_INIT_BUILD_TYPE_PACK_ELEMENT_HPP
@@ -10,14 +11,19 @@ namespace cib::detail {
         template<auto Index, typename... Tn>
         using type_pack_element = __type_pack_element<Index, Tn...>;
     #else
-        template<int Index, typename T, typename... Tn>
+        template<class, int>
+        struct type_id {};
+        template<class... Ts> struct inherit : Ts... {};
+        template<int Index, class T>
+        auto get_type_pack_element_impl(type_id<T, Index>) -> T;
+        template<int Index, typename... Ts, auto... Ns>
+        auto get_type_pack_element_impl(std::index_sequence<Ns...>) ->
+        decltype(get_type_pack_element_impl<Index>(inherit<type_id<Ts, Ns>...>{}));
+        template<int Index, typename... Ts>
         struct get_type_pack_element {
-            using type = typename get_type_pack_element<Index - 1, Tn...>::type;
-        };
-
-        template<typename T, typename... Tn>
-        struct get_type_pack_element<0, T, Tn...> {
-            using type = T;
+          using type = decltype(get_type_pack_element_impl<Index, Ts...>(
+            std::make_index_sequence<sizeof...(Ts)>{})
+          );
         };
 
         template<int Index, typename... Tn>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(compile_time_init_build)
 
 add_executable(tests
     detail/type_list.cpp
+    detail/type_pack_element.cpp
     detail/meta.cpp
     builder_meta.cpp
     callback.cpp

--- a/test/detail/type_pack_element.cpp
+++ b/test/detail/type_pack_element.cpp
@@ -1,0 +1,15 @@
+#include <cib/cib.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <type_traits>
+
+TEST_CASE("type pack element") {
+  static_assert(std::is_same_v<int, cib::detail::type_pack_element<0, int>>);
+  static_assert(std::is_same_v<int, cib::detail::type_pack_element<0, int, float>>);
+  static_assert(std::is_same_v<float, cib::detail::type_pack_element<1, int, float>>);
+  static_assert(std::is_same_v<void, cib::detail::type_pack_element<0, void, void, void>>);
+  static_assert(std::is_same_v<void, cib::detail::type_pack_element<1, void, void, void>>);
+  static_assert(std::is_same_v<void, cib::detail::type_pack_element<2, void, void, void>>);
+  static_assert(std::is_same_v<const int&, cib::detail::type_pack_element<0, const int&, void*>>);
+  static_assert(std::is_same_v<void*, cib::detail::type_pack_element<1, const int&, void*>>);
+}


### PR DESCRIPTION
…version

Problem:
- When `__type_pack_element` builtin is not implemented `type_pack_element`
  is using recursion which is slow to compile.

Solution:
- Speed up compilation time by replacing non-recursive version of type_pack_element when
  `__type_pack_element` is not available by creating inherited list of type
  and id pairs and leverage inheritance to get the Nth type pack
  element.