### PR TITLE
Fix create_type_names for GCC 12.2

### DIFF
--- a/include/cib/detail/set_details.hpp
+++ b/include/cib/detail/set_details.hpp
@@ -76,7 +76,7 @@ namespace cib::detail {
     };
 
     template<typename Tag>
-    constexpr static std::string_view name() {
+    CIB_CONSTEVAL static std::string_view name() {
         #if defined(__clang__)
             constexpr std::string_view function_name = __PRETTY_FUNCTION__;
             constexpr auto lhs = 44;
@@ -99,7 +99,7 @@ namespace cib::detail {
     }
 
     template<typename MetaFunc, typename... Types>
-    constexpr static auto create_type_names(std::size_t src) {
+    CIB_CONSTEVAL static auto create_type_names(std::size_t src) {
         if constexpr (sizeof...(Types) == 0) {
             return std::array<typename_map_entry, 0>{};
 

--- a/include/cib/detail/set_details.hpp
+++ b/include/cib/detail/set_details.hpp
@@ -87,7 +87,7 @@ namespace cib::detail {
             constexpr auto lhs = 59;
             constexpr auto rhs = function_name.size() - 51;
 
-        #elif #elif defined(_MSC_VER)
+        #elif defined(_MSC_VER)
             constexpr std::string_view function_name = __FUNCSIG__;
             constexpr auto lhs = 0;
             constexpr auto rhs = function_name.size();

--- a/include/flow/milestone.hpp
+++ b/include/flow/milestone.hpp
@@ -52,7 +52,7 @@ namespace flow {
         [[nodiscard]] constexpr bool operator==(milestone_base const & rhs) const {
             #if defined(__GNUC__) && __GNUC__ < 12
                 return this->hash == rhs.hash;
-            #elif
+            #else
                 return
                     (this->run) == (rhs.run) &&
                     (this->log_name) == (rhs.log_name);


### PR DESCRIPTION
Immediate (`consteval`) functions can't be called from `constexpr` functions. There is no reason for `create_type_names` not to be an immediate function, I think.

Note: re https://github.com/intel/compile-time-init-build/issues/27, I think this is related. The reason tests don't compile properly under GCC 11.2 (and now 12.2) is likely that `consteval` functions are being called from `constexpr` functions (or lambdas, which is the same thing). See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95968 - lambdas are implicitly `constexpr` (if they can be) but not implicitly immediate. I don't think this is a GCC bug.

With this change, all tests compile with GCC 12.2 except `nexus.cpp` and `flow.cpp`, which both run into the `constexpr`/`consteval` issue related to tuple handling.

The Array test compiles but fails at https://github.com/intel/compile-time-init-build/blob/main/test/container/Array.cpp#L46. Not sure why this changes with GCC 12.2, but zero-size C-style arrays are not standard in C++...