### PR TITLE
:recycle: :white_check_mark: Refactor container tests

### DIFF
--- a/include/container/ConstexprSet.hpp
+++ b/include/container/ConstexprSet.hpp
@@ -165,3 +165,6 @@ template <typename KeyType, std::size_t Capacity> class ConstexprSet {
      */
     [[nodiscard]] constexpr auto pop() -> KeyType { return storage.pop().key; }
 };
+
+template <typename T, typename... Ts>
+ConstexprSet(T, Ts...) -> ConstexprSet<T, 1 + sizeof...(Ts)>;

--- a/include/container/Vector.hpp
+++ b/include/container/Vector.hpp
@@ -101,7 +101,7 @@ template <typename ValueType, size_t Capacity> class Vector {
 
     constexpr auto push(ValueType value) -> void {
         if (isFull()) {
-            CIB_FATAL("Vector:push() attempted when full");
+            CIB_FATAL("Vector::push() attempted when full");
             return;
         }
         storage[currentSize] = value;
@@ -143,3 +143,6 @@ template <typename ValueType, size_t Capacity> class Vector {
         return result;
     }
 };
+
+template <typename T, typename... Ts>
+Vector(T, Ts...) -> Vector<T, 1 + sizeof...(Ts)>;

--- a/test/container/ConstexprMap.cpp
+++ b/test/container/ConstexprMap.cpp
@@ -2,17 +2,19 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "log.hpp"
+
 namespace {
 TEST_CASE("EmptyAndSize", "[constexpr_map]") {
     ConstexprMap<int, int, 64> t;
 
-    REQUIRE(t.getSize() == 0);
-    REQUIRE(t.isEmpty() == true);
+    CHECK(t.getSize() == 0);
+    CHECK(t.isEmpty() == true);
 
     t.put(10, 50);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.isEmpty() == false);
+    CHECK(t.getSize() == 1);
+    CHECK(t.isEmpty() == false);
 }
 
 TEST_CASE("ContainsAndGet", "[constexpr_map]") {
@@ -21,10 +23,11 @@ TEST_CASE("ContainsAndGet", "[constexpr_map]") {
     t.put(11, 100);
 
     REQUIRE(t.contains(10) == true);
-    REQUIRE(t.get(10) == 50);
+    CHECK(t.get(10) == 50);
     REQUIRE(t.contains(11) == true);
-    REQUIRE(t.get(11) == 100);
-    REQUIRE(t.contains(12) == false);
+    CHECK(t.get(11) == 100);
+    CHECK(t.contains(12) == false);
+    CHECK_THROWS_AS(t.get(12), test_log_config::exception);
 }
 
 TEST_CASE("ConstGet", "[constexpr_map]") {
@@ -36,10 +39,11 @@ TEST_CASE("ConstGet", "[constexpr_map]") {
     }();
 
     REQUIRE(t.contains(10) == true);
-    REQUIRE(t.get(10) == 50);
+    CHECK(t.get(10) == 50);
     REQUIRE(t.contains(11) == true);
-    REQUIRE(t.get(11) == 100);
-    REQUIRE(t.contains(12) == false);
+    CHECK(t.get(11) == 100);
+    CHECK(t.contains(12) == false);
+    CHECK_THROWS_AS(t.get(12), test_log_config::exception);
 }
 
 TEST_CASE("UpdateExistingKey", "[constexpr_map]") {
@@ -48,7 +52,13 @@ TEST_CASE("UpdateExistingKey", "[constexpr_map]") {
     t.put(13, 700);
 
     REQUIRE(t.contains(13) == true);
-    REQUIRE(t.get(13) == 700);
+    CHECK(t.get(13) == 700);
+}
+
+TEST_CASE("PutWhenFull", "[constexpr_map]") {
+    ConstexprMap<int, int, 1> t;
+    t.put(13, 500);
+    CHECK_THROWS_AS(t.put(12, 700), test_log_config::exception);
 }
 
 TEST_CASE("Pop", "[constexpr_map]") {
@@ -57,10 +67,11 @@ TEST_CASE("Pop", "[constexpr_map]") {
 
     auto entry = t.pop();
 
-    REQUIRE(t.getSize() == 0);
-    REQUIRE(t.isEmpty() == true);
-    REQUIRE(entry.key == 13);
-    REQUIRE(entry.value == 500);
+    CHECK(t.getSize() == 0);
+    CHECK(t.isEmpty() == true);
+    CHECK(entry.key == 13);
+    CHECK(entry.value == 500);
+    CHECK_THROWS_AS(t.pop(), test_log_config::exception);
 }
 
 TEST_CASE("Remove", "[constexpr_map]") {
@@ -71,10 +82,10 @@ TEST_CASE("Remove", "[constexpr_map]") {
 
     t.remove(18);
 
-    REQUIRE(t.getSize() == 2);
-    REQUIRE(t.contains(18) == false);
-    REQUIRE(t.get(13) == 500);
-    REQUIRE(t.get(19) == 700);
+    CHECK(t.getSize() == 2);
+    CHECK(t.contains(18) == false);
+    CHECK(t.get(13) == 500);
+    CHECK(t.get(19) == 700);
 }
 
 TEST_CASE("RemoveNonExistantKey", "[constexpr_map]") {
@@ -84,16 +95,16 @@ TEST_CASE("RemoveNonExistantKey", "[constexpr_map]") {
 
     t.remove(50);
 
-    REQUIRE(t.getSize() == 2);
-    REQUIRE(t.contains(50) == false);
-    REQUIRE(t.get(13) == 500);
-    REQUIRE(t.get(18) == 600);
+    CHECK(t.getSize() == 2);
+    CHECK(t.contains(50) == false);
+    CHECK(t.get(13) == 500);
+    CHECK(t.get(18) == 600);
 }
 
 TEST_CASE("EmptyIterators", "[constexpr_map]") {
     ConstexprMap<int, int, 64> t;
 
-    REQUIRE(t.begin() == t.end());
+    CHECK(t.begin() == t.end());
 }
 
 TEST_CASE("NonEmptyIterators", "[constexpr_map]") {
@@ -101,7 +112,7 @@ TEST_CASE("NonEmptyIterators", "[constexpr_map]") {
 
     t.put(18, 600);
 
-    REQUIRE((t.begin() + 1) == t.end());
+    CHECK((t.begin() + 1) == t.end());
 }
 
 constexpr auto emptyMapTest = [] {

--- a/test/container/ConstexprMultiMap.cpp
+++ b/test/container/ConstexprMultiMap.cpp
@@ -6,8 +6,8 @@ namespace {
 TEST_CASE("EmptyAndSize", "[constexpr_multimap]") {
     ConstexprMultiMap<int, int, 64> t;
 
-    REQUIRE(t.getSize() == 0);
-    REQUIRE(t.isEmpty() == true);
+    CHECK(t.getSize() == 0);
+    CHECK(t.isEmpty() == true);
 }
 
 TEST_CASE("PutAndContains", "[constexpr_multimap]") {
@@ -15,13 +15,13 @@ TEST_CASE("PutAndContains", "[constexpr_multimap]") {
 
     t.put(60, 40);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.isEmpty() == false);
-    REQUIRE(t.contains(60) == true);
-    REQUIRE(t.contains(40) == false);
-    REQUIRE(t.contains(60, 40) == true);
-    REQUIRE(t.contains(60, 60) == false);
-    REQUIRE(t.contains(40, 40) == false);
+    CHECK(t.getSize() == 1);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(60) == true);
+    CHECK(t.contains(40) == false);
+    CHECK(t.contains(60, 40) == true);
+    CHECK(t.contains(60, 60) == false);
+    CHECK(t.contains(40, 40) == false);
 }
 
 constexpr auto emptyMultiMapTest = [] {
@@ -40,11 +40,11 @@ TEST_CASE("PutMultipleValues", "[constexpr_multimap]") {
     t.put(60, 2);
     t.put(60, 3);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.contains(60, 1) == true);
-    REQUIRE(t.contains(60, 2) == true);
-    REQUIRE(t.contains(60, 3) == true);
-    REQUIRE(t.contains(60, 0) == false);
+    CHECK(t.getSize() == 1);
+    CHECK(t.contains(60, 1) == true);
+    CHECK(t.contains(60, 2) == true);
+    CHECK(t.contains(60, 3) == true);
+    CHECK(t.contains(60, 0) == false);
 }
 
 constexpr auto populatedMultiMapTest = [] {

--- a/test/container/ConstexprSet.cpp
+++ b/test/container/ConstexprSet.cpp
@@ -2,12 +2,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "log.hpp"
+
 namespace {
 TEST_CASE("EmptyAndSize", "[constexpr_set]") {
     ConstexprSet<int, 64> t;
 
-    REQUIRE(t.getSize() == 0);
-    REQUIRE(t.isEmpty() == true);
+    CHECK(t.getSize() == 0);
+    CHECK(t.isEmpty() == true);
 }
 
 constexpr auto emptySetTest = [] {
@@ -18,17 +20,46 @@ constexpr auto emptySetTest = [] {
 static_assert(emptySetTest.isEmpty());
 static_assert(!emptySetTest.contains(10));
 
+TEST_CASE("CTAD", "[constexpr_set]") {
+    ConstexprSet set{1, 2, 3, 4, 5, 6};
+    static_assert(std::is_same_v<decltype(set), ConstexprSet<int, 6>>);
+}
+
 TEST_CASE("TestContains", "[constexpr_set]") {
     ConstexprSet<int, 64> t;
 
-    REQUIRE(t.contains(10) == false);
+    CHECK(t.contains(10) == false);
 
     t.add(10);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.isEmpty() == false);
-    REQUIRE(t.contains(10) == true);
-    REQUIRE(t.contains(11) == false);
+    CHECK(t.getSize() == 1);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(10) == true);
+    CHECK(t.contains(11) == false);
+}
+
+TEST_CASE("Create", "[constexpr_set]") {
+    ConstexprSet<int, 64> t{1, 2, 3};
+
+    CHECK(t.getSize() == 3);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(1) == true);
+    CHECK(t.contains(2) == true);
+    CHECK(t.contains(3) == true);
+    CHECK(t.contains(11) == false);
+}
+
+TEST_CASE("CreateOverCapacity", "[constexpr_set]") {
+    constexpr auto make_set = []() {
+        ConstexprSet<int, 1> const set{1, 2};
+        return set;
+    };
+    CHECK_THROWS_AS(make_set(), test_log_config::exception);
+
+    test_log_config::prevent_throws nothrows{};
+    auto const set = make_set();
+    CHECK(0u == set.getSize());
+    CHECK(set.isEmpty());
 }
 
 TEST_CASE("TestMultipleAdd", "[constexpr_set]") {
@@ -37,9 +68,9 @@ TEST_CASE("TestMultipleAdd", "[constexpr_set]") {
     t.add(10);
     t.add(10);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.isEmpty() == false);
-    REQUIRE(t.contains(10) == true);
+    CHECK(t.getSize() == 1);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(10) == true);
 }
 
 constexpr auto populatedSetTest = [] {
@@ -59,9 +90,9 @@ TEST_CASE("TestRemoveEverything", "[constexpr_set]") {
     t.add(10);
     t.remove(10);
 
-    REQUIRE(t.getSize() == 0);
-    REQUIRE(t.isEmpty() == true);
-    REQUIRE(t.contains(10) == false);
+    CHECK(t.getSize() == 0);
+    CHECK(t.isEmpty() == true);
+    CHECK(t.contains(10) == false);
 }
 
 TEST_CASE("TestRemoveSome", "[constexpr_set]") {
@@ -71,10 +102,10 @@ TEST_CASE("TestRemoveSome", "[constexpr_set]") {
     t.add(11);
     t.remove(10);
 
-    REQUIRE(t.getSize() == 1);
-    REQUIRE(t.isEmpty() == false);
-    REQUIRE(t.contains(10) == false);
-    REQUIRE(t.contains(11) == true);
+    CHECK(t.getSize() == 1);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(10) == false);
+    CHECK(t.contains(11) == true);
 }
 
 constexpr auto testSetRemove = [] {
@@ -123,15 +154,15 @@ TEST_CASE("TestRemoveAll", "[constexpr_set]") {
 
     t.removeAll(setToRemove);
 
-    REQUIRE(t.getSize() == 3);
-    REQUIRE(t.isEmpty() == false);
-    REQUIRE(t.contains(12) == true);
-    REQUIRE(t.contains(40) == true);
-    REQUIRE(t.contains(42) == true);
-    REQUIRE(t.contains(10) == false);
-    REQUIRE(t.contains(11) == false);
-    REQUIRE(t.contains(32) == false);
-    REQUIRE(t.contains(56) == false);
+    CHECK(t.getSize() == 3);
+    CHECK(t.isEmpty() == false);
+    CHECK(t.contains(12) == true);
+    CHECK(t.contains(40) == true);
+    CHECK(t.contains(42) == true);
+    CHECK(t.contains(10) == false);
+    CHECK(t.contains(11) == false);
+    CHECK(t.contains(32) == false);
+    CHECK(t.contains(56) == false);
 }
 
 constexpr auto testSetRemoveAll = [] {

--- a/test/container/Vector.cpp
+++ b/test/container/Vector.cpp
@@ -2,179 +2,186 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "log.hpp"
+
 namespace {
 TEST_CASE("EmptyVector", "[vector]") {
     const Vector<uint32_t, 3> vector({});
-    REQUIRE(0u == vector.size());
-    REQUIRE(3u == vector.getCapacity());
+    CHECK(0u == vector.size());
+    CHECK(3u == vector.getCapacity());
 }
 
-TEST_CASE("OverCapacity", "[vector]") {
-    Vector<uint32_t, 1> vector({0x3, 0xdeadbeef});
-    REQUIRE(0u == vector.size());
-    REQUIRE(vector.isEmpty());
+TEST_CASE("CTAD", "[vector]") {
+    Vector vector{1, 2, 3, 4, 5, 6};
+    static_assert(std::is_same_v<decltype(vector), Vector<int, 6>>);
+}
+
+TEST_CASE("CreateOverCapacity", "[vector]") {
+    constexpr auto make_vector = []() {
+        Vector<uint32_t, 1> const vector{0x3, 0xdeadbeef};
+        return vector;
+    };
+    CHECK_THROWS_AS(make_vector(), test_log_config::exception);
+
+    test_log_config::prevent_throws nothrows{};
+    auto const vector = make_vector();
+    CHECK(0u == vector.size());
+    CHECK(vector.isEmpty());
 }
 
 TEST_CASE("NonConstVector", "[vector]") {
-    Vector<uint32_t, 6> vector({0x13, 0x8, 0x43, 0x1024, 0xdeadbeef, 0x600});
+    Vector<uint32_t, 6> vector{0x13, 0x8, 0x43, 0x1024, 0xdeadbeef, 0x600};
 
     REQUIRE(6u == vector.size());
-
-    REQUIRE(0x13 == vector[0]);
-    REQUIRE(0x8 == vector[1]);
-    REQUIRE(0x43 == vector[2]);
-    REQUIRE(0x1024 == vector[3]);
-    REQUIRE(0xdeadbeef == vector[4]);
-    REQUIRE(0x600 == vector[5]);
+    CHECK(0x13 == vector[0]);
+    CHECK(0x8 == vector[1]);
+    CHECK(0x43 == vector[2]);
+    CHECK(0x1024 == vector[3]);
+    CHECK(0xdeadbeef == vector[4]);
+    CHECK(0x600 == vector[5]);
 
     vector[2] = 0x55;
-    REQUIRE(0x55 == vector[2]);
+    CHECK(0x55 == vector[2]);
 }
 
 TEST_CASE("ConstVector", "[vector]") {
-    const Vector<uint32_t, 7> vector({0xFF0F, 0x1420, 0x5530});
+    const Vector<uint32_t, 7> vector{0xFF0F, 0x1420, 0x5530};
 
-    REQUIRE(0xFF0F == vector[0]);
-    REQUIRE(0x1420 == vector[1]);
-    REQUIRE(0x5530 == vector[2]);
+    REQUIRE(3u == vector.size());
+    CHECK(0xFF0F == vector[0]);
+    CHECK(0x1420 == vector[1]);
+    CHECK(0x5530 == vector[2]);
 }
 
 TEST_CASE("OutOfBounds", "[vector]") {
-    Vector<uint32_t, 15> vector({0x30, 0x75, 0x44, 0xAB, 0x88});
-
-    vector[10] = 0u;
+    Vector<uint32_t, 15> vector{0x30, 0x75, 0x44, 0xAB, 0x88};
+    CHECK_THROWS_AS((vector[10] = 0), test_log_config::exception);
 }
 
 TEST_CASE("OutOfBoundsConst", "[vector]") {
     const Vector<uint32_t, 9> vector;
-
-    [[maybe_unused]] const uint32_t &x = vector[8];
+    CHECK_THROWS_AS(vector[8], test_log_config::exception);
 }
 
 TEST_CASE("OutOfBoundsEdge", "[vector]") {
-    Vector<uint32_t, 11> vector({0x12, 0x33, 0x78});
-
-    vector[3] = 0u;
+    Vector<uint32_t, 11> vector{0x12, 0x33, 0x78};
+    CHECK_THROWS_AS((vector[3] = 0), test_log_config::exception);
 }
 
 TEST_CASE("OutOfBoundsEmpty", "[vector]") {
     Vector<uint32_t, 10> vector;
-
-    vector[0] = 0xdeadbeef;
+    CHECK_THROWS_AS((vector[0] = 0xdeadbeef), test_log_config::exception);
 }
 
 TEST_CASE("VectorIterator", "[vector]") {
-    Vector<uint32_t, 12> vector({0x11, 0x22, 0x33, 0x44, 0x55, 0x66});
+    Vector<uint32_t, 12> vector{0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
 
     for (auto &item : vector) {
         item++;
     }
 
     auto iter = vector.begin();
-    REQUIRE(0x12 == *iter);
+    CHECK(0x12 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x23 == *iter);
+    CHECK(0x23 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x34 == *iter);
+    CHECK(0x34 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x45 == *iter);
+    CHECK(0x45 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x56 == *iter);
+    CHECK(0x56 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x67 == *iter);
+    CHECK(0x67 == *iter);
     ++iter;
-    REQUIRE(iter == vector.end());
+    CHECK(iter == vector.end());
 }
 
 TEST_CASE("VectorConstIterator", "[vector]") {
-    const Vector<uint32_t, 7> vector({0x54, 0x70, 0x31});
+    const Vector<uint32_t, 7> vector{0x54, 0x70, 0x31};
 
     auto iter = vector.begin();
-
-    REQUIRE(0x54 == *iter);
+    CHECK(0x54 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x70 == *iter);
+    CHECK(0x70 == *iter);
     ++iter;
     REQUIRE(iter != vector.end());
-    REQUIRE(0x31 == *iter);
+    CHECK(0x31 == *iter);
     ++iter;
-    REQUIRE(iter == vector.end());
+    CHECK(iter == vector.end());
 }
 
 TEST_CASE("VectorPush", "[vector]") {
-    Vector<uint32_t, 6> vector({0x1, 0x12, 0x123, 0x1234});
+    Vector<uint32_t, 6> vector{0x1, 0x12, 0x123, 0x1234};
 
-    REQUIRE(4u == vector.size());
+    CHECK(4u == vector.size());
     REQUIRE_FALSE(vector.isFull());
     vector.push(0x12345);
     REQUIRE(5u == vector.size());
-    REQUIRE(0x12345 == vector[4]);
+    CHECK(0x12345 == vector[4]);
     REQUIRE_FALSE(vector.isFull());
     vector.push(0x123456);
     REQUIRE(6u == vector.size());
-    REQUIRE(0x123456 == vector[5]);
+    CHECK(0x123456 == vector[5]);
     REQUIRE(vector.isFull());
-
-    vector.push(0xF5);
+    CHECK_THROWS_AS(vector.push(0xF5), test_log_config::exception);
 }
 
 TEST_CASE("VectorPop", "[vector]") {
-    Vector<uint32_t, 14> vector({0xA, 0xB, 0xC, 0xD, 0xE, 0xF});
+    Vector<uint32_t, 14> vector{0xA, 0xB, 0xC, 0xD, 0xE, 0xF};
 
-    REQUIRE(0xF == vector.pop());
-    REQUIRE(5u == vector.size());
+    CHECK(0xF == vector.pop());
+    CHECK(5u == vector.size());
     REQUIRE_FALSE(vector.isEmpty());
-    REQUIRE(0xE == vector.pop());
-    REQUIRE(0xD == vector.pop());
-    REQUIRE(0xC == vector.pop());
-    REQUIRE(0xB == vector.pop());
+    CHECK(0xE == vector.pop());
+    CHECK(0xD == vector.pop());
+    CHECK(0xC == vector.pop());
+    CHECK(0xB == vector.pop());
     REQUIRE_FALSE(vector.isEmpty());
-    REQUIRE(0xA == vector.pop());
+    CHECK(0xA == vector.pop());
     REQUIRE(vector.isEmpty());
-
-    std::ignore = vector.pop();
+    CHECK_THROWS_AS(vector.pop(), test_log_config::exception);
 }
 
 TEST_CASE("VectorEqualOperator", "[vector]") {
-    Vector<uint32_t, 10> a({4, 9, 2, 3, 1});
-    Vector<uint32_t, 10> b({4, 9, 2, 3, 1});
+    Vector<uint32_t, 10> a{4, 9, 2, 3, 1};
+    Vector<uint32_t, 10> b{4, 9, 2, 3, 1};
 
-    Vector<uint32_t, 10> c({4, 9, 2, 3, 1, 0});
-    Vector<uint32_t, 10> d({4, 9, 2, 3});
-    Vector<uint32_t, 10> e({1, 9, 2, 3, 1});
+    Vector<uint32_t, 10> c{4, 9, 2, 3, 1, 0};
+    Vector<uint32_t, 10> d{4, 9, 2, 3};
+    Vector<uint32_t, 10> e{1, 9, 2, 3, 1};
 
-    REQUIRE(a == b);
-    REQUIRE_FALSE(a == c);
-    REQUIRE_FALSE(a == d);
-    REQUIRE_FALSE(a == e);
+    CHECK(a == b);
+    CHECK_FALSE(a == c);
+    CHECK_FALSE(a == d);
+    CHECK_FALSE(a == e);
 }
 
 TEST_CASE("VectorNotEqualOperator", "[vector]") {
-    Vector<uint32_t, 10> a({4, 9, 2, 3, 1});
-    Vector<uint32_t, 10> b({4, 9, 2, 3, 1});
+    Vector<uint32_t, 10> a{4, 9, 2, 3, 1};
+    Vector<uint32_t, 10> b{4, 9, 2, 3, 1};
 
-    Vector<uint32_t, 10> c({4, 9, 2, 3, 1, 0});
-    Vector<uint32_t, 10> d({4, 9, 2, 3});
-    Vector<uint32_t, 10> e({1, 9, 2, 3, 1});
+    Vector<uint32_t, 10> c{4, 9, 2, 3, 1, 0};
+    Vector<uint32_t, 10> d{4, 9, 2, 3};
+    Vector<uint32_t, 10> e{1, 9, 2, 3, 1};
 
-    REQUIRE_FALSE(a != b);
-    REQUIRE(a != c);
-    REQUIRE(a != d);
-    REQUIRE(a != e);
+    CHECK_FALSE(a != b);
+    CHECK(a != c);
+    CHECK(a != d);
+    CHECK(a != e);
 }
 
 TEST_CASE("VectorConcatenate", "[vector]") {
-    Vector<uint32_t, 10> lhs({1, 2, 3});
-    Vector<uint32_t, 10> rhs({4, 5});
+    Vector<uint32_t, 10> lhs{1, 2, 3};
+    Vector<uint32_t, 10> rhs{4, 5};
 
-    Vector<uint32_t, 10> cat({1, 2, 3, 4, 5});
+    Vector<uint32_t, 10> cat{1, 2, 3, 4, 5};
 
-    REQUIRE(lhs + rhs == cat);
+    CHECK(lhs + rhs == cat);
 }
 } // namespace

--- a/test/container/log.hpp
+++ b/test/container/log.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <log/log.hpp>
+
+struct test_log_config : logging::null::config {
+    struct exception {};
+
+    struct [[nodiscard]] prevent_throws {
+        prevent_throws() { throws = false; }
+        prevent_throws(prevent_throws &&) = delete;
+        auto operator=(prevent_throws &&) -> prevent_throws & = delete;
+        ~prevent_throws() { throws = true; }
+    };
+
+    static auto terminate() -> void {
+        if (throws) {
+            throw exception{};
+        }
+    }
+
+  private:
+    static inline bool throws = true;
+};
+
+template <> inline auto logging::config<> = test_log_config{};


### PR DESCRIPTION
 - Use CHECK and REQUIRES properly: REQUIRES halts a test if it cannot continue and should be used before operations that will otherwise be UB, e.g. REQUIRE an index is in range before using it.
 - Add tests for the CIB_ASSERT or CIB_FATAL control paths in container usage, now that that behaviour can be injected with a log config.