### PR TITLE
:bug: Workaround for clang ICE

### DIFF
--- a/include/cib/top.hpp
+++ b/include/cib/top.hpp
@@ -65,6 +65,8 @@ template <typename ProjectConfig> class top {
     }
 
     template <typename ServiceMeta>
-    static constexpr auto &service = my_nexus.template service<ServiceMeta>;
+    static constexpr auto get_service() -> auto & {
+        return my_nexus.template service<ServiceMeta>;
+    }
 };
 } // namespace cib


### PR DESCRIPTION
Providing access to services through a variable template causes the clang frontend to ICE. Providing access through a function is apparently fine.