### PR TITLE
:art: Make log implementations opt-in

### DIFF
--- a/include/log/catalog/mipi_encoder.hpp
+++ b/include/log/catalog/mipi_encoder.hpp
@@ -3,7 +3,7 @@
 #include <cib/detail/compiler.hpp>
 #include <cib/tuple.hpp>
 #include <log/catalog/catalog.hpp>
-#include <log/level.hpp>
+#include <log/log.hpp>
 
 #include <cstdint>
 #include <exception>

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cib/tuple.hpp>
-#include <log/level.hpp>
+#include <log/log.hpp>
 
 #include <fmt/format.h>
 

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -45,6 +45,3 @@ template <typename... Ts> static auto terminate() -> void {
 
 #define CIB_ASSERT(expr)                                                       \
     ((expr) ? void(0) : CIB_FATAL("Assertion failure: " #expr))
-
-#include <log/catalog/mipi_encoder.hpp>
-#include <log/fmt/logger.hpp>

--- a/test/log/fmt_logger.cpp
+++ b/test/log/fmt_logger.cpp
@@ -1,4 +1,4 @@
-#include <log/log.hpp>
+#include <log/fmt/logger.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/log/mipi_encoder.cpp
+++ b/test/log/mipi_encoder.cpp
@@ -1,4 +1,4 @@
-#include <log/log.hpp>
+#include <log/catalog/mipi_encoder.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 


### PR DESCRIPTION
Using fmt for logging implies including some parts of the STL like iostreams; if a client doesn't want to use fmt for logging this should not be pulled in.