### PR TITLE
:construction_worker: Update CI: add llvm-15, use ubuntu-22.04

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -10,17 +10,17 @@ env:
 
 jobs:
   performance_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
       - name: Install compiler
-        run: sudo apt update && sudo apt-get install -y clang-12
+        run: sudo apt update && sudo apt-get install -y clang-14
 
       - name: Configure CMake
         env:
-          CC: clang-12
-          CXX: clang++-12
+          CC: "/usr/lib/llvm-14/bin/clang"
+          CXX: "/usr/lib/llvm-14/bin/clang++"
           CXX_STANDARD: 20
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,91 +11,37 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  CMAKE_GENERATOR: Ninja
-
 jobs:
-  build_and_test:
+  build_and_test_older_compilers:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [9, 10, 11, 12, 13, 14, 15]
-        cxx_standard: [17, 20]
+        version: [9, 10]
+        cxx_standard: [17]
         build_type: [Debug]
         include:
-          - version: 15
-            compiler: clang
-            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 15
-            cc: "/usr/lib/llvm-15/bin/clang"
-            cxx: "/usr/lib/llvm-15/bin/clang++"
-          - version: 14
-            compiler: clang
-            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 14
-            cc: "/usr/lib/llvm-14/bin/clang"
-            cxx: "/usr/lib/llvm-14/bin/clang++"
-          - version: 13
-            compiler: clang
-            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 13
-            cc: "/usr/lib/llvm-13/bin/clang"
-            cxx: "/usr/lib/llvm-13/bin/clang++"
-          - version: 12
-            compiler: clang
-            install: sudo apt update && sudo apt-get install -y clang-12
-            cc: "/usr/lib/llvm-12/bin/clang"
-            cxx: "/usr/lib/llvm-12/bin/clang++"
-          - version: 11
-            compiler: clang
-            install: sudo apt update && sudo apt-get install -y clang-11
-            cc: "/usr/lib/llvm-11/bin/clang"
-            cxx: "/usr/lib/llvm-11/bin/clang++"
           - version: 10
             compiler: clang
-            install: sudo apt update && sudo apt-get install -y clang-10
+            install: sudo apt update && sudo apt install -y clang-10
             cc: "/usr/lib/llvm-10/bin/clang"
             cxx: "/usr/lib/llvm-10/bin/clang++"
           - version: 9
             compiler: clang
-            install: sudo apt update && sudo apt-get install -y clang-9
+            install: sudo apt update && sudo apt install -y clang-9
             cc: "/usr/lib/llvm-9/bin/clang"
             cxx: "/usr/lib/llvm-9/bin/clang++"
-          - version: 11
-            compiler: gcc
-            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt-get install -y gcc-11 g++-11
-            cc: "/usr/bin/gcc-11"
-            cxx: "/usr/bin/g++-11"
           - version: 10
             compiler: gcc
-            install: sudo apt update && sudo apt-get install -y gcc-10
+            install: sudo apt update && sudo apt install -y gcc-10
             cc: "/usr/bin/gcc-10"
             cxx: "/usr/bin/g++-10"
           - version: 9
             compiler: gcc
-            install: sudo apt update && sudo apt-get install -y gcc-9
+            install: sudo apt update && sudo apt install -y gcc-9
             cc: "/usr/bin/gcc-9"
             cxx: "/usr/bin/g++-9"
-        exclude:
-          # clang pre-version 11: C++17 only
-          - compiler: clang
-            version: 10
-            cxx_standard: 20
-          - compiler: clang
-            version: 9
-            cxx_standard: 20
-          # gcc only goes up to 11 on ubuntu-20.04
-          - compiler: gcc
-            version: 15
-          - compiler: gcc
-            version: 14
-          - compiler: gcc
-            version: 13
-          - compiler: gcc
-            version: 12
-          # gcc pre-version 10: C++17 only
-          - compiler: gcc
-            version: 9
-            cxx_standard: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -110,6 +56,84 @@ jobs:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
           CXX_STANDARD: ${{ matrix.cxx_standard }}
