### PR TITLE
:art: Remove CIB_CONSTEXPR

### DIFF
--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -50,11 +50,11 @@ template <int NumFuncs = 0, typename... ArgTypes> struct callback {
      * @see cib::built
      */
     template <typename BuilderValue> static void run(ArgTypes... args) {
-        CIB_CONSTEXPR auto handler_builder = BuilderValue::value;
-        CIB_CONSTEXPR auto num_funcs = std::integral_constant<int, NumFuncs>{};
+        constexpr auto handler_builder = BuilderValue::value;
+        constexpr auto num_funcs = std::integral_constant<int, NumFuncs>{};
 
         detail::for_each(num_funcs, [&](auto i) {
-            CIB_CONSTEXPR auto func = handler_builder.funcs[i];
+            constexpr auto func = handler_builder.funcs[i];
             func(args...);
         });
     }

--- a/include/cib/config.hpp
+++ b/include/cib/config.hpp
@@ -55,7 +55,7 @@ template <auto... Args, typename... Configs>
  * @see cib::args
  */
 template <typename Args, typename... Components>
-CIB_CONSTEXPR static detail::components<Args, Components...> components{};
+constexpr static detail::components<Args, Components...> components{};
 
 /**
  * Declare a list of services for use in the project.
@@ -63,7 +63,7 @@ CIB_CONSTEXPR static detail::components<Args, Components...> components{};
  * @tparam Services
  */
 template <typename... Services>
-CIB_CONSTEXPR static detail::exports<Services...> exports{};
+constexpr static detail::exports<Services...> exports{};
 
 /**
  * Extend a service with new functionality.
@@ -89,7 +89,7 @@ template <typename Service, typename... Args>
  * @tparam ArgType
  *      The type of argument to reference from the args list.
  */
-template <typename ArgType> CIB_CONSTEXPR static detail::arg<ArgType> arg{};
+template <typename ArgType> constexpr static detail::arg<ArgType> arg{};
 
 /**
  * Include configs based on predicate.

--- a/include/cib/detail/builder_traits.hpp
+++ b/include/cib/detail/builder_traits.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
-
 #include <utility>
 
 namespace cib::traits {
@@ -12,8 +10,7 @@ template <typename BuilderMeta> struct builder {
 template <typename BuilderMeta>
 using builder_t = typename builder<BuilderMeta>::type;
 
-template <typename BuilderMeta>
-CIB_CONSTEXPR builder_t<BuilderMeta> builder_v = {};
+template <typename BuilderMeta> constexpr builder_t<BuilderMeta> builder_v = {};
 
 template <typename BuilderMeta> struct interface {
     using type = decltype(std::declval<BuilderMeta>().interface());

--- a/include/cib/detail/compiler.hpp
+++ b/include/cib/detail/compiler.hpp
@@ -15,5 +15,3 @@
 #else
 #define CIB_CONSTEVAL consteval
 #endif
-
-#define CIB_CONSTEXPR constexpr

--- a/include/cib/detail/components.hpp
+++ b/include/cib/detail/components.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/tuple.hpp>
 
@@ -8,7 +7,7 @@ namespace cib::detail {
 template <typename... Components>
 struct components : public detail::config_item {
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...args) const {
+    [[nodiscard]] constexpr auto extends_tuple(Args const &...args) const {
         return cib::tuple_cat(Components::config.extends_tuple(args...)...);
     }
 };

--- a/include/cib/detail/conditional.hpp
+++ b/include/cib/detail/conditional.hpp
@@ -8,14 +8,14 @@
 namespace cib::detail {
 template <typename Condition, typename... Configs>
 struct conditional : public config_item {
-    CIB_CONSTEXPR static Condition condition{};
+    constexpr static Condition condition{};
     detail::config<detail::args<>, Configs...> body;
 
     CIB_CONSTEVAL explicit conditional(Condition, Configs const &...configs)
         : body{{}, configs...} {}
 
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...) const {
+    [[nodiscard]] constexpr auto extends_tuple(Args const &...) const {
         if constexpr (condition(Args{}...)) {
             return body.extends_tuple(Args{}...);
         } else {
@@ -25,11 +25,11 @@ struct conditional : public config_item {
 };
 
 template <typename Lhs, typename Rhs> struct equality {
-    CIB_CONSTEXPR static Lhs lhs{};
-    CIB_CONSTEXPR static Rhs rhs{};
+    constexpr static Lhs lhs{};
+    constexpr static Rhs rhs{};
 
     template <typename... Args>
-    CIB_CONSTEXPR auto operator()(Args const &...args) const -> bool {
+    constexpr auto operator()(Args const &...args) const -> bool {
         return lhs(args...) ==
                rhs; // FIXME: this assumes the RHS is a literal value
     }
@@ -42,8 +42,7 @@ template <typename MatchType> struct arg {
         return {};
     }
 
-    template <typename... Args>
-    CIB_CONSTEXPR auto operator()(Args... args) const {
+    template <typename... Args> constexpr auto operator()(Args... args) const {
         return cib::make_tuple(self_type_index, args...)
             .fold_right(
                 detail::int_<0>, [=](auto elem, [[maybe_unused]] auto state) {

--- a/include/cib/detail/config_details.hpp
+++ b/include/cib/detail/config_details.hpp
@@ -9,11 +9,11 @@
 
 namespace cib::detail {
 template <auto Value>
-CIB_CONSTEXPR static auto as_constant_v = std::integral_constant<
+constexpr static auto as_constant_v = std::integral_constant<
     std::remove_cv_t<std::remove_reference_t<decltype(Value)>>, Value>{};
 
 template <auto... Args> struct args {
-    static CIB_CONSTEXPR auto value =
+    static constexpr auto value =
         cib::make_tuple(self_type_index, as_constant_v<Args>...);
 };
 
@@ -27,7 +27,7 @@ struct config : public detail::config_item {
     }
 
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...args) const {
+    [[nodiscard]] constexpr auto extends_tuple(Args const &...args) const {
         return ConfigArgs::value.apply([&](auto const &...config_args) {
             return configs_tuple.apply([&](auto const &...configs_pack) {
                 return cib::tuple_cat(

--- a/include/cib/detail/config_item.hpp
+++ b/include/cib/detail/config_item.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
 #include <cib/tuple.hpp>
 
 namespace cib::detail {
 struct config_item {
     template <typename... Args>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(Args const &...) const {
+    [[nodiscard]] constexpr auto extends_tuple(Args const &...) const {
         return cib::tuple<>{};
     }
 };

--- a/include/cib/detail/exports.hpp
+++ b/include/cib/detail/exports.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/detail/extend.hpp>
 #include <cib/tuple.hpp>
@@ -13,7 +12,7 @@ template <typename ServiceT, typename BuilderT> struct service_entry {
 
 template <typename... Services> struct exports : public detail::config_item {
     template <typename... InitArgs>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(InitArgs const &...) const {
+    [[nodiscard]] constexpr auto extends_tuple(InitArgs const &...) const {
         return cib::make_tuple(extend<Services>{}...);
     }
 };

--- a/include/cib/detail/extend.hpp
+++ b/include/cib/detail/extend.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cib/detail/builder_traits.hpp>
+#include <cib/detail/compiler.hpp>
 #include <cib/detail/config_item.hpp>
 #include <cib/tuple.hpp>
 
@@ -17,7 +18,7 @@ struct extend : public config_item {
     }
 
     template <typename... InitArgs>
-    [[nodiscard]] CIB_CONSTEXPR auto extends_tuple(InitArgs const &...) const {
+    [[nodiscard]] constexpr auto extends_tuple(InitArgs const &...) const {
         return cib::make_tuple(*this);
     }
 };

--- a/include/cib/detail/meta.hpp
+++ b/include/cib/detail/meta.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
-
 #include <cstddef>
 #include <type_traits>
 #include <utility>
 
 namespace cib::detail {
 template <int value>
-CIB_CONSTEXPR static auto int_ = std::integral_constant<int, value>{};
+constexpr static auto int_ = std::integral_constant<int, value>{};
 
 template <std::size_t value>
-CIB_CONSTEXPR static auto size_ = std::integral_constant<std::size_t, value>{};
+constexpr static auto size_ = std::integral_constant<std::size_t, value>{};
 
 template <typename Lhs, typename Rhs>
-CIB_CONSTEXPR static auto is_same_v =
+constexpr static auto is_same_v =
     std::is_same_v<std::remove_cv_t<std::remove_reference_t<Lhs>>,
                    std::remove_cv_t<std::remove_reference_t<Rhs>>>;
 
@@ -26,7 +24,7 @@ CIB_CONSTEXPR static auto is_same_v =
  * parameter.
  */
 template <typename IntegralType, IntegralType... Indices, typename CallableType>
-CIB_CONSTEXPR inline static void
+constexpr inline static void
 for_each([[maybe_unused]] std::integer_sequence<IntegralType, Indices...> const
              &sequence,
          CallableType const &operation) {
@@ -43,11 +41,11 @@ for_each([[maybe_unused]] std::integer_sequence<IntegralType, Indices...> const
  */
 template <typename IntegralType, IntegralType NumElements,
           typename CallableType>
-CIB_CONSTEXPR inline void for_each(
+constexpr inline void for_each(
     [[maybe_unused]] std::integral_constant<IntegralType, NumElements> const
         &num_elements,
     CallableType const &operation) {
-    CIB_CONSTEXPR auto seq =
+    constexpr auto seq =
         std::make_integer_sequence<IntegralType, NumElements>{};
     for_each(seq, operation);
 }

--- a/include/cib/detail/nexus_details.hpp
+++ b/include/cib/detail/nexus_details.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
 #include <cib/detail/exports.hpp>
 #include <cib/detail/meta.hpp>
 #include <cib/detail/type_list.hpp>
@@ -40,7 +39,7 @@ struct get_service_from_tuple {
 };
 
 template <typename Config> struct initialized_builders {
-    CIB_CONSTEXPR static auto value = transform(
+    constexpr static auto value = transform(
         index_metafunc_<extract_service_tag>,
         demux(get_service{}, Config::config.extends_tuple()),
         [](auto extensions) {
@@ -63,11 +62,11 @@ template <typename Config> struct initialized_builders {
 };
 
 template <typename Config>
-CIB_CONSTEXPR static auto &initialized_builders_v =
+constexpr static auto &initialized_builders_v =
     initialized_builders<Config>::value;
 
 template <typename Config, typename Tag> struct initialized {
-    CIB_CONSTEXPR static auto value =
+    constexpr static auto value =
         initialized_builders_v<Config>.get(cib::tag_<Tag>).builder;
 };
 } // namespace cib

--- a/include/cib/detail/set_details.hpp
+++ b/include/cib/detail/set_details.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cib/detail/compiler.hpp>
 #include <cib/tuple.hpp>
 
 #include <array>

--- a/include/cib/nexus.hpp
+++ b/include/cib/nexus.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cib/built.hpp>
-#include <cib/detail/compiler.hpp>
 #include <cib/detail/nexus_details.hpp>
 
 #include <type_traits>

--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cib/detail/compiler.hpp>
-
 #include <array>
 #if __has_include(<compare>)
 #include <compare>
@@ -27,16 +25,16 @@ constexpr static index_metafunc_t<self_type> self_type_index{};
 
 namespace detail {
 template <typename ElementT, typename IndexT> struct type_indexed_element {
-    [[nodiscard]] CIB_CONSTEXPR auto get(tag_t<IndexT>) const &noexcept
+    [[nodiscard]] constexpr auto get(tag_t<IndexT>) const &noexcept
         -> decltype(auto) {
         return static_cast<ElementT const &>(*this).get(
             index_<ElementT::index>);
     }
-    [[nodiscard]] CIB_CONSTEXPR auto get(tag_t<IndexT>) &noexcept
+    [[nodiscard]] constexpr auto get(tag_t<IndexT>) &noexcept
         -> decltype(auto) {
         return static_cast<ElementT &>(*this).get(index_<ElementT::index>);
     }
-    [[nodiscard]] CIB_CONSTEXPR auto get(tag_t<IndexT>) &&noexcept
+    [[nodiscard]] constexpr auto get(tag_t<IndexT>) &&noexcept
         -> decltype(auto) {
         return static_cast<ElementT &&>(*this).get(index_<ElementT::index>);
     }
@@ -45,23 +43,22 @@ template <typename ElementT, typename IndexT> struct type_indexed_element {
 template <typename T, std::size_t Index, typename... IndexTs>
 struct tuple_element
     : type_indexed_element<tuple_element<T, Index, IndexTs...>, IndexTs>... {
-    CIB_CONSTEXPR static auto index = Index;
+    constexpr static auto index = Index;
     using value_type = T;
     value_type value{};
 
-    CIB_CONSTEXPR tuple_element() = default;
-    CIB_CONSTEXPR explicit tuple_element(T const &t) : value{t} {}
-    CIB_CONSTEXPR explicit tuple_element(T &&t) : value{std::move(t)} {}
+    constexpr tuple_element() = default;
+    constexpr explicit tuple_element(T const &t) : value{t} {}
+    constexpr explicit tuple_element(T &&t) : value{std::move(t)} {}
 
-    [[nodiscard]] CIB_CONSTEXPR auto get(index_t<Index>) const &noexcept
+    [[nodiscard]] constexpr auto get(index_t<Index>) const &noexcept
         -> value_type const & {
         return value;
     }
-    [[nodiscard]] CIB_CONSTEXPR auto get(index_t<Index>) &noexcept
-        -> value_type & {
+    [[nodiscard]] constexpr auto get(index_t<Index>) &noexcept -> value_type & {
         return value;
     }
-    [[nodiscard]] CIB_CONSTEXPR auto get(index_t<Index>) &&noexcept
+    [[nodiscard]] constexpr auto get(index_t<Index>) &&noexcept
         -> value_type && {
         return std::move(value);
     }
@@ -86,7 +83,7 @@ template <typename TValue, typename TOp> struct fold_right_helper {
 
   private:
     template <typename T>
-    [[nodiscard]] CIB_CONSTEXPR friend inline auto
+    [[nodiscard]] constexpr friend inline auto
     operator+(T &&lhs, fold_right_helper &&rhs) {
         using R = decltype(rhs.op(std::forward<T>(lhs), std::move(rhs).value));
         return fold_right_helper<R, TOp>{
@@ -95,7 +92,7 @@ template <typename TValue, typename TOp> struct fold_right_helper {
     }
 
     template <typename T>
-    [[nodiscard]] CIB_CONSTEXPR friend inline auto
+    [[nodiscard]] constexpr friend inline auto
     operator+(fold_right_helper<T, TOp> &&lhs, fold_right_helper &&rhs) {
         using R =
             decltype(rhs.op(std::forward<fold_right_helper<T, TOp>>(lhs).value,
@@ -116,8 +113,8 @@ template <typename TValue, typename TOp> struct fold_left_helper {
 
   private:
     template <typename T>
-    [[nodiscard]] CIB_CONSTEXPR friend inline auto
-    operator+(fold_left_helper &&lhs, T &&rhs) {
+    [[nodiscard]] constexpr friend inline auto operator+(fold_left_helper &&lhs,
+                                                         T &&rhs) {
         using R = decltype(lhs.op(std::move(lhs).value, std::forward<T>(rhs)));
         return fold_left_helper<R, TOp>{
             lhs.op(std::move(lhs).value, std::forward<T>(rhs)),
@@ -125,7 +122,7 @@ template <typename TValue, typename TOp> struct fold_left_helper {
     }
 
     template <typename T>
-    [[nodiscard]] CIB_CONSTEXPR friend inline auto
+    [[nodiscard]] constexpr friend inline auto
     operator+(fold_left_helper &&lhs, fold_left_helper<T, TOp> &&rhs) {
         using R =
             decltype(lhs.op(std::move(lhs).value,
@@ -145,17 +142,17 @@ fold_left_helper(TValue, TOp) -> fold_left_helper<std::decay_t<TValue>, TOp>;
 template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
     using TupleElementTs::get...;
 
-    [[nodiscard]] CIB_CONSTEXPR static auto size() -> std::size_t {
+    [[nodiscard]] constexpr static auto size() -> std::size_t {
         return sizeof...(TupleElementTs);
     }
 
     template <typename Callable>
-    CIB_CONSTEXPR auto apply(Callable &&operation) const & -> decltype(auto) {
+    constexpr auto apply(Callable &&operation) const & -> decltype(auto) {
         return std::forward<Callable>(operation)(TupleElementTs::value...);
     }
 
     template <typename Callable>
-    CIB_CONSTEXPR auto apply(Callable &&operation) && -> decltype(auto) {
+    constexpr auto apply(Callable &&operation) && -> decltype(auto) {
         return std::forward<Callable>(operation)(
             std::move(TupleElementTs::value)...);
     }
@@ -167,12 +164,11 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
      *      The operation to perform. Must be a callable that accepts a single
      * parameter.
      */
-    template <typename TOp>
-    CIB_CONSTEXPR auto for_each(TOp &&op) const & -> TOp {
+    template <typename TOp> constexpr auto for_each(TOp &&op) const & -> TOp {
         (op(TupleElementTs::value), ...);
         return op;
     }
-    template <typename TOp> CIB_CONSTEXPR auto for_each(TOp &&op) & -> TOp {
+    template <typename TOp> constexpr auto for_each(TOp &&op) & -> TOp {
         (op(TupleElementTs::value), ...);
         return op;
     }
@@ -195,15 +191,14 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
      *      The final state of all of the operations.
      */
     template <typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto
-    fold_right(TOp &&operation) const & {
+    [[nodiscard]] constexpr inline auto fold_right(TOp &&operation) const & {
         return (detail::fold_right_helper{TupleElementTs::value,
                                           std::forward<TOp>(operation)} +
                 ...)
             .value;
     }
     template <typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_right(TOp &&operation) && {
+    [[nodiscard]] constexpr inline auto fold_right(TOp &&operation) && {
         return (detail::fold_right_helper{std::move(TupleElementTs::value),
                                           std::forward<TOp>(operation)} +
                 ...)
@@ -228,16 +223,16 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
      *      The final state of all of the operations.
      */
     template <typename TInit, typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto
-    fold_right(TInit &&initial_state, TOp &&operation) const & {
+    [[nodiscard]] constexpr inline auto fold_right(TInit &&initial_state,
+                                                   TOp &&operation) const & {
         return (TupleElementTs::value + ... +
                 detail::fold_right_helper{std::forward<TInit>(initial_state),
                                           std::forward<TOp>(operation)})
             .value;
     }
     template <typename TInit, typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_right(TInit &&initial_state,
-                                                       TOp &&operation) && {
+    [[nodiscard]] constexpr inline auto fold_right(TInit &&initial_state,
+                                                   TOp &&operation) && {
         return (std::move(TupleElementTs::value) + ... +
                 detail::fold_right_helper{std::forward<TInit>(initial_state),
                                           std::forward<TOp>(operation)})
@@ -262,13 +257,13 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
      *      The final state of all of the operations.
      */
     template <typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_left(TOp &&operation) const & {
+    [[nodiscard]] constexpr inline auto fold_left(TOp &&operation) const & {
         return (... + detail::fold_left_helper{TupleElementTs::value,
                                                std::forward<TOp>(operation)})
             .value;
     }
     template <typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_left(TOp &&operation) && {
+    [[nodiscard]] constexpr inline auto fold_left(TOp &&operation) && {
         return (... + detail::fold_left_helper{std::move(TupleElementTs::value),
                                                std::forward<TOp>(operation)})
             .value;
@@ -292,16 +287,16 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
      *      The final state of all of the operations.
      */
     template <typename TInit, typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_left(TInit &&initial_state,
-                                                      TOp &&operation) const & {
+    [[nodiscard]] constexpr inline auto fold_left(TInit &&initial_state,
+                                                  TOp &&operation) const & {
         return (detail::fold_left_helper{std::forward<TInit>(initial_state),
                                          std::forward<TOp>(operation)} +
                 ... + TupleElementTs::value)
             .value;
     }
     template <typename TInit, typename TOp>
-    [[nodiscard]] CIB_CONSTEXPR inline auto fold_left(TInit &&initial_state,
-                                                      TOp &&operation) && {
+    [[nodiscard]] constexpr inline auto fold_left(TInit &&initial_state,
+                                                  TOp &&operation) && {
         return (detail::fold_left_helper{std::forward<TInit>(initial_state),
                                          std::forward<TOp>(operation)} +
                 ... + std::move(TupleElementTs::value))
@@ -309,22 +304,22 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
     }
 
   private:
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator==(tuple_impl const &lhs,
-                                                       tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator==(tuple_impl const &lhs,
+                                                   tuple_impl const &rhs)
         -> bool {
         return ((lhs.TupleElementTs::value == rhs.TupleElementTs::value) and
                 ...);
     }
 
 #if __cpp_lib_three_way_comparison < 201907L
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator!=(tuple_impl const &lhs,
-                                                       tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator!=(tuple_impl const &lhs,
+                                                   tuple_impl const &rhs)
         -> bool {
         return not(lhs == rhs);
     }
 
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator<(tuple_impl const &lhs,
-                                                      tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator<(tuple_impl const &lhs,
+                                                  tuple_impl const &rhs)
         -> bool {
         bool result{};
         const auto cmp = [&](auto const &x, auto const &y) {
@@ -336,25 +331,25 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
         return result;
     }
 
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator>(tuple_impl const &lhs,
-                                                      tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator>(tuple_impl const &lhs,
+                                                  tuple_impl const &rhs)
         -> bool {
         return rhs < lhs;
     }
 
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator<=(tuple_impl const &lhs,
-                                                       tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator<=(tuple_impl const &lhs,
+                                                   tuple_impl const &rhs)
         -> bool {
         return not(rhs < lhs);
     }
 
-    [[nodiscard]] CIB_CONSTEXPR friend auto operator>=(tuple_impl const &lhs,
-                                                       tuple_impl const &rhs)
+    [[nodiscard]] constexpr friend auto operator>=(tuple_impl const &lhs,
+                                                   tuple_impl const &rhs)
         -> bool {
         return not(lhs < rhs);
     }
 #else
-    [[nodiscard]] CIB_CONSTEXPR friend auto
+    [[nodiscard]] constexpr friend auto
     operator<=>(tuple_impl const &lhs, tuple_impl const &rhs) requires(
         std::three_way_comparable<typename TupleElementTs::value_type> and...) {
         std::common_comparison_category_t<std::compare_three_way_result_t<
@@ -431,26 +426,26 @@ template <typename... Ts>
 using tuple = decltype(cib::make_tuple(std::declval<Ts>()...));
 
 template <typename Callable, typename Tuple>
-CIB_CONSTEXPR auto apply(Callable &&operation, Tuple &&t) {
+constexpr auto apply(Callable &&operation, Tuple &&t) {
     return std::forward<Tuple>(t).apply(std::forward<Callable>(operation));
 }
 
 namespace detail {
 template <std::size_t Index, typename TOp, typename... Tuples>
-CIB_CONSTEXPR auto invoke_at(TOp &&op, Tuples &&...ts) -> void {
+constexpr auto invoke_at(TOp &&op, Tuples &&...ts) -> void {
     std::forward<TOp>(op)(std::forward<Tuples>(ts).get(index_<Index>)...);
 }
 
 template <typename TOp, std::size_t... Indices, typename... Tuples>
-CIB_CONSTEXPR auto for_each_impl(TOp &&op, std::index_sequence<Indices...>,
-                                 Tuples &&...ts) -> TOp {
+constexpr auto for_each_impl(TOp &&op, std::index_sequence<Indices...>,
+                             Tuples &&...ts) -> TOp {
     (invoke_at<Indices>(op, std::forward<Tuples>(ts)...), ...);
     return op;
 }
 } // namespace detail
 
 template <typename TOp, typename Tuple, typename... Tuples>
-CIB_CONSTEXPR auto for_each(TOp &&op, Tuple &&t, Tuples &&...ts) -> TOp {
+constexpr auto for_each(TOp &&op, Tuple &&t, Tuples &&...ts) -> TOp {
     return detail::for_each_impl(
         std::forward<TOp>(op),
         std::make_index_sequence<std::decay_t<Tuple>::size()>{},
@@ -458,21 +453,21 @@ CIB_CONSTEXPR auto for_each(TOp &&op, Tuple &&t, Tuples &&...ts) -> TOp {
 }
 
 template <typename MetaFunc, typename Tuple, typename Operation>
-[[nodiscard]] CIB_CONSTEXPR auto transform(MetaFunc meta_func, Tuple tuple,
-                                           Operation op) {
+[[nodiscard]] constexpr auto transform(MetaFunc meta_func, Tuple tuple,
+                                       Operation op) {
     return tuple.apply([&](auto... elements) {
         return cib::make_tuple(meta_func, op(elements)...);
     });
 }
 
 template <typename Tuple, typename Operation>
-[[nodiscard]] CIB_CONSTEXPR auto transform(Tuple tuple, Operation op) {
+[[nodiscard]] constexpr auto transform(Tuple tuple, Operation op) {
     return tuple.apply(
         [&](auto... elements) { return cib::make_tuple(op(elements)...); });
 }
 
 template <typename IntegralType, IntegralType... Indices, typename CallableType>
-[[nodiscard]] CIB_CONSTEXPR auto
+[[nodiscard]] constexpr auto
 transform(std::integer_sequence<IntegralType, Indices...>,
           CallableType const &op) {
     return cib::make_tuple(
@@ -480,7 +475,7 @@ transform(std::integer_sequence<IntegralType, Indices...>,
 }
 
 template <typename Tuple, typename Operation>
-[[nodiscard]] CIB_CONSTEXPR auto filter(Tuple tuple, Operation op) {
+[[nodiscard]] constexpr auto filter(Tuple tuple, Operation op) {
     return tuple.apply([&](auto... elements) {
         std::array<bool, tuple.size()> constexpr op_results{
             op(decltype(elements){})...};
@@ -519,7 +514,7 @@ template <typename Tuple, typename Operation>
 }
 
 template <typename Operation>
-[[nodiscard]] CIB_CONSTEXPR auto filter(cib::tuple_impl<> t, Operation) {
+[[nodiscard]] constexpr auto filter(cib::tuple_impl<> t, Operation) {
     return t;
 }
 


### PR DESCRIPTION
We target C++17 and above; `CIB_CONSTEXPR` is never anything other than `constexpr`. `constexpr` is already used a lot and we might as well use the standard keyword everywhere.

This commit also cleans up the include usage for `cib/details/compiler.hpp`.