### PR TITLE
:bug: Make logging::config an inline variable template

### DIFF
--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -18,7 +18,7 @@ struct config {
 };
 } // namespace null
 
-template <typename...> static auto config = null::config{};
+template <typename...> inline auto config = null::config{};
 
 template <level L, typename... Ts, typename... TArgs>
 static auto log(TArgs &&...args) -> void {

--- a/test/log/fmt_logger.cpp
+++ b/test/log/fmt_logger.cpp
@@ -18,7 +18,8 @@ std::string buffer{};
 // The override test requires that the specialization here happen after the body
 // of log_test_override above.
 template <>
-auto logging::config<> = logging::fmt::config{std::back_inserter(buffer)};
+inline auto logging::config<> =
+    logging::fmt::config{std::back_inserter(buffer)};
 
 #ifndef SANITIZER_NEW_DEL
 void *operator new(std::size_t count) {

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -7,7 +7,7 @@ struct test_config : logging::null::config {
     static auto terminate() noexcept -> void { terminated = true; }
 };
 
-template <> auto logging::config<> = test_config{};
+template <> inline auto logging::config<> = test_config{};
 
 TEST_CASE("FATAL calls terminate", "[log]") {
     CIB_FATAL("Hello");


### PR DESCRIPTION
`logging::config` should be declared `inline` so that it doesn't provoke link errors.