### PR TITLE
Show summary for performance test action output

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -28,8 +28,18 @@ jobs:
         id: build_step
         shell: bash
         run: |
-          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -t compilation_benchmark | tee ${{github.workspace}}/build/compilation_output.log
-          echo "compile_benchmark_time="`grep "Clang front-end timer" ${{github.workspace}}/build/compilation_output.log | awk '{print $1}'` >> $GITHUB_OUTPUT
+          # interesting summary data on stderr
+          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -t compilation_benchmark 2>&1 | tee ${{github.workspace}}/build/compilation_output.log
+          FRONT_END_TIME=$(grep "Clang front-end timer" ${{github.workspace}}/build/compilation_output.log | awk '{print $1}')
+
+          # generate summary with expandable section
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "  <summary>Clang front-end: ${FRONT_END_TIME} seconds</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "  \`\`\`" >> $GITHUB_STEP_SUMMARY
+          cat ${{github.workspace}}/build/compilation_output.log >> $GITHUB_STEP_SUMMARY
+          echo "  \`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: 'Upload Compilation Trace'
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.vscode
 /toolchains
 CMakePresets.json
+# clion
+.idea/
+cmake-build-*


### PR DESCRIPTION
Create a set summary for the performance_test action which displays in the GitHub action screen.

Summarize the Clang front end time, and expand out to provide the compilation timing log.