### PR TITLE
C++20 cleanup to use `constexpr` STL algorithms

### DIFF
--- a/include/container/ConstexprMap.hpp
+++ b/include/container/ConstexprMap.hpp
@@ -60,7 +60,7 @@ class ConstexprMap {
      *
      * @return
      *      Index into storage where the corresponding entry is stored. If
-     *      the targetKey cannot be found, then -1 is returned.
+     *      the targetKey cannot be found, then std::nullopt is returned.
      */
     [[nodiscard]] constexpr auto find(KeyType targetKey) const
         -> std::optional<std::size_t> {
@@ -121,7 +121,9 @@ class ConstexprMap {
     /**
      * <b>Runtime complexity:</b> O(1)
      */
-    [[nodiscard]] constexpr auto end() -> Entry * { return &(storage[size]); }
+    [[nodiscard]] constexpr auto end() -> Entry * {
+        return std::begin(storage) + size;
+    }
 
     /**
      * <b>Runtime complexity:</b> O(1)
@@ -134,7 +136,7 @@ class ConstexprMap {
      * <b>Runtime complexity:</b> O(1)
      */
     [[nodiscard]] constexpr auto end() const -> Entry const * {
-        return &(storage[size]);
+        return std::cbegin(storage) + size;
     }
 
     /**

--- a/include/container/ConstexprMultiMap.hpp
+++ b/include/container/ConstexprMultiMap.hpp
@@ -23,12 +23,13 @@
  * quadratically, or O(n^2).
  *
  * Consider an appropriate Capacity for the ConstexprMultiMap. It will be
- * able to contain up to "Capacity" number of keys, and each key will be
- * able to contain up to "Capacity" number of values.
+ * able to contain up to "KeyCapacity" number of keys, and each key will be
+ * able to contain up to "ValueCapacity" number of values.
  *
  * @tparam KeyType
  * @tparam ValueType
  * @tparam KeyCapacity
+ * @tparam ValueCapacity
  */
 template <typename KeyType, typename ValueType, std::size_t KeyCapacity,
           std::size_t ValueCapacity = KeyCapacity>

--- a/include/container/Vector.hpp
+++ b/include/container/Vector.hpp
@@ -46,18 +46,20 @@ template <typename ValueType, size_t Capacity> class Vector {
 
     constexpr Vector() = default;
 
-    [[nodiscard]] constexpr auto begin() -> iterator { return storage.data(); }
+    [[nodiscard]] constexpr auto begin() -> iterator {
+        return std::begin(storage);
+    }
 
     [[nodiscard]] constexpr auto begin() const -> const_iterator {
-        return storage.data();
+        return std::cbegin(storage);
     }
 
     [[nodiscard]] constexpr auto end() -> iterator {
-        return &storage[currentSize];
+        return std::begin(storage) + currentSize;
     }
 
     [[nodiscard]] constexpr auto end() const -> const_iterator {
-        return &storage[currentSize];
+        return std::cbegin(storage) + currentSize;
     }
 
     [[nodiscard]] constexpr auto size() const -> std::size_t {

--- a/include/container/Vector.hpp
+++ b/include/container/Vector.hpp
@@ -2,6 +2,7 @@
 
 #include <log/log.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <initializer_list>
@@ -38,11 +39,7 @@ template <typename ValueType, size_t Capacity> class Vector {
                 "Initializer list size {} is bigger than vector capacity {}",
                 src.size(), sc::int_<Capacity>);
         } else {
-            auto i = std::size_t{};
-            for (auto element : src) {
-                storage[i++] = element;
-            }
-
+            std::copy(src.begin(), src.end(), storage.begin());
             currentSize = src.size();
         }
     }

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -56,12 +56,9 @@ class generic_builder {
      */
     static constexpr auto hasNoIncomingEdges(GraphType &graph, NodeType node)
         -> bool {
-        for (auto const &entry : graph) {
-            if (entry.value.contains(node)) {
-                return false;
-            }
-        }
-        return true;
+        return std::find_if(graph.begin(), graph.end(), [&](auto const &entry) {
+                   return entry.value.contains(node);
+               }) == graph.end();
     }
 
     [[nodiscard]] constexpr auto getNodesWithNoIncomingEdge() const

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -33,10 +33,7 @@ template <std::uint32_t MaxNumDWordsT> struct message_data {
 
     constexpr message_data(std::initializer_list<std::uint32_t> src)
         : num_dwords{static_cast<std::uint32_t>(src.size())} {
-        auto i = std::size_t{};
-        for (auto element : src) {
-            data[i++] = element;
-        }
+        std::copy(src.begin(), src.end(), data.begin());
     }
 
     [[nodiscard]] constexpr auto operator[](std::size_t index) const

--- a/include/sc/detail/string_meta.hpp
+++ b/include/sc/detail/string_meta.hpp
@@ -2,6 +2,7 @@
 
 #include <sc/fwd.hpp>
 
+#include <algorithm>
 #include <array>
 #include <string_view>
 #include <utility>
@@ -24,28 +25,15 @@ struct Replace {
     constexpr static StrT str{};
     constexpr static int size = thisStr.length() - count + str.length();
     constexpr static std::array<char_type, size> storage = []() {
-        // NOTE: use algorithms when moving to c++20
-
         std::array<char_type, size> buffer{};
         auto dst = buffer.begin();
 
         auto const first = thisStr.begin() + pos;
         auto const last = first + count;
 
-        // copy begin() until first
-        for (auto src = thisStr.begin(); src != first; src++, dst++) {
-            *dst = *src;
-        }
-
-        // copy str.begin() until str.end()
-        for (auto src = str.begin(); src != str.end(); src++, dst++) {
-            *dst = *src;
-        }
-
-        // copy last until end()
-        for (auto src = last; src != thisStr.end(); src++, dst++) {
-            *dst = *src;
-        }
+        dst = std::copy(thisStr.begin(), first, dst);
+        dst = std::copy(str.begin(), str.end(), dst);
+        std::copy(last, thisStr.end(), dst);
 
         return buffer;
     }();

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -6,6 +6,8 @@
 #include <seq/impl.hpp>
 #include <seq/step.hpp>
 
+#include <algorithm>
+
 namespace seq {
 template <typename NameT = void, std::size_t NodeCapacity = 64,
           std::size_t DependencyCapacity = 16>
@@ -32,14 +34,9 @@ class builder {
      */
     static constexpr auto hasNoIncomingEdges(GraphType &graph, step_base node)
         -> bool {
-        // std::find_if is not constexpr in c++17 :(
-        for (auto s : graph) {
-            if (s.value.contains(node)) {
-                return false;
-            }
-        }
-
-        return true;
+        return std::find_if(graph.begin(), graph.end(), [&](auto const &s) {
+                   return s.value.contains(node);
+               }) == graph.end();
     }
 
     [[nodiscard]] constexpr auto getNodesWithNoIncomingEdge() const


### PR DESCRIPTION
Update to use C++20 constexpr std algorithms

- update code tagged to be rewritten after updating to C++20.
- convert Vector to use C++20 algorithms
- convert message to use C++20 algorithms
- convert sc/format to C++20 algorithms

The change to `flow::generic_builder::hasNoIncomingEdges()` resulted in
a build failure in GCC, but success in Clang. This was tracked down to
the `begin()` and `end()` iterators some how resulting in a different
type in GCC. This then caused GCC's implementation to fail when it
attempted to subtract the iterators.

This was fixed by always using the `std::{c}begin()` method to generate
both the begin and end iterators. Other occurrences of the generation of
end iterators in a similar way were identified and corrected in
`Vector`.