### PR TITLE
:bug: Use libfmt in header-only mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(cib INTERFACE)
 target_compile_features(cib INTERFACE cxx_std_17)
 target_include_directories(cib INTERFACE ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(cib SYSTEM INTERFACE ${hana_SOURCE_DIR}/include)
-target_link_libraries_system(cib INTERFACE fmt::fmt)
+target_link_libraries_system(cib INTERFACE fmt::fmt-header-only)
 
 target_compile_options(
     cib

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#define FMT_HEADER_ONLY
 #include <log/fmt/catalog.hpp>
 #include <log/log_level.hpp>
 #include <sc/format.hpp>


### PR DESCRIPTION
Linking against `fmt::fmt` causes projects that depend on cib to build the non-header parts of libfmt, which cib doesn't use. Better to link against `fmt::fmt-header-only`.