### PR TITLE
:bug: Fix field::WithIn handling for enums

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -3,7 +3,7 @@
 #include <cib/tuple.hpp>
 #include <msg/field.hpp>
 #include <msg/match.hpp>
-#include <sc/string_constant.hpp>
+#include <sc/fwd.hpp>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
`in_t` was not handling enumerations correctly. It was also doing too much work creating and transforming a tuple, when a simple fold expression over the values pack is sufficient.