### PR TITLE
:bug: Fix message handler with multiple callbacks

### DIFF
--- a/include/msg/match.hpp
+++ b/include/msg/match.hpp
@@ -105,8 +105,9 @@ template <bool value> constexpr always_t<value> always{};
 
 template <typename... MatcherTypes> struct any_t {
     using MatchersType = cib::tuple<MatcherTypes...>;
-    MatchersType matchers;
+    MatchersType matchers{};
 
+    constexpr any_t() = default;
     constexpr explicit any_t(MatchersType new_matchers)
         : matchers{new_matchers} {}
 


### PR DESCRIPTION
The way that tuple filter works currently requires the elements of the tuple to be default constructible. This was not the case for `any_t`.

This is a partial fix for #231 (which is two issues in one).