### PR TITLE
:construction_worker: Fix performance test

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -11,9 +11,6 @@ env:
 jobs:
   performance_test:
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
 
@@ -29,9 +26,10 @@ jobs:
 
       - name: Build
         id: build_step
+        shell: bash
         run: |
-          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -t compilation_benchmark |& tee ${{github.workspace}}/build/compilation_output.log
-          echo "::set-output name=compile_benchmark_time::"`grep "Clang front-end timer" ${{github.workspace}}/build/compilation_output.log | grep -o "^\s\+\S\+\s" | grep -o "\S\+"`
+          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -t compilation_benchmark | tee ${{github.workspace}}/build/compilation_output.log
+          echo "compile_benchmark_time="`grep "Clang front-end timer" ${{github.workspace}}/build/compilation_output.log | awk '{print $1}'` >> $GITHUB_OUTPUT
 
       - name: 'Upload Compilation Trace'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,10 +21,15 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [9, 10, 11, 12, 13, 14]
+        version: [9, 10, 11, 12, 13, 14, 15]
         cxx_standard: [17, 20]
         build_type: [Debug]
         include:
+          - version: 15
+            compiler: clang
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 15
+            cc: "/usr/lib/llvm-15/bin/clang"
+            cxx: "/usr/lib/llvm-15/bin/clang++"
           - version: 14
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 14
@@ -79,6 +84,8 @@ jobs:
             version: 9
             cxx_standard: 20
           # gcc only goes up to 11 on ubuntu-20.04
+          - compiler: gcc
+            version: 15
           - compiler: gcc
             version: 14
           - compiler: gcc
@@ -142,13 +149,13 @@ jobs:
 
       - name: Install build tools
         run: |
-          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 14
+          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 15
           sudo apt install -y ninja-build
 
       - name: Configure CMake
         env:
-          CC: "/usr/lib/llvm-14/bin/clang"
-          CXX: "/usr/lib/llvm-14/bin/clang++"
+          CC: "/usr/lib/llvm-15/bin/clang"
+          CXX: "/usr/lib/llvm-15/bin/clang++"
           CXX_STANDARD: 20
         run: cmake -B ${{github.workspace}}/build -DSANITIZERS=undefined,address
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,6 +5,7 @@ target_compile_options(
     PRIVATE -ftemplate-backtrace-limit=0
             -ftime-report
             $<$<CXX_COMPILER_ID:Clang>:-fconstexpr-steps=2000000>
+            $<$<CXX_COMPILER_ID:Clang>:-fbracket-depth=512>
             $<$<CXX_COMPILER_ID:Clang>:-ferror-limit=8>
             $<$<CXX_COMPILER_ID:Clang>:-ftime-trace>
             $<$<CXX_COMPILER_ID:Clang>:-ftime-trace-granularity=10>


### PR DESCRIPTION
The perf test does not fail the job when it fails. It also uses deprecated github commands.

Closes #205 