+          CMAKE_GENERATOR: Ninja
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+
+      - name: Build Unit Tests
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -t unit_tests
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.build_type}}
+  
+  build_and_test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang, gcc]
+        version: [11, 12, 13, 14, 15]
+        cxx_standard: [17, 20]
+        build_type: [Debug]
+        include:
+          - version: 15
+            compiler: clang
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 15
+            cc: "/usr/lib/llvm-15/bin/clang"
+            cxx: "/usr/lib/llvm-15/bin/clang++"
+          - version: 14
+            compiler: clang
+            install: sudo apt update && sudo apt install -y clang-14
+            cc: "/usr/lib/llvm-14/bin/clang"
+            cxx: "/usr/lib/llvm-14/bin/clang++"
+          - version: 13
+            compiler: clang
+            install: sudo apt update && sudo apt install -y clang-13
+            cc: "/usr/lib/llvm-13/bin/clang"
+            cxx: "/usr/lib/llvm-13/bin/clang++"
+          - version: 12
+            compiler: clang
+            install: sudo apt update && sudo apt install -y clang-12
+            cc: "/usr/lib/llvm-12/bin/clang"
+            cxx: "/usr/lib/llvm-12/bin/clang++"
+          - version: 11
+            compiler: clang
+            install: sudo apt update && sudo apt install -y clang-11
+            cc: "/usr/lib/llvm-11/bin/clang"
+            cxx: "/usr/lib/llvm-11/bin/clang++"
+          - version: 12
+            compiler: gcc
+            install: sudo apt update && sudo apt install -y gcc-12
+            cc: "/usr/bin/gcc-12"
+            cxx: "/usr/bin/g++-12"
+          - version: 11
+            compiler: gcc
+            install: sudo apt update && sudo apt install -y gcc-11
+            cc: "/usr/bin/gcc-11"
+            cxx: "/usr/bin/g++-11"
+        exclude:
+          # gcc only goes up to 12 on ubuntu-22.04
+          - compiler: gcc
+            version: 15
+          - compiler: gcc
+            version: 14
+          - compiler: gcc
+            version: 13
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build tools
+        run: |
+          ${{ matrix.install }}
+          sudo apt install -y ninja-build
+
+      - name: Configure CMake
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+          CXX_STANDARD: ${{ matrix.cxx_standard }}
+          CMAKE_GENERATOR: Ninja
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
 
       - name: Build Unit Tests
@@ -120,12 +144,14 @@ jobs:
         run: ctest -C ${{matrix.build_type}}
 
   quality_checks_pass:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
       - name: Install build tools
-        run: sudo apt update && sudo apt-get install -y clang-11 ninja-build
+        run: |
+          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 15
+          sudo apt install -y ninja-build clang-tidy-15 clang-format-15
 
       - name: Install cmake-format
         run: |
@@ -134,16 +160,17 @@ jobs:
 
       - name: Configure CMake
         env:
-          CC: "/usr/lib/llvm-11/bin/clang"
-          CXX: "/usr/lib/llvm-11/bin/clang++"
+          CC: "/usr/lib/llvm-15/bin/clang"
+          CXX: "/usr/lib/llvm-15/bin/clang++"
           CXX_STANDARD: 20
-        run: cmake -B ${{github.workspace}}/build
+          CMAKE_GENERATOR: Ninja
+        run: cmake -B ${{github.workspace}}/build -DCLANG_TOOLS_PATH=/usr/lib/llvm-15/bin
 
       - name: Run quality checks
         run: cmake --build ${{github.workspace}}/build -t quality
 
   sanitize:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -157,31 +184,25 @@ jobs:
           CC: "/usr/lib/llvm-15/bin/clang"
           CXX: "/usr/lib/llvm-15/bin/clang++"
           CXX_STANDARD: 20
