### PR TITLE
:art: Inject ConcurrencyPolicy into dynamic_controller

### DIFF
--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -29,7 +29,7 @@ namespace interrupt {
  *
  * @tparam IRQs
  */
-template <typename RootT> class manager {
+template <typename RootT, typename ConcurrencyPolicyT> class manager {
   public:
     using InterruptHal = typename RootT::InterruptHal;
 
@@ -44,7 +44,7 @@ template <typename RootT> class manager {
 
     std::remove_cv_t<decltype(irqs_type)> irqs;
 
-    using Dynamic = dynamic_controller<RootT>;
+    using Dynamic = dynamic_controller<RootT, ConcurrencyPolicyT>;
 
   public:
     /**

--- a/test/conc/concurrency.hpp
+++ b/test/conc/concurrency.hpp
@@ -1,42 +1,57 @@
 #pragma once
 
-// NOTE: this is a mock implementation of concurrency
+#include <utility>
 
-namespace conc {
-template <typename Callable> inline void critical_section(Callable callable) {
-    callable();
-}
+// NOTE: this is a mock implementation of concurrency: it does nothing but
+// fulfil the required interface.
 
-/**
- * Safely poll on condition before entering a critical section.
- *
- * This construct ensures that the condition can be polled on without blocking
- * higher priority tasks or interrupts from being executed.
- *
- * @param condition Callable that returns true if the critical section can be
- * entered
- * @param callable  Callable to be executed within the critical section
- */
-template <typename ConditionType, typename CallableType>
-inline void critical_section(ConditionType condition, CallableType callable) {
-    while (true) {
-        if (condition()) {
-            // execute the main body of the critical section
-            callable();
-            return;
-        } else {
-            // if condition() is false, then re-enable interrupts to give higher
-            // priority tasks and interrupts an opportunity to be serviced
-            // before checking condition() again
+namespace test {
+
+class ConcurrencyPolicy {
+    /**
+     * An RAII object that represents holding a critical section. Execution
+     * enters the critical section on construction and leaves it on
+     * destruction.
+     */
+    class [[nodiscard]] CriticalSection {};
+
+  public:
+    /**
+     * Call a callable under a critical section.
+     *
+     * @param callable Callable to be executed within the critical section
+     */
+    template <typename CallableT>
+    static inline auto call_in_critical_section(CallableT &&callable)
+        -> decltype(auto) {
+        [[maybe_unused]] CriticalSection cs{};
+        return std::forward<CallableT>(callable)();
+    }
+
+    /**
+     * Safely poll on condition before entering a critical section.
+     *
+     * This construct ensures that the condition can be polled on without
+     * blocking higher priority tasks or interrupts from being executed.
+     *
+     * @param predicate Callable that returns true if the critical section can
+     *                  be entered
+     * @param callable  Callable to be executed within the critical section
+     */
+    template <typename PredicateT, typename CallableT>
+    static inline auto call_in_critical_section(PredicateT &&predicate,
+                                                CallableT &&callable)
+        -> decltype(auto) {
+        while (true) {
+            [[maybe_unused]] CriticalSection cs{};
+            if (predicate()) {
+                return std::forward<CallableT>(callable)();
+            }
+            // if predicate() is false, then re-enable interrupts to give
+            // higher priority tasks and interrupts an opportunity to be
+            // serviced before checking again
         }
     }
-}
-
-class CriticalSection {
-  public:
-    CriticalSection() {}
-
-    ~CriticalSection() {}
 };
 
-} // namespace conc
+} // namespace test


### PR DESCRIPTION
It's better to pass a policy as a template argument than rely on a global dependency.