### PR TITLE
:art: Use #pragma once consistently

### DIFF
--- a/examples/hello_world/core.hpp
+++ b/examples/hello_world/core.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_SAY_MESSAGE_HPP
-#define CIB_SAY_MESSAGE_HPP
+#pragma once
 
 #include <cib/cib.hpp>
 
@@ -8,5 +7,3 @@ struct say_message : public cib::callback_meta<> {};
 struct core {
     constexpr static auto config = cib::config(cib::exports<say_message>);
 };
-
-#endif // CIB_SAY_MESSAGE_HPP

--- a/examples/hello_world/dont_panic.hpp
+++ b/examples/hello_world/dont_panic.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_DONT_PANIC_HPP
-#define CIB_DONT_PANIC_HPP
+#pragma once
 
 #include <cib/cib.hpp>
 
@@ -17,5 +16,3 @@ struct dont_panic {
     constexpr static auto config = cib::config(
         cib::extend<say_message>(&say_it), cib::extend<say_message>(&so_long));
 };
-
-#endif // CIB_DONT_PANIC_HPP

--- a/examples/hello_world/hello_world.hpp
+++ b/examples/hello_world/hello_world.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_HELLO_WORLD_HPP
-#define CIB_HELLO_WORLD_HPP
+#pragma once
 
 #include <cib/cib.hpp>
 
@@ -12,5 +11,3 @@ struct hello_world {
     constexpr static auto config =
         cib::components<core, say_hello_world, lazy_dog, dont_panic>;
 };
-
-#endif // CIB_HELLO_WORLD_HPP

--- a/examples/hello_world/lazy_dog.hpp
+++ b/examples/hello_world/lazy_dog.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_LAZY_DOG_HPP
-#define CIB_LAZY_DOG_HPP
+#pragma once
 
 #include <cib/cib.hpp>
 
@@ -14,5 +13,3 @@ struct lazy_dog {
     constexpr static auto config =
         cib::config(cib::extend<say_message>(&talk_about_the_dog));
 };
-
-#endif // CIB_LAZY_DOG_HPP

--- a/examples/hello_world/say_hello_world.hpp
+++ b/examples/hello_world/say_hello_world.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_SAY_HELLO_WORLD_HPP
-#define CIB_SAY_HELLO_WORLD_HPP
+#pragma once
 
 #include <cib/cib.hpp>
 
@@ -9,5 +8,3 @@ struct say_hello_world {
     constexpr static auto config = cib::config(cib::extend<say_message>(
         []() { std::cout << "Hello, world!" << std::endl; }));
 };
-
-#endif // CIB_SAY_HELLO_WORLD_HPP

