### PR TITLE
:bug: Fix constexpr evaluation for GCC 11

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,12 +49,11 @@ jobs:
             install: sudo apt update && sudo apt-get install -y clang-11
             cc: " /usr/lib/llvm-11/bin/clang"
             cxx: "/usr/lib/llvm-11/bin/clang++"
-            # gcc-11 c++20 is disabled because it fails to compile the unit tests
-#          - name: gcc-11
-#            cxx_standard: 20
-#            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt-get install -y gcc-11 g++-11
-#            cc: "/usr/bin/gcc-11"
-#            cxx: "/usr/bin/g++-11"
+          - name: gcc-11
+            cxx_standard: 20
+            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt-get install -y gcc-11 g++-11
+            cc: "/usr/bin/gcc-11"
+            cxx: "/usr/bin/g++-11"
           - name: gcc-10
             cxx_standard: 20
             install: sudo apt update && sudo apt-get install -y gcc-10

--- a/include/cib/detail/components.hpp
+++ b/include/cib/detail/components.hpp
@@ -13,7 +13,7 @@ namespace cib::detail {
 template <typename... Components>
 struct components : public detail::config_item {
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(Args const &...args) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...args) const {
         return cib::tuple_cat(Components::config.extends_tuple(args...)...);
     }
 };

--- a/include/cib/detail/conditional.hpp
+++ b/include/cib/detail/conditional.hpp
@@ -17,7 +17,7 @@ struct conditional : public config_item {
         : body{{}, configs...} {}
 
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(Args const &...) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...) const {
         if constexpr (condition(Args{}...)) {
             return body.extends_tuple(Args{}...);
         } else {
@@ -31,7 +31,7 @@ template <typename Lhs, typename Rhs> struct equality {
     CIB_CONSTEXPR static Rhs rhs{};
 
     template <typename... Args>
-    CIB_CONSTEVAL bool operator()(Args const &...args) const {
+    CIB_CONSTEXPR bool operator()(Args const &...args) const {
         return lhs(args...) ==
                rhs; // FIXME: this assumes the RHS is a literal value
     }
@@ -45,7 +45,7 @@ template <typename MatchType> struct arg {
     }
 
     template <typename... Args>
-    CIB_CONSTEVAL auto operator()(Args... args) const {
+    CIB_CONSTEXPR auto operator()(Args... args) const {
         return cib::make_tuple(self_type_index, args...)
             .fold_right(
                 detail::int_<0>, [=](auto elem, [[maybe_unused]] auto state) {

--- a/include/cib/detail/config_details.hpp
+++ b/include/cib/detail/config_details.hpp
@@ -27,7 +27,7 @@ struct config : public detail::config_item {
     }
 
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(Args const &...args) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...args) const {
         return ConfigArgs::value.apply([&](auto const &...config_args) {
             return configs_tuple.apply([&](auto const &...configs_pack) {
                 return cib::tuple_cat(

--- a/include/cib/detail/config_item.hpp
+++ b/include/cib/detail/config_item.hpp
@@ -8,7 +8,7 @@
 namespace cib::detail {
 struct config_item {
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(Args const &...) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...) const {
         return cib::tuple<>{};
     }
 };

--- a/include/cib/detail/exports.hpp
+++ b/include/cib/detail/exports.hpp
@@ -17,7 +17,7 @@ template <typename ServiceT, typename BuilderT> struct service_entry {
 
 template <typename... Services> struct exports : public detail::config_item {
     template <typename... InitArgs>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(InitArgs const &...) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(InitArgs const &...) const {
         return cib::make_tuple(extend<Services>{}...);
     }
 };

--- a/include/cib/detail/extend.hpp
+++ b/include/cib/detail/extend.hpp
@@ -20,7 +20,7 @@ struct extend : public config_item {
     }
 
     template <typename... InitArgs>
-    [[nodiscard]] CIB_CONSTEVAL auto extends_tuple(InitArgs const &...) const {
+    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(InitArgs const &...) const {
         return cib::make_tuple(*this);
     }
 };

--- a/test/container/Array.cpp
+++ b/test/container/Array.cpp
@@ -43,10 +43,8 @@ TEST_CASE("OutOfBoundsAccessClose", "[array]") {
     array[4] = 0u;
 }
 
-TEST_CASE("OutOfBoundsAccessEmpty", "[array]") {
-    Array<std::uint32_t, 0> array;
-
-    array[0] = 0u;
+TEST_CASE("DeclareEmpty", "[array]") {
+    [[maybe_unused]] Array<std::uint32_t, 0> array;
 }
 
 TEST_CASE("InitializationWithBuiltInArray", "[array]") {


### PR DESCRIPTION
GCC 11 correctly points out that the following cannot be compiled:

```cpp
struct S {
  int i{42};
  consteval auto func() { return i; }
};

constexpr auto call_func_on(auto obj) {
  return obj.func();
}

constexpr S s;
constexpr auto x = call_func_on(s);
```

Even though `s` is `constexpr`, inside `call_func_on` it's a parameter, and there's no such thing as constexpr function parameters in C++. So attempting to call a `consteval` function fails. When func is `constexpr`, everything is OK.

GCC 11 also correctly spots that indexing into a C-style array of size 0 is UB, so that test is changed to merely declaring an array of size 0. TBD: `Array<T, 0>` should simply not support many operations. See [what the standard says about `std::array<T, 0>`](http://eel.is/c++draft/array.zero).