### PR TITLE
:bug: Fix gen_str_catalog for new logging

### DIFF
--- a/include/cib/detail/compiler.hpp
+++ b/include/cib/detail/compiler.hpp
@@ -16,5 +16,10 @@
 #define CIB_CONSTEVAL consteval
 #endif
 
+#ifndef CIB_ALWAYS_INLINE
 #define CIB_ALWAYS_INLINE inline __attribute__((always_inline))
+#endif
+
+#ifndef CIB_NEVER_INLINE
 #define CIB_NEVER_INLINE __attribute__((noinline))
+#endif

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -26,8 +26,10 @@ xml_file = sys.argv[4]
 
 catalog_re = re.compile("^.+?(unsigned int catalog<(.+?)>\(\))\s*$")
 
-#unsigned int catalog<message<(LogLevel)7, sc::lazy_string_format<sc::string_constant<char, (char)102, (char)108, (char)111, (char)119, (char)46, (char)115, (char)116, (char)97, (char)114, (char)116, (char)40, (char)77, (char)101, (char)109, (char)111, (char)114, (char)121, (char)69, (char)114, (char)114, (char)111, (char)114, (char)41>, std::__1::tuple<> > > >()
-string_re = re.compile("message<\(log_level\)(\d+), sc::lazy_string_format<sc::string_constant<char, (.*)>\s*(?:const)?, cib::(?:[a-zA-Z0-9_]+::)*tuple_impl<(.*)>\s*>\s*>")
+# unsigned int catalog<message<(logging::level)7, sc::lazy_string_format<sc::string_constant<char, (char)102, (char)108, (char)111, (char)119, (char)46, (char)115, (char)116, (char)97, (char)114, (char)116, (char)40, (char)77, (char)101, (char)109, (char)111, (char)114, (char)121, (char)69, (char)114, (char)114, (char)111, (char)114, (char)41>, std::__1::tuple<> > > >()
+string_re = re.compile(
+    "message<\(logging::level\)(\d+), sc::lazy_string_format<sc::string_constant<char, (.*)>\s*(?:const)?, cib::(?:[a-zA-Z0-9_]+::)*tuple_impl<(.*)>\s*>\s*>"
+)
 
 
 string_id = 0
@@ -38,14 +40,15 @@ out = open(cpp_file, "w")
 
 messages = []
 
-out.write("""
-
+out.write(
+    """
+#include <log/catalog/catalog.hpp>
+#include <log/log.hpp>
 #include <sc/lazy_string_format.hpp>
 #include <sc/string_constant.hpp>
-#include <log/catalog/catalog.hpp>
-#include <log/log_level.hpp>
 
-""")
+"""
+)
 
 # https://stackoverflow.com/questions/174890/how-to-output-cdata-using-elementtree
 def _escape_cdata(text):


### PR DESCRIPTION
 - `log_level` -> `logging::level`
 - including `log/log.hpp` instead of `log/log_levels.hpp`