### PR TITLE
:white_check_mark: Structure units tests better

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -102,7 +102,7 @@ jobs:
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
 
       - name: Build Unit Tests
-        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -t all-cib-tests
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -t unit_tests
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,10 @@ target_compile_options(
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    include(cmake/test.cmake)
     include(cmake/warnings.cmake)
 
     # Enable functional and performance test suites.
-    enable_testing()
     add_subdirectory(test)
     add_subdirectory(benchmark)
     add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -122,15 +122,19 @@ downloaded. To avoid re-downloading dependencies when reconfiguring cmake, it's
 recommended to designate a cache directory and set the `CPM_SOURCE_CACHE`
 environment variable.
 
-Unit tests are registered with CTest:
+Unit tests are registered with CTest, and will build and run as part of the
+built-in `all` target.
 
 ```shell
 cmake -B build
-cmake --build build -t all-cib-tests
-ctest --test-dir build
+cmake --build build
 ```
 
-This will build and run all the unit tests with CMake, Catch2 and GTest.
+This will build and run all the unit tests with Catch2 and GTest. To re-run them:
+
+```shell
+ctest --test-dir build
+```
 
 ## Features
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(compilation_benchmark big_nexus.cpp)
+add_executable(compilation_benchmark EXCLUDE_FROM_ALL big_nexus.cpp)
 
 target_compile_options(
     compilation_benchmark

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -14,7 +14,7 @@ function(clang_tidy_header HEADER TARGET)
                 ${HEADER}
         DEPENDS ${HEADER} ${CMAKE_SOURCE_DIR}/.clang-tidy)
 
-    add_library(${CT_NAME} ${CPP_NAME})
+    add_library(${CT_NAME} EXCLUDE_FROM_ALL ${CPP_NAME})
     target_link_libraries(${CT_NAME} PRIVATE ${TARGET})
     set_target_properties(
         ${CT_NAME}

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,0 +1,48 @@
+enable_testing()
+add_custom_target(unit_tests)
+
+if(DEFINED ENV{CXX_STANDARD} AND NOT $ENV{CXX_STANDARD} EQUAL "")
+    set(CMAKE_CXX_STANDARD $ENV{CXX_STANDARD})
+else()
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+add_versioned_package("gh:catchorg/Catch2@3.1.1")
+add_versioned_package("gh:google/googletest#release-1.12.1")
+
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+include(Catch)
+include(GoogleTest)
+
+function(add_unit_test name)
+    set(options CATCH2 GTEST)
+    set(multiValueArgs FILES INCLUDE_DIRECTORIES LIBRARIES SYSTEM_LIBRARIES)
+    cmake_parse_arguments(UNIT "${options}" "" "${multiValueArgs}" ${ARGN})
+
+    add_executable(${name} ${UNIT_FILES})
+    target_include_directories(${name} PRIVATE ${UNIT_INCLUDE_DIRECTORIES})
+    target_link_libraries(${name} PRIVATE ${UNIT_LIBRARIES})
+    target_link_libraries_system(${name} PRIVATE ${UNIT_SYSTEM_LIBRARIES})
+
+    set(target_test_command $<TARGET_FILE:${name}>)
+
+    if(UNIT_CATCH2)
+        catch_discover_tests(${name})
+        target_link_libraries_system(${name} PRIVATE Catch2::Catch2WithMain)
+    elseif(UNIT_GTEST)
+        gtest_discover_tests(${name})
+        target_link_libraries_system(${name} PRIVATE gmock gtest gmock_main)
+    else()
+        add_test(NAME ${name} COMMAND ${target_test_command})
+    endif()
+
+    add_custom_target(all_${name} ALL DEPENDS run_${name})
+    add_custom_target(run_${name} DEPENDS ${name}.passed)
+    add_custom_command(
+        OUTPUT ${name}.passed
+        COMMAND ${target_test_command}
+        COMMAND ${CMAKE_COMMAND} "-E" "touch" "${name}.passed"
+        DEPENDS ${name})
+
+    add_dependencies(unit_tests "run_${name}")
+endfunction()

--- a/include/cib/detail/set_details.hpp
+++ b/include/cib/detail/set_details.hpp
@@ -53,32 +53,45 @@ template <typename T> CIB_CONSTEVAL static void quicksort(T &collection) {
 
 namespace cib::detail {
 struct typename_map_entry {
-    std::string_view name;
-    std::size_t index;
-    std::size_t src;
+    std::string_view name{};
+    std::size_t index{};
+    std::size_t src{};
 
-    constexpr auto operator<(typename_map_entry rhs) const {
-        return name < rhs.name;
+  private:
+    [[nodiscard]] constexpr friend auto
+    operator==(typename_map_entry const &lhs, typename_map_entry const &rhs)
+        -> bool {
+        return lhs.name == rhs.name;
     }
 
-    constexpr auto operator<=(typename_map_entry rhs) const {
-        return name <= rhs.name;
+    [[nodiscard]] constexpr friend auto
+    operator!=(typename_map_entry const &lhs, typename_map_entry const &rhs)
+        -> bool {
+        return not(lhs == rhs);
     }
 
-    constexpr auto operator>(typename_map_entry rhs) const {
-        return name > rhs.name;
+    [[nodiscard]] constexpr friend auto operator<(typename_map_entry const &lhs,
+                                                  typename_map_entry const &rhs)
+        -> bool {
+        return lhs.name < rhs.name; // NOLINT(modernize-use-nullptr)
     }
 
-    constexpr auto operator>=(typename_map_entry rhs) const {
-        return name >= rhs.name;
+    [[nodiscard]] constexpr friend auto operator>(typename_map_entry const &lhs,
+                                                  typename_map_entry const &rhs)
+        -> bool {
+        return rhs < lhs;
     }
 
-    constexpr auto operator==(typename_map_entry rhs) const {
-        return name == rhs.name;
+    [[nodiscard]] constexpr friend auto
+    operator<=(typename_map_entry const &lhs, typename_map_entry const &rhs)
+        -> bool {
+        return not(rhs < lhs);
     }
 
-    constexpr auto operator!=(typename_map_entry rhs) const {
-        return name != rhs.name;
+    [[nodiscard]] constexpr friend auto
+    operator>=(typename_map_entry const &lhs, typename_map_entry const &rhs)
+        -> bool {
+        return not(lhs < rhs);
     }
 };
 

--- a/include/seq/step.hpp
+++ b/include/seq/step.hpp
@@ -21,7 +21,8 @@ class step_base {
 
   public:
     template <typename Name>
-    constexpr step_base(Name name, func_ptr forward_ptr, func_ptr backward_ptr)
+    constexpr step_base([[maybe_unused]] Name name, func_ptr forward_ptr,
+                        func_ptr backward_ptr)
         : _forward_ptr{forward_ptr}, _backward_ptr{backward_ptr}, log_name {
         []() { CIB_TRACE("seq.step({})", Name{}); }
     }
@@ -38,7 +39,7 @@ class step_base {
         -> bool {
 #if defined(__GNUC__) && __GNUC__ < 12
         return lhs.hash == rhs.hash;
-#elif
+#else
         return (lhs._forward_ptr) == (rhs._forward_ptr) &&
                (lhs._backward_ptr) == (rhs._backward_ptr) &&
                (lhs.log_name) == (rhs.log_name);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,7 @@
-if(DEFINED ENV{CXX_STANDARD} AND NOT $ENV{CXX_STANDARD} EQUAL "")
-    set(CMAKE_CXX_STANDARD $ENV{CXX_STANDARD})
-else()
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-
-add_versioned_package("gh:catchorg/Catch2@3.1.1")
-add_versioned_package("gh:google/googletest#release-1.12.1")
-
-# Catch tests
-add_executable(
-    cib-catch-tests
+add_unit_test(
+    cib_test
+    CATCH2
+    FILES
     cib/detail/type_list.cpp
     cib/detail/type_pack_element.cpp
     cib/detail/type_to_string_view.cpp
@@ -19,39 +11,72 @@ add_executable(
     cib/tuple.cpp
     cib/set.cpp
     cib/readme_hello_world.cpp
-    flow/flow.cpp
-    sc/format.cpp
-    sc/string_constant.cpp
+    LIBRARIES
+    cib
+    warnings)
+
+add_unit_test(
+    container_test
+    CATCH2
+    FILES
     container/Array.cpp
     container/ConstexprMap.cpp
     container/ConstexprMultiMap.cpp
     container/ConstexprSet.cpp
     container/Vector.cpp
     container/PriorityQueue.cpp
+    LIBRARIES
+    cib
+    warnings)
+
+add_unit_test(
+    msg_test
+    CATCH2
+    FILES
     msg/match.cpp
     msg/disjoint_field.cpp
     msg/field.cpp
     msg/handler.cpp
     msg/message.cpp
-    seq/sequencer.cpp)
+    LIBRARIES
+    cib
+    warnings)
 
-target_link_libraries_system(cib-catch-tests PRIVATE Catch2::Catch2WithMain)
-target_link_libraries(cib-catch-tests PRIVATE cib warnings)
-target_include_directories(cib-catch-tests PRIVATE ${CMAKE_SOURCE_DIR}/test/)
+add_unit_test(
+    flow_test
+    CATCH2
+    FILES
+    flow/flow.cpp
+    LIBRARIES
+    cib
+    warnings)
 
-list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
-include(Catch)
-catch_discover_tests(cib-catch-tests)
+add_unit_test(
+    sc_test
+    CATCH2
+    FILES
+    sc/format.cpp
+    sc/string_constant.cpp
+    LIBRARIES
+    cib
+    warnings)
 
-# Google tests
-add_executable(cib-gtests interrupt/manager.cpp)
+add_unit_test(
+    seq_test
+    CATCH2
+    FILES
+    seq/sequencer.cpp
+    LIBRARIES
+    cib
+    warnings)
 
-target_link_libraries_system(cib-gtests PRIVATE gmock gtest gmock_main)
-target_link_libraries(cib-gtests PRIVATE cib warnings)
-target_include_directories(cib-gtests PRIVATE ${CMAKE_SOURCE_DIR}/test/)
-
-include(GoogleTest)
-gtest_discover_tests(cib-gtests)
-
-# Top-level test target
-add_custom_target(all-cib-tests DEPENDS cib-gtests cib-catch-tests)
+add_unit_test(
+    interrupt_test
+    GTEST
+    FILES
+    interrupt/manager.cpp
+    INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/test/
+    LIBRARIES
+    cib
+    warnings)


### PR DESCRIPTION
In this commit:
- Unit tests are separated by subsystem and more easily declared.
- The `all` target is cleaned up so as not to include building the release header or compilation benchmark.
- Unit tests run as part of the build rather than a separate step.

Also:
- This PR includes a fix for seq/step.hpp which for some reason tools were not flagging before?
- clang-tidy in LLVM 11.0.0 has a bug that (only sometimes) gives a false positive on comparisons - worked around in cib/detail/set_details.hpp.