### PR TITLE
Fix Logger uses dynamic memory (std::string)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ add_unit_test(
     log_test
     CATCH2
     FILES
+    log/logger.cpp
     log/mipi_encoder.cpp
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/test/

--- a/test/log/logger.cpp
+++ b/test/log/logger.cpp
@@ -1,36 +1,26 @@
 #include <log/fmt/logger.hpp>
-#include "testing_logger.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+
+#include "testing_logger.hpp"
 #include <atomic>
 
 static std::atomic<bool> testing_logger_flag{false};
 
-testing_logger::testing_logger()
-{
-    testing_logger_flag.store(true);
-}
+testing_logger::testing_logger() { testing_logger_flag.store(true); }
 
-testing_logger::~testing_logger()
-{
-    testing_logger_flag.store(false);
-}
+testing_logger::~testing_logger() { testing_logger_flag.store(false); }
 
-void* operator new  ( std::size_t count ) {
-    if(testing_logger_flag.load())
-    {
+void *operator new(std::size_t count) {
+    if (testing_logger_flag.load()) {
         REQUIRE(false);
     }
     return malloc(count);
 }
 
-void operator delete  ( void* ptr, size_t ) {
-    return free(ptr);
-}
+void operator delete(void *ptr, std::size_t) noexcept { return free(ptr); }
 
-void operator delete  ( void* ptr) {
-    return free(ptr);
-}
+void operator delete(void *ptr) noexcept { return free(ptr); }
 
 TEST_CASE("TRACE doesn't use dynamic memory", "[log]") {
     testing_logger test;

--- a/test/log/logger.cpp
+++ b/test/log/logger.cpp
@@ -1,0 +1,43 @@
+#include <log/fmt/logger.hpp>
+#include "testing_logger.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <atomic>
+
+static std::atomic<bool> testing_logger_flag{false};
+
+testing_logger::testing_logger()
+{
+    testing_logger_flag.store(true);
+}
+
+testing_logger::~testing_logger()
+{
+    testing_logger_flag.store(false);
+}
+
+void* operator new  ( std::size_t count ) {
+    if(testing_logger_flag.load())
+    {
+        REQUIRE(false);
+    }
+    return malloc(count);
+}
+
+void operator delete  ( void* ptr, size_t ) {
+    return free(ptr);
+}
+
+void operator delete  ( void* ptr) {
+    return free(ptr);
+}
+
+TEST_CASE("TRACE doesn't use dynamic memory", "[log]") {
+    testing_logger test;
+    CIB_TRACE("Hello");
+}
+
+TEST_CASE("TRACE doesn't use dynamic memory with larger strings", "[log]") {
+    testing_logger test;
+    CIB_TRACE("cib trace is not allowed to use dynamic memory");
+}

--- a/test/log/testing_logger.hpp
+++ b/test/log/testing_logger.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+struct testing_logger
+{
+    testing_logger();
+    ~testing_logger();
+};

--- a/test/log/testing_logger.hpp
+++ b/test/log/testing_logger.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-struct testing_logger
-{
+extern void operator delete(void *ptr, std::size_t) noexcept;
+
+struct testing_logger {
     testing_logger();
     ~testing_logger();
 };


### PR DESCRIPTION
fmt::format returns a string which uses dynamic memory so every trace and log produced small dynamic memory allocations switch to use fmt::format_to with fmt::memory_buffer thsize can be set with changing fmt::internal::INLINE_BUFFER_SIZE
closes#221