### PR TITLE
:green_heart: Fix merge gating

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -1,6 +1,7 @@
-name: Unit Tests
+name: Performance Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 
@@ -15,16 +16,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
-      - name: install compiler
+      - name: Install compiler
         run: sudo apt update && sudo apt-get install -y clang-12
 
       - name: Configure CMake
         env:
           CC: clang-12
           CXX: clang++-12
+          CXX_STANDARD: 20
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
       - name: Build

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CMAKE_GENERATOR: Ninja
 
@@ -130,6 +134,13 @@ jobs:
 
       - name: Run quality checks
         run: cmake --build ${{github.workspace}}/build -t quality
+
+  merge_ok:
+    runs-on: ubuntu-20.04
+    needs: [build_and_test, quality_checks_pass]
+    steps:
+      - name: Enable merge
+        run: echo "OK to merge!"
 
   build_single_header:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Merges can be gated on the success of a job, but when using a matrix, it's annoying to put in all the variants as gating. This commit adds a merge_ok job that depends on both the unit tests and the quality checks passing.

Also:
- Cancel in progress jobs that are superseded (for example by pushing newer code to a branch on a PR).
- Fix workflow name of the performance tests.