--- a/include/cib/builder_meta.hpp
+++ b/include/cib/builder_meta.hpp
@@ -1,5 +1,4 @@
-#ifndef COMPILE_TIME_INIT_BUILD_BUILDER_META_HPP
-#define COMPILE_TIME_INIT_BUILD_BUILDER_META_HPP
+#pragma once
 
 namespace cib {
 /**
@@ -25,5 +24,3 @@ template <typename BuilderType, typename InterfaceType> struct builder_meta {
     auto interface() -> InterfaceType;
 };
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_BUILDER_META_HPP

--- a/include/cib/built.hpp
+++ b/include/cib/built.hpp
@@ -1,8 +1,6 @@
-#include <cib/builder_meta.hpp>
-#include <cib/detail/builder_traits.hpp>
+#pragma once
 
-#ifndef COMPILE_TIME_INIT_BUILD_BUILT_HPP
-#define COMPILE_TIME_INIT_BUILD_BUILT_HPP
+#include <cib/detail/builder_traits.hpp>
 
 namespace cib {
 /**
@@ -15,5 +13,3 @@ namespace cib {
  */
 template <typename ServiceMeta> traits::interface_t<ServiceMeta> service;
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_BUILT_HPP

--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -1,12 +1,11 @@
+#pragma once
+
 #include <cib/builder_meta.hpp>
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/meta.hpp>
 
 #include <array>
 #include <type_traits>
-
-#ifndef COMPILE_TIME_INIT_BUILD_CALLBACK_HPP
-#define COMPILE_TIME_INIT_BUILD_CALLBACK_HPP
 
 namespace cib {
 /**
@@ -129,5 +128,3 @@ template <typename... ArgTypes>
 struct callback_meta : public cib::builder_meta<callback<0, ArgTypes...>,
                                                 void (*)(ArgTypes...)> {};
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_CALLBACK_HPP

--- a/include/cib/cib.hpp
+++ b/include/cib/cib.hpp
@@ -1,5 +1,4 @@
-#ifndef COMPILE_TIME_INIT_BUILD_CIB_HPP
-#define COMPILE_TIME_INIT_BUILD_CIB_HPP
+#pragma once
 
 /*
  * Boost Software License - Version 1.0 - August 17th, 2003
@@ -45,5 +44,3 @@
 #include <cib/tuple.hpp>
 #include <interrupt/manager.hpp>
 #include <log/log.hpp>
-
-#endif // COMPILE_TIME_INIT_BUILD_CIB_HPP

--- a/include/cib/config.hpp
+++ b/include/cib/config.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cib/builder_meta.hpp>
 #include <cib/detail/builder_traits.hpp>
 #include <cib/detail/compiler.hpp>
@@ -8,11 +10,6 @@
 #include <cib/detail/exports.hpp>
 #include <cib/detail/extend.hpp>
 #include <cib/detail/meta.hpp>
-
-#include <type_traits>
-
-#ifndef COMPILE_TIME_INIT_BUILD_CONFIG_HPP
-#define COMPILE_TIME_INIT_BUILD_CONFIG_HPP
 
 namespace cib {
 /**
@@ -107,5 +104,3 @@ template <typename Predicate, typename... Configs>
     return detail::conditional{predicate, configs...};
 }
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_CONFIG_HPP

--- a/include/cib/detail/builder_traits.hpp
+++ b/include/cib/detail/builder_traits.hpp
@@ -1,9 +1,8 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 
 #include <utility>
-
-#ifndef COMPILE_TIME_INIT_BUILD_BUILDER_TRAITS_HPP
-#define COMPILE_TIME_INIT_BUILD_BUILDER_TRAITS_HPP
 
 namespace cib::traits {
 template <typename BuilderMeta> struct builder {
@@ -23,5 +22,3 @@ template <typename BuilderMeta> struct interface {
 template <typename BuilderMeta>
 using interface_t = typename interface<BuilderMeta>::type;
 } // namespace cib::traits
-
-#endif // COMPILE_TIME_INIT_BUILD_BUILDER_TRAITS_HPP

--- a/include/cib/detail/compiler.hpp
+++ b/include/cib/detail/compiler.hpp
@@ -1,5 +1,4 @@
-#ifndef COMPILE_TIME_INIT_BUILD_COMPILER_HPP
-#define COMPILE_TIME_INIT_BUILD_COMPILER_HPP
+#pragma once
 
 #ifndef __cpp_constinit
 #if defined(__clang__)
@@ -18,5 +17,3 @@
 #endif
 
 #define CIB_CONSTEXPR constexpr
-
-#endif // COMPILE_TIME_INIT_BUILD_COMPILER_HPP

--- a/include/cib/detail/components.hpp
+++ b/include/cib/detail/components.hpp
@@ -1,13 +1,8 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
-#include <cib/detail/meta.hpp>
-#include <cib/detail/type_list.hpp>
 #include <cib/tuple.hpp>
-
-#include <type_traits>
-
-#ifndef COMPILE_TIME_INIT_BUILD_COMPONENTS_HPP
-#define COMPILE_TIME_INIT_BUILD_COMPONENTS_HPP
 
 namespace cib::detail {
 template <typename... Components>
@@ -18,5 +13,3 @@ struct components : public detail::config_item {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_COMPONENTS_HPP

--- a/include/cib/detail/conditional.hpp
+++ b/include/cib/detail/conditional.hpp
@@ -1,11 +1,9 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/config_details.hpp>
 #include <cib/detail/config_item.hpp>
-#include <cib/detail/type_list.hpp>
 #include <cib/tuple.hpp>
-
-#ifndef COMPILE_TIME_INIT_BUILD_CONDITIONAL_HPP
-#define COMPILE_TIME_INIT_BUILD_CONDITIONAL_HPP
 
 namespace cib::detail {
 template <typename Condition, typename... Configs>
@@ -61,5 +59,3 @@ template <typename MatchType> struct arg {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_CONDITIONAL_HPP

--- a/include/cib/detail/config_details.hpp
+++ b/include/cib/detail/config_details.hpp
@@ -1,11 +1,11 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/detail/meta.hpp>
-#include <cib/detail/type_list.hpp>
 #include <cib/tuple.hpp>
 
-#ifndef COMPILE_TIME_INIT_BUILD_DETAIL_CONFIG_HPP
-#define COMPILE_TIME_INIT_BUILD_DETAIL_CONFIG_HPP
+#include <type_traits>
 
 namespace cib::detail {
 template <auto Value>
@@ -37,5 +37,3 @@ struct config : public detail::config_item {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_DETAIL_CONFIG_HPP

--- a/include/cib/detail/config_item.hpp
+++ b/include/cib/detail/config_item.hpp
@@ -1,9 +1,7 @@
-#include <cib/detail/compiler.hpp>
-#include <cib/detail/type_list.hpp>
-#include <cib/tuple.hpp>
+#pragma once
 
-#ifndef COMPILE_TIME_INIT_BUILD_CONFIG_DETAIL_HPP
-#define COMPILE_TIME_INIT_BUILD_CONFIG_DETAIL_HPP
+#include <cib/detail/compiler.hpp>
+#include <cib/tuple.hpp>
 
 namespace cib::detail {
 struct config_item {
@@ -13,5 +11,3 @@ struct config_item {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_CONFIG_DETAIL_HPP

--- a/include/cib/detail/exports.hpp
+++ b/include/cib/detail/exports.hpp
@@ -1,13 +1,9 @@
-#include <cib/detail/builder_traits.hpp>
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/detail/extend.hpp>
-#include <cib/detail/type_list.hpp>
-
-#include <utility>
-
-#ifndef COMPILE_TIME_INIT_BUILD_EXPORTS_HPP
-#define COMPILE_TIME_INIT_BUILD_EXPORTS_HPP
+#include <cib/tuple.hpp>
 
 namespace cib::detail {
 template <typename ServiceT, typename BuilderT> struct service_entry {
@@ -22,5 +18,3 @@ template <typename... Services> struct exports : public detail::config_item {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_EXPORTS_HPP

--- a/include/cib/detail/extend.hpp
+++ b/include/cib/detail/extend.hpp
@@ -1,11 +1,8 @@
+#pragma once
+
 #include <cib/detail/builder_traits.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/tuple.hpp>
-
-#include <utility>
-
-#ifndef COMPILE_TIME_INIT_BUILD_EXTEND_HPP
-#define COMPILE_TIME_INIT_BUILD_EXTEND_HPP
 
 namespace cib::detail {
 template <typename ServiceType, typename... Args>
@@ -25,5 +22,3 @@ struct extend : public config_item {
     }
 };
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_EXTEND_HPP

--- a/include/cib/detail/meta.hpp
+++ b/include/cib/detail/meta.hpp
@@ -1,10 +1,10 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
-#include <cib/tuple.hpp>
 
+#include <cstddef>
 #include <type_traits>
-
-#ifndef COMPILE_TIME_INIT_BUILD_META_HPP
-#define COMPILE_TIME_INIT_BUILD_META_HPP
+#include <utility>
 
 namespace cib::detail {
 template <int value>
@@ -52,5 +52,3 @@ CIB_CONSTEXPR inline void for_each(
     for_each(seq, operation);
 }
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_META_HPP

--- a/include/cib/detail/nexus_details.hpp
+++ b/include/cib/detail/nexus_details.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 #include <cib/detail/exports.hpp>
 #include <cib/detail/meta.hpp>
@@ -5,8 +7,8 @@
 #include <cib/set.hpp>
 #include <cib/tuple.hpp>
 
-#ifndef COMPILE_TIME_INIT_BUILD_NEXUS_DETAILS_HPP
-#define COMPILE_TIME_INIT_BUILD_NEXUS_DETAILS_HPP
+#include <type_traits>
+#include <utility>
 
 namespace cib {
 struct extract_service_tag {
@@ -68,7 +70,4 @@ template <typename Config, typename Tag> struct initialized {
     CIB_CONSTEXPR static auto value =
         initialized_builders_v<Config>.get(cib::tag_<Tag>).builder;
 };
-
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_NEXUS_DETAILS_HPP

--- a/include/cib/detail/set_details.hpp
+++ b/include/cib/detail/set_details.hpp
@@ -1,10 +1,12 @@
+#pragma once
+
 #include <cib/tuple.hpp>
 
 #include <array>
+#include <cstddef>
+#include <iterator>
 #include <string_view>
-
-#ifndef CIB_SET_DETAILS_HPP
-#define CIB_SET_DETAILS_HPP
+#include <utility>
 
 namespace cib::detail {
 // https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme
@@ -229,5 +231,3 @@ struct set_operation_algorithm {
     }
 };
 } // namespace cib::detail
-
-#endif // CIB_SET_DETAILS_HPP

--- a/include/cib/detail/type_list.hpp
+++ b/include/cib/detail/type_list.hpp
@@ -1,11 +1,9 @@
+#pragma once
+
 #include <cib/detail/type_pack_element.hpp>
 
 #include <array>
-#include <type_traits>
 #include <utility>
-
-#ifndef COMPILE_TIME_INIT_BUILD_TYPE_LIST_HPP
-#define COMPILE_TIME_INIT_BUILD_TYPE_LIST_HPP
 
 namespace cib::detail {
 template <typename... Values> struct type_list {
@@ -64,5 +62,3 @@ constexpr auto type_list_cat(TypeLists... type_lists) {
         type_lists...);
 }
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_TYPE_LIST_HPP

--- a/include/cib/detail/type_pack_element.hpp
+++ b/include/cib/detail/type_pack_element.hpp
@@ -1,8 +1,6 @@
-#include <type_traits>
-#include <utility>
+#pragma once
 
-#ifndef COMPILE_TIME_INIT_BUILD_TYPE_PACK_ELEMENT_HPP
-#define COMPILE_TIME_INIT_BUILD_TYPE_PACK_ELEMENT_HPP
+#include <utility>
 
 namespace cib::detail {
 #if defined(__clang__)
@@ -25,5 +23,3 @@ template <int Index, typename... Tn>
 using type_pack_element = typename get_type_pack_element<Index, Tn...>::type;
 #endif
 } // namespace cib::detail
-
-#endif // COMPILE_TIME_INIT_BUILD_TYPE_PACK_ELEMENT_HPP

--- a/include/cib/nexus.hpp
+++ b/include/cib/nexus.hpp
@@ -1,12 +1,10 @@
+#pragma once
+
 #include <cib/built.hpp>
 #include <cib/detail/compiler.hpp>
-#include <cib/detail/meta.hpp>
 #include <cib/detail/nexus_details.hpp>
 
 #include <type_traits>
-
-#ifndef COMPILE_TIME_INIT_BUILD_NEXUS_HPP
-#define COMPILE_TIME_INIT_BUILD_NEXUS_HPP
 
 namespace cib {
 /**
@@ -52,5 +50,3 @@ template <typename Config> struct nexus {
     }
 };
 } // namespace cib
-
-#endif // COMPILE_TIME_INIT_BUILD_NEXUS_HPP

--- a/include/cib/set.hpp
+++ b/include/cib/set.hpp
@@ -1,8 +1,7 @@
+#pragma once
+
 #include <cib/detail/meta.hpp>
 #include <cib/detail/set_details.hpp>
-
-#ifndef CIB_SET_HPP
-#define CIB_SET_HPP
 
 namespace cib {
 template <typename LhsTuple, typename RhsTuple, typename MetaFunc = self_type>
@@ -170,5 +169,3 @@ template <typename MetaFunc, typename Tuple>
 #undef tags
 }
 } // namespace cib
-
-#endif // CIB_SET_HPP

--- a/include/cib/top.hpp
+++ b/include/cib/top.hpp
@@ -1,9 +1,8 @@
+#pragma once
+
 #include <cib/config.hpp>
 #include <cib/nexus.hpp>
 #include <flow/flow.hpp>
-
-#ifndef COMPILE_TIME_INIT_BUILD_TOP_HPP
-#define COMPILE_TIME_INIT_BUILD_TOP_HPP
 
 namespace cib {
 /**
@@ -69,5 +68,3 @@ template <typename ProjectConfig> class top {
     static auto &service = my_nexus.template service<ServiceMeta>;
 };
 } // namespace cib
-
-#endif

--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cib/detail/compiler.hpp>
 
 #include <array>
@@ -7,9 +9,6 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
-
-#ifndef COMPILE_TIME_INIT_BUILD_TUPLE_HPP
-#define COMPILE_TIME_INIT_BUILD_TUPLE_HPP
 
 namespace cib {
 template <typename T> struct tag_t {};
@@ -545,5 +544,3 @@ template <typename... Tuples> constexpr auto tuple_cat(Tuples &&...tuples) {
 template <typename... Elements>
 struct std::tuple_size<cib::tuple_impl<Elements...>>
     : std::integral_constant<std::size_t, sizeof...(Elements)> {};
-
-#endif // COMPILE_TIME_INIT_BUILD_TUPLE_HPP

--- a/include/interrupt/builder/irq_builder.hpp
+++ b/include/interrupt/builder/irq_builder.hpp
@@ -1,13 +1,8 @@
-#include <interrupt/config/fwd.hpp>
-#include <interrupt/fwd.hpp>
+#pragma once
+
 #include <interrupt/impl/irq_impl.hpp>
 
-#include <boost/hana.hpp>
-
 #include <type_traits>
-
-#ifndef CIB_INTERRUPT_BUILDER_IRQ_BUILDER_HPP
-#define CIB_INTERRUPT_BUILDER_IRQ_BUILDER_HPP
 
 namespace interrupt {
 /**
@@ -73,5 +68,3 @@ template <typename ConfigT> struct irq_builder {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_BUILDER_IRQ_BUILDER_HPP

--- a/include/interrupt/builder/shared_irq_builder.hpp
+++ b/include/interrupt/builder/shared_irq_builder.hpp
@@ -1,15 +1,12 @@
+#pragma once
+
 #include <interrupt/builder/shared_sub_irq_builder.hpp>
 #include <interrupt/builder/sub_irq_builder.hpp>
-#include <interrupt/config/fwd.hpp>
-#include <interrupt/fwd.hpp>
 #include <interrupt/impl/shared_irq_impl.hpp>
 
 #include <boost/hana.hpp>
 
 #include <type_traits>
-
-#ifndef CIB_INTERRUPT_BUILDER_SHARED_IRQ_BUILDER_HPP
-#define CIB_INTERRUPT_BUILDER_SHARED_IRQ_BUILDER_HPP
 
 namespace interrupt {
 /**
@@ -27,8 +24,9 @@ template <typename ConfigT> struct shared_irq_builder {
     constexpr static auto children = ConfigT::children;
 
     constexpr static auto irqs_type =
-        hana::transform(ConfigT::children, [](auto child) {
-            if constexpr (hana::size(child.children) > hana::size_c<0>) {
+        boost::hana::transform(ConfigT::children, [](auto child) {
+            if constexpr (boost::hana::size(child.children) >
+                          boost::hana::size_c<0>) {
                 return shared_sub_irq_builder<decltype(child)>{};
             } else {
                 return sub_irq_builder<decltype(child)>{};
@@ -39,7 +37,7 @@ template <typename ConfigT> struct shared_irq_builder {
 
     template <typename IrqType, typename T>
     void constexpr add(T const &flow_description) {
-        hana::for_each(irqs, [&](auto &irq) {
+        boost::hana::for_each(irqs, [&](auto &irq) {
             irq.template add<IrqType>(flow_description);
         });
     }
@@ -53,6 +51,7 @@ template <typename ConfigT> struct shared_irq_builder {
      */
     template <typename BuilderValue>
     [[nodiscard]] auto constexpr build() const {
+        using namespace boost;
         auto constexpr builder = BuilderValue::value;
 
         auto constexpr irq_indices = hana::to<hana::tuple_tag>(
@@ -70,5 +69,3 @@ template <typename ConfigT> struct shared_irq_builder {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_BUILDER_SHARED_IRQ_BUILDER_HPP

--- a/include/interrupt/builder/shared_sub_irq_builder.hpp
+++ b/include/interrupt/builder/shared_sub_irq_builder.hpp
@@ -1,14 +1,11 @@
+#pragma once
+
 #include <interrupt/builder/sub_irq_builder.hpp>
-#include <interrupt/config/fwd.hpp>
-#include <interrupt/fwd.hpp>
 #include <interrupt/impl/shared_sub_irq_impl.hpp>
 
 #include <boost/hana.hpp>
 
 #include <type_traits>
-
-#ifndef CIB_INTERRUPT_BUILDER_SHARED_SUB_IRQ_BUILDER_HPP
-#define CIB_INTERRUPT_BUILDER_SHARED_SUB_IRQ_BUILDER_HPP
 
 namespace interrupt {
 template <typename ConfigT> struct shared_sub_irq_builder {
@@ -17,8 +14,9 @@ template <typename ConfigT> struct shared_sub_irq_builder {
     constexpr static auto children = ConfigT::children;
 
     constexpr static auto irqs_type =
-        hana::transform(ConfigT::children, [](auto child) {
-            if constexpr (hana::size(child.children) > hana::size_c<0>) {
+        boost::hana::transform(ConfigT::children, [](auto child) {
+            if constexpr (boost::hana::size(child.children) >
+                          boost::hana::size_c<0>) {
                 return shared_sub_irq_builder<decltype(child)>{};
             } else {
                 return sub_irq_builder<decltype(child)>{};
@@ -29,7 +27,7 @@ template <typename ConfigT> struct shared_sub_irq_builder {
 
     template <typename IrqType, typename T>
     void constexpr add(T const &flow_description) {
-        hana::for_each(irqs, [&](auto &irq) {
+        boost::hana::for_each(irqs, [&](auto &irq) {
             irq.template add<IrqType>(flow_description);
         });
     }
@@ -43,6 +41,7 @@ template <typename ConfigT> struct shared_sub_irq_builder {
      */
     template <typename BuilderValue>
     [[nodiscard]] auto constexpr build() const {
+        using namespace boost;
         auto constexpr builder = BuilderValue::value;
 
         auto constexpr irq_indices = hana::to<hana::tuple_tag>(
@@ -60,5 +59,3 @@ template <typename ConfigT> struct shared_sub_irq_builder {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_BUILDER_SHARED_SUB_IRQ_BUILDER_HPP

--- a/include/interrupt/builder/sub_irq_builder.hpp
+++ b/include/interrupt/builder/sub_irq_builder.hpp
@@ -1,13 +1,10 @@
-#include <interrupt/config/fwd.hpp>
-#include <interrupt/fwd.hpp>
+#pragma once
+
 #include <interrupt/impl/sub_irq_impl.hpp>
 
 #include <boost/hana.hpp>
 
 #include <type_traits>
-
-#ifndef CIB_INTERRUPT_BUILDER_SUB_IRQ_BUILDER_HPP
-#define CIB_INTERRUPT_BUILDER_SUB_IRQ_BUILDER_HPP
 
 namespace interrupt {
 /**
@@ -66,5 +63,3 @@ template <typename ConfigT> struct sub_irq_builder {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_BUILDER_SUB_IRQ_BUILDER_HPP

--- a/include/interrupt/config/fwd.hpp
+++ b/include/interrupt/config/fwd.hpp
@@ -1,6 +1,3 @@
-#ifndef CIB_INTERRUPT_CONFIG_FWD_HPP
-#define CIB_INTERRUPT_CONFIG_FWD_HPP
+#pragma once
 
 using EnableActionType = void (*)();
-
-#endif // CIB_INTERRUPT_CONFIG_FWD_HPP

--- a/include/interrupt/config/irq.hpp
+++ b/include/interrupt/config/irq.hpp
@@ -1,11 +1,11 @@
+#pragma once
 
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
 
-#ifndef CIB_INTERRUPT_CONFIG_IRQ_HPP
-#define CIB_INTERRUPT_CONFIG_IRQ_HPP
+#include <cstddef>
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -44,5 +44,3 @@ struct irq {
     constexpr static auto irq_number = IrqNumberT;
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_CONFIG_IRQ_HPP

--- a/include/interrupt/config/root.hpp
+++ b/include/interrupt/config/root.hpp
@@ -1,10 +1,9 @@
+#pragma once
+
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
-
-#ifndef CIB_INTERRUPT_CONFIG_ROOT_HPP
-#define CIB_INTERRUPT_CONFIG_ROOT_HPP
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -40,5 +39,3 @@ template <typename InterruptHalT, typename... IrqsT> struct root {
         });
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_CONFIG_ROOT_HPP

--- a/include/interrupt/config/shared_irq.hpp
+++ b/include/interrupt/config/shared_irq.hpp
@@ -1,10 +1,9 @@
+#pragma once
+
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
-
-#ifndef CIB_INTERRUPT_CONFIG_SHARED_IRQ_HPP
-#define CIB_INTERRUPT_CONFIG_SHARED_IRQ_HPP
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -51,5 +50,3 @@ struct shared_irq {
     constexpr static auto irq_number = IrqNumberT;
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_CONFIG_SHARED_IRQ_HPP

--- a/include/interrupt/config/shared_sub_irq.hpp
+++ b/include/interrupt/config/shared_sub_irq.hpp
@@ -1,10 +1,9 @@
+#pragma once
+
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
-
-#ifndef CIB_INTERRUPT_CONFIG_SHARED_SUB_IRQ_HPP
-#define CIB_INTERRUPT_CONFIG_SHARED_SUB_IRQ_HPP
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -27,5 +26,3 @@ struct shared_sub_irq {
     constexpr static hana::tuple<SubIrqs...> children{};
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_CONFIG_SHARED_SUB_IRQ_HPP

--- a/include/interrupt/config/sub_irq.hpp
+++ b/include/interrupt/config/sub_irq.hpp
@@ -1,10 +1,9 @@
+#pragma once
+
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
-
-#ifndef CIB_INTERRUPT_CONFIG_SUB_IRQ_HPP
-#define CIB_INTERRUPT_CONFIG_SUB_IRQ_HPP
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -41,5 +40,3 @@ struct sub_irq {
     constexpr static hana::tuple<> children{};
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_CONFIG_SUB_IRQ_HPP

--- a/include/interrupt/fwd.hpp
+++ b/include/interrupt/fwd.hpp
@@ -1,17 +1,9 @@
+#pragma once
+
 #include <flow/flow.hpp>
 
-#include <boost/hana.hpp>
-
-#ifndef CIB_INTERRUPT_FWD_HPP
-#define CIB_INTERRUPT_FWD_HPP
-
 namespace interrupt {
-namespace hana = boost::hana;
-using namespace hana::literals;
-
 using FunctionPtr = std::add_pointer<void()>::type;
 
 template <typename Name = void> using irq_flow = flow::builder<Name, 16, 8>;
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_FWD_HPP

--- a/include/interrupt/impl/irq_impl.hpp
+++ b/include/interrupt/impl/irq_impl.hpp
@@ -1,8 +1,9 @@
-#ifndef CIB_INTERRUPT_IMPL_IRQ_IMPL_HPP
-#define CIB_INTERRUPT_IMPL_IRQ_IMPL_HPP
+#pragma once
 
 #include <interrupt/config/fwd.hpp>
 #include <interrupt/fwd.hpp>
+
+#include <boost/hana.hpp>
 
 namespace interrupt {
 /**
@@ -52,7 +53,9 @@ template <typename ConfigT, typename FlowTypeT> struct irq_impl {
         enable_action<InterruptHal, active>();
     }
 
-    inline auto get_interrupt_enables() const { return hana::make_tuple(); }
+    inline auto get_interrupt_enables() const {
+        return boost::hana::make_tuple();
+    }
 
     /**
      * Run the interrupt service routine and clear any pending interrupt status.
@@ -71,5 +74,3 @@ template <typename ConfigT, typename FlowTypeT> struct irq_impl {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_IMPL_IRQ_IMPL_HPP

--- a/include/interrupt/impl/manager_impl.hpp
+++ b/include/interrupt/impl/manager_impl.hpp
@@ -1,11 +1,10 @@
+#pragma once
+
 #include <interrupt/manager_interface.hpp>
 
 #include <boost/hana.hpp>
 
-#include <type_traits>
-
-#ifndef CIB_INTERRUPT_IMPL_MANAGER_IMPL_HPP
-#define CIB_INTERRUPT_IMPL_MANAGER_IMPL_HPP
+#include <cstddef>
 
 namespace interrupt {
 namespace hana = boost::hana;
@@ -104,5 +103,3 @@ class manager_impl : public manager_interface {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_IMPL_MANAGER_IMPL_HPP

--- a/include/interrupt/impl/shared_sub_irq_impl.hpp
+++ b/include/interrupt/impl/shared_sub_irq_impl.hpp
@@ -1,8 +1,8 @@
-#include <interrupt/config/fwd.hpp>
-#include <interrupt/fwd.hpp>
+#pragma once
 
-#ifndef CIB_INTERRUPT_IMPL_SHARED_SUB_IRQ_IMPL_HPP
-#define CIB_INTERRUPT_IMPL_SHARED_SUB_IRQ_IMPL_HPP
+#include <interrupt/config/fwd.hpp>
+
+#include <boost/hana.hpp>
 
 namespace interrupt {
 template <typename ConfigT, typename... SubIrqImpls>
@@ -26,13 +26,14 @@ struct shared_sub_irq_impl {
     constexpr static auto status_field = ConfigT::status_field;
     using StatusPolicy = typename ConfigT::StatusPolicy;
 
-    hana::tuple<SubIrqImpls...> sub_irq_impls;
+    boost::hana::tuple<SubIrqImpls...> sub_irq_impls;
 
   public:
     explicit constexpr shared_sub_irq_impl(SubIrqImpls const &...impls)
         : sub_irq_impls(impls...) {}
 
     auto get_interrupt_enables() const {
+        using namespace boost;
         if constexpr (active) {
             auto const active_sub_irq_impls =
                 hana::filter(sub_irq_impls, [](auto irq) {
@@ -63,7 +64,7 @@ struct shared_sub_irq_impl {
                 apply(read((*status_field)(1)))) {
                 StatusPolicy::run([&] { apply(clear(*status_field)); },
                                   [&] {
-                                      hana::for_each(
+                                      boost::hana::for_each(
                                           sub_irq_impls,
                                           [](auto irq) { irq.run(); });
                                   });
@@ -72,5 +73,3 @@ struct shared_sub_irq_impl {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_IMPL_SHARED_SUB_IRQ_IMPL_HPP

--- a/include/interrupt/impl/sub_irq_impl.hpp
+++ b/include/interrupt/impl/sub_irq_impl.hpp
@@ -1,7 +1,8 @@
+#pragma once
+
 #include <interrupt/fwd.hpp>
 
-#ifndef CIB_INTERRUPT_IMPL_SUB_IRQ_IMPL_HPP
-#define CIB_INTERRUPT_IMPL_SUB_IRQ_IMPL_HPP
+#include <boost/hana.hpp>
 
 namespace interrupt {
 /**
@@ -36,7 +37,7 @@ template <typename ConfigT, typename FlowTypeT> struct sub_irq_impl {
         : interrupt_service_routine(flow) {}
 
     [[nodiscard]] auto get_interrupt_enables() const {
-        return hana::make_tuple(*enable_field);
+        return boost::hana::make_tuple(*enable_field);
     }
 
     /**
@@ -59,5 +60,3 @@ template <typename ConfigT, typename FlowTypeT> struct sub_irq_impl {
     }
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_IMPL_SUB_IRQ_IMPL_HPP

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -7,14 +7,12 @@
 #include <interrupt/builder/sub_irq_builder.hpp>
 #include <interrupt/config.hpp>
 #include <interrupt/dynamic_controller.hpp>
-#include <interrupt/fwd.hpp>
 #include <interrupt/impl/manager_impl.hpp>
 #include <interrupt/manager_interface.hpp>
 #include <interrupt/policies.hpp>
 
 #include <boost/hana.hpp>
 
-#include <tuple>
 #include <type_traits>
 
 namespace interrupt {

--- a/include/interrupt/manager_interface.hpp
+++ b/include/interrupt/manager_interface.hpp
@@ -1,5 +1,4 @@
-#ifndef CIB_INTERRUPT_MANAGER_INTERFACE_HPP
-#define CIB_INTERRUPT_MANAGER_INTERFACE_HPP
+#pragma once
 
 namespace interrupt {
 /**
@@ -12,5 +11,3 @@ class manager_interface {
     virtual void init_sub_interrupts() const = 0;
 };
 } // namespace interrupt
-
-#endif // CIB_INTERRUPT_MANAGER_INTERFACE_HPP


### PR DESCRIPTION
Some headers were using `#pragma once`, some were using include guards. This commit changes them all to use `#pragma once`. In addition, some redundant includes were removed from a few places.