### PR TITLE
:art: Use steady_clock instead of high_resolution_clock

### DIFF
--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -39,8 +39,7 @@ template <> struct fmt::formatter<log_level> {
 };
 
 namespace {
-inline const auto logging_start_time =
-    std::chrono::high_resolution_clock::now();
+inline const auto logging_start_time = std::chrono::steady_clock::now();
 
 template <typename StringType>
 inline auto trim_source_filename(StringType src) -> char const * {
@@ -62,7 +61,7 @@ inline auto output_line = []([[maybe_unused]] auto filename,
                              const auto &msg) {
     const auto currentTime =
         std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::high_resolution_clock::now() - logging_start_time)
+            std::chrono::steady_clock::now() - logging_start_time)
             .count();
 
     fmt::print("{:>8}us {}: {}\n", currentTime, level, msg.data());


### PR DESCRIPTION
`high_resolution_clock` sounds good but doesn't deliver: it's not well-defined by the standard. In libc++ and MS STL it is an alias for `steady_clock`; however in libstdc++ it is an alias for `system_clock` (which is not steady).

As a rule of thumb, `high_resolution_clock` should never be used. For a stopwatch, use `steady_clock`. For a wall time, use `system_clock`.

https://stackoverflow.com/a/38253266