### PR TITLE
:hammer: Pin CI images to ubuntu 20.04

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   performance_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +109,7 @@ jobs:
         run: ctest -C ${{matrix.build_type}}
 
   quality_checks_pass:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -132,7 +132,7 @@ jobs:
         run: cmake --build ${{github.workspace}}/build -t quality
 
   build_single_header:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Github just updated ubuntu-latest to 22.04, resulting in package availability changes that broke the CI. Pinning to 20.04 until we are ready to go to 22.04.