### PR TITLE
:recycle: Refactor `ConcurrencyPolicy`

### DIFF
--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 #include <cstddef>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
Nothing currently uses the overload that takes a predicate; it's easier if the predicate (if any) is the second argument.