### PR TITLE
:bug: Fix fmt logger reading off end of buffer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^<(container|cib|flow|interrupt|log|msg|sc|seq)/.*'
     Priority: 1
-  - Regex: '^<(boost|catch2|gmock|gtest)/.*'
+  - Regex: '^<(boost|catch2|fmt|gmock|gtest)/.*'
     Priority: 2
   - Regex: '.*'
     Priority: 3


### PR DESCRIPTION
`fmt::format_to` does not null-terminate the output. The fmt logging code assumed that the data in the fmt::memory_buffer was null-terminated, resulting in printing garbage characters sometimes.