+          CMAKE_GENERATOR: Ninja
         run: cmake -B ${{github.workspace}}/build -DSANITIZERS=undefined,address
 
       - name: Build Unit Tests
         run: cmake --build ${{github.workspace}}/build -t unit_tests
 
   merge_ok:
-    runs-on: ubuntu-20.04
-    needs: [build_and_test, quality_checks_pass, sanitize]
+    runs-on: ubuntu-22.04
+    needs: [build_and_test_older_compilers, build_and_test, quality_checks_pass, sanitize]
     steps:
       - name: Enable merge
         run: echo "OK to merge!"
 
   build_single_header:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install build tools
-        run: sudo apt update && sudo apt-get install -y clang-11 ninja-build
-
       - name: Configure CMake
-        env:
-          CC: "/usr/lib/llvm-11/bin/clang"
-          CXX: "/usr/lib/llvm-11/bin/clang++"
-          CXX_STANDARD: 20
         run: cmake -B ${{github.workspace}}/build
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    if(CLANG_TOOLS_PATH)
+        list(APPEND CMAKE_PROGRAM_PATH ${CLANG_TOOLS_PATH})
+    endif()
+
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
     include(cmake/sanitizers.cmake)
     include(cmake/test.cmake)

--- a/include/cib/detail/nexus_details.hpp
+++ b/include/cib/detail/nexus_details.hpp
@@ -34,8 +34,8 @@ struct get_service {
 
 struct get_service_from_tuple {
     template <typename T>
-    using invoke = typename std::remove_cv_t<std::remove_reference_t<decltype(
-        std::declval<T>().get(index_<0>))>>::service_type;
+    using invoke = typename std::remove_cv_t<std::remove_reference_t<
+        decltype(std::declval<T>().get(index_<0>))>>::service_type;
 };
 
 template <typename Config> struct initialized_builders {

--- a/include/cib/detail/type_list.hpp
+++ b/include/cib/detail/type_list.hpp
@@ -47,9 +47,9 @@ type_list_cat_impl(std::integer_sequence<unsigned int, Indices...>,
 
     auto const outer_type_list = type_list<decltype(type_lists)...>{};
 
-    return type_list<decltype(
-        outer_type_list.template get<element_indices[Indices].outer>()
-            .template get<element_indices[Indices].inner>())...>{};
+    return type_list<
+        decltype(outer_type_list.template get<element_indices[Indices].outer>()
+                     .template get<element_indices[Indices].inner>())...>{};
 }
 
 template <typename... TypeLists>

--- a/include/cib/detail/type_pack_element.hpp
+++ b/include/cib/detail/type_pack_element.hpp
@@ -12,8 +12,9 @@ template <class... Ts> struct inherit : Ts... {};
 template <int Index, class T>
 auto get_type_pack_element_impl(type_id<T, Index>) -> T;
 template <int Index, typename... Ts, auto... Ns>
-auto get_type_pack_element_impl(std::index_sequence<Ns...>) -> decltype(
-    get_type_pack_element_impl<Index>(inherit<type_id<Ts, Ns>...>{}));
+auto get_type_pack_element_impl(std::index_sequence<Ns...>)
+    -> decltype(get_type_pack_element_impl<Index>(
+        inherit<type_id<Ts, Ns>...>{}));
 template <int Index, typename... Ts> struct get_type_pack_element {
     using type = decltype(get_type_pack_element_impl<Index, Ts...>(
         std::make_index_sequence<sizeof...(Ts)>{}));

--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -349,9 +349,12 @@ template <typename... TupleElementTs> struct tuple_impl : TupleElementTs... {
         return not(lhs < rhs);
     }
 #else
-    [[nodiscard]] constexpr friend auto
-    operator<=>(tuple_impl const &lhs, tuple_impl const &rhs) requires(
-        std::three_way_comparable<typename TupleElementTs::value_type> and...) {
+    [[nodiscard]] constexpr friend auto operator<=>(tuple_impl const &lhs,
+                                                    tuple_impl const &rhs)
+        requires(
+            std::three_way_comparable<typename TupleElementTs::value_type> and
+            ...)
+    {
         std::common_comparison_category_t<std::compare_three_way_result_t<
             typename TupleElementTs::value_type>...>
             result{std::strong_ordering::equivalent};

--- a/include/container/Vector.hpp
+++ b/include/container/Vector.hpp
@@ -50,10 +50,10 @@ template <typename ValueType, size_t Capacity> class Vector {
 
     constexpr Vector() = default;
 
-    [[nodiscard]] constexpr auto begin() -> iterator { return &storage[0]; }
+    [[nodiscard]] constexpr auto begin() -> iterator { return storage.data(); }
 
     [[nodiscard]] constexpr auto begin() const -> const_iterator {
-        return &storage[0];
+        return storage.data();
     }
 
     [[nodiscard]] constexpr auto end() -> iterator {

--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 
 namespace flow {
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
 struct interface {
     virtual auto operator()() const -> void {}
 };

--- a/include/flow/milestone.hpp
+++ b/include/flow/milestone.hpp
@@ -4,7 +4,7 @@
 #include <flow/detail/parallel.hpp>
 
 namespace flow {
-using FunctionPtr = auto (*)() -> void;
+using FunctionPtr = auto(*)() -> void;
 
 class milestone_base {
   private:
@@ -20,14 +20,16 @@ class milestone_base {
   public:
     template <typename Name>
     constexpr milestone_base([[maybe_unused]] Name name, FunctionPtr run_ptr)
-        : run{run_ptr}, log_name {
-        []() { CIB_TRACE("flow.milestone({})", Name{}); }
-    }
+        : run{run_ptr}, log_name{[]() {
+              CIB_TRACE("flow.milestone({})", Name{});
+          }}
 
 #if defined(__GNUC__) && __GNUC__ < 12
-    , hash { name.hash() }
+          ,
+          hash{name.hash()}
 #endif
-    {}
+    {
+    }
 
     constexpr milestone_base() = default;
 

--- a/include/flow/run.hpp
+++ b/include/flow/run.hpp
@@ -4,7 +4,7 @@
 
 namespace flow {
 namespace detail {
-using FunctionPtr = auto (*)() -> void;
+using FunctionPtr = auto(*)() -> void;
 }
 
 /**

--- a/include/interrupt/config/fwd.hpp
+++ b/include/interrupt/config/fwd.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
 namespace interrupt {
-using EnableActionType = auto (*)() -> void;
+using EnableActionType = auto(*)() -> void;
 } // namespace interrupt

--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -102,9 +102,9 @@ struct dynamic_controller {
             fields, hana::make_tuple(), [](auto regs, auto field) {
                 constexpr bool reg_has_been_seen_already =
                     hana::unpack(decltype(regs){}, [=](auto... regs_pack) {
-                        return (std::is_same_v<typename decltype(
-                                                   field)::RegisterType,
-                                               decltype(regs_pack)> ||
+                        return (std::is_same_v<
+                                    typename decltype(field)::RegisterType,
+                                    decltype(regs_pack)> ||
                                 ...);
                     });
 

--- a/include/interrupt/fwd.hpp
+++ b/include/interrupt/fwd.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
 namespace interrupt {
-using FunctionPtr = auto (*)() -> void;
+using FunctionPtr = auto(*)() -> void;
 } // namespace interrupt

--- a/include/interrupt/manager_interface.hpp
+++ b/include/interrupt/manager_interface.hpp
@@ -4,6 +4,7 @@ namespace interrupt {
 /**
  * Type-erased interface to the interrupt manager.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
 class manager_interface {
   public:
     virtual void init() const = 0;

--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -32,10 +32,10 @@ template <typename BaseMsgT, typename ExtraCallbackArgsListT,
 struct callback_impl;
 
 template <typename CallableT> struct func_args {
-    using msg_type = typename func_args<decltype(
-        &remove_cvref_t<CallableT>::operator())>::msg_type;
-    using type = typename func_args<decltype(
-        &remove_cvref_t<CallableT>::operator())>::type;
+    using msg_type = typename func_args<
+        decltype(&remove_cvref_t<CallableT>::operator())>::msg_type;
+    using type = typename func_args<
+        decltype(&remove_cvref_t<CallableT>::operator())>::type;
 };
 
 template <typename DataIterableT, typename... ArgTs>

--- a/include/sc/format.hpp
+++ b/include/sc/format.hpp
@@ -36,8 +36,8 @@ struct repl_field_iter {
             end++;
         }
 
-        return std::string_view(
-            i, static_cast<std::string_view::size_type>(std::distance(i, end)));
+        return {
+            i, static_cast<std::string_view::size_type>(std::distance(i, end))};
     }
 
     [[nodiscard]] constexpr auto operator==(repl_field_iter other) const
@@ -244,8 +244,8 @@ template <typename CharT, CharT... chars, typename... ArgTs>
                     if constexpr (is_integral_v<decltype(arg)>) {
                         return cib::tuple_cat(cib::make_tuple(to_integral(arg)),
                                               state);
-                    } else if constexpr (is_lazy_format_string_v<decltype(
-                                             arg)>) {
+                    } else if constexpr (is_lazy_format_string_v<
+                                             decltype(arg)>) {
                         return cib::tuple_cat(arg.args, state);
                     } else {
                         return state;

--- a/include/seq/step.hpp
+++ b/include/seq/step.hpp
@@ -9,8 +9,8 @@
 namespace seq {
 enum class status { NOT_DONE = 0, DONE = 1 };
 
-using func_ptr = auto (*)() -> status;
-using log_func_ptr = auto (*)() -> void;
+using func_ptr = auto(*)() -> status;
+using log_func_ptr = auto(*)() -> void;
 
 class step_base {
   private:
@@ -28,14 +28,15 @@ class step_base {
     template <typename Name>
     constexpr step_base([[maybe_unused]] Name name, func_ptr forward_ptr,
                         func_ptr backward_ptr)
-        : _forward_ptr{forward_ptr}, _backward_ptr{backward_ptr}, log_name {
-        []() { CIB_TRACE("seq.step({})", Name{}); }
-    }
+        : _forward_ptr{forward_ptr}, _backward_ptr{backward_ptr},
+          log_name{[]() { CIB_TRACE("seq.step({})", Name{}); }}
 
 #if defined(__GNUC__) && __GNUC__ < 12
-    , hash { name.hash() }
+          ,
+          hash{name.hash()}
 #endif
-    {}
+    {
+    }
 
     constexpr step_base() = default;
 

--- a/test/sc/format.cpp
+++ b/test/sc/format.cpp
@@ -222,7 +222,9 @@ TEST_CASE("lazy_runtime_integral_values", "[sc::format]") {
 }
 
 namespace ns {
-template <typename T> struct IntegerLike { T value; };
+template <typename T> struct IntegerLike {
+    T value;
+};
 template <typename T> IntegerLike(T) -> IntegerLike<T>;
 
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>

--- a/test/sc/string_constant.cpp
+++ b/test/sc/string_constant.cpp
@@ -1,7 +1,9 @@
 #include <sc/string_constant.hpp>
 
 namespace sc {
-template <auto... chars> struct Log { constexpr static bool v = false; };
+template <auto... chars> struct Log {
+    constexpr static bool v = false;
+};
 
 template <char... chars> void log(sc::string_constant<char, chars...>) {
     static_assert(Log<chars...>::v);


### PR DESCRIPTION
- clang/GCC 9 and 10 are now considered "older compilers" and only build C++17
- updated clang-format has reformatted some files.
- updated clang-tidy: tweaked Vector.hpp to use `std::array<...>::data`.
- updated clang-tidy: nolint directives for abstract base classes that don't define a virtual destructor (`flow::interface` and `interrupt::manager_interface`).