### PR TITLE
:bug: Allow logging names of incomplete types

### DIFF
--- a/include/sc/fwd.hpp
+++ b/include/sc/fwd.hpp
@@ -25,7 +25,7 @@ template <typename T> struct type_name {
     constexpr type_name() = default;
 };
 
-template <typename T> constexpr static type_name<T> type_{T{}};
+template <typename T> constexpr static type_name<T> type_{};
 
 template <typename CharT, CharT... chars> struct string_constant;
 } // namespace sc

--- a/test/sc/format.cpp
+++ b/test/sc/format.cpp
@@ -153,6 +153,13 @@ TEST_CASE("typenames", "[sc::format]") {
             "Type = sc::ExampleTypeName"_sc);
 }
 
+struct IncompleteType;
+
+TEST_CASE("incomplete typenames", "[sc::format]") {
+    REQUIRE(format("Type = {}"_sc, type_<IncompleteType>).str ==
+            "Type = sc::IncompleteType"_sc);
+}
+
 static_assert(sc::to_string_constant(int_<5>) == "5"_sc);
 static_assert(sc::to_string_constant(int_<0>) == "0"_sc);
 static_assert(sc::to_string_constant(int_<10>) == "10"_sc);


### PR DESCRIPTION
`sc::type_` does not need to instantiate the type to represent its name.