### PR TITLE
:art: Automatically order qualifiers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,6 @@ IncludeCategories:
     Priority: 3
   - Regex: '<.*'
     Priority: 4
+
+QualifierAlignment: Custom
+QualifierOrder: ['constexpr', 'static', 'inline', 'type', 'const', 'volatile']

--- a/include/cib/detail/config_details.hpp
+++ b/include/cib/detail/config_details.hpp
@@ -14,7 +14,7 @@ constexpr static auto as_constant_v = std::integral_constant<
     std::remove_cv_t<std::remove_reference_t<decltype(Value)>>, Value>{};
 
 template <auto... Args> struct args {
-    static constexpr auto value = cib::make_tuple(as_constant_v<Args>...);
+    constexpr static auto value = cib::make_tuple(as_constant_v<Args>...);
 };
 
 template <typename ConfigArgs, typename... ConfigTs>

--- a/include/cib/detail/meta.hpp
+++ b/include/cib/detail/meta.hpp
@@ -24,7 +24,7 @@ constexpr static auto is_same_v =
  * parameter.
  */
 template <typename IntegralType, IntegralType... Indices, typename CallableType>
-constexpr inline static void
+constexpr static inline void
 for_each([[maybe_unused]] std::integer_sequence<IntegralType, Indices...> const
              &sequence,
          CallableType const &operation) {

--- a/include/cib/nexus.hpp
+++ b/include/cib/nexus.hpp
@@ -30,7 +30,7 @@ template <typename Config> struct nexus {
 #undef CIB_BUILD_SERVICE
 
     static void init() {
-        const auto service = []<typename T> {
+        auto const service = []<typename T> {
             auto &service_impl = this_t::service<T>;
             using service_impl_type =
                 std::remove_reference_t<decltype(service_impl)>;

--- a/include/cib/set.hpp
+++ b/include/cib/set.hpp
@@ -44,7 +44,7 @@ struct bin {
 };
 
 template <std::size_t N>
-[[nodiscard]] constexpr auto create_bins(const auto &tags) {
+[[nodiscard]] constexpr auto create_bins(auto const &tags) {
     std::array<bin, N> bins{};
     auto index = std::size_t{};
     auto offset = std::size_t{};

--- a/include/cib/top.hpp
+++ b/include/cib/top.hpp
@@ -65,7 +65,7 @@ template <typename ProjectConfig> class top {
     }
 
     template <typename ServiceMeta>
-    static constexpr auto get_service() -> auto & {
+    constexpr static auto get_service() -> auto & {
         return my_nexus.template service<ServiceMeta>;
     }
 };

--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -39,9 +39,9 @@ namespace cib {
 // - top-level types are aliases if alias CTAD is available
 
 template <std::size_t> struct index_constant;
-template <std::size_t I> static constexpr index_constant<I> *index{};
+template <std::size_t I> constexpr static index_constant<I> *index{};
 template <typename> struct tag_constant;
-template <typename T> static constexpr tag_constant<T> *tag{};
+template <typename T> constexpr static tag_constant<T> *tag{};
 
 namespace tuple_literals {
 template <char... Chars>
@@ -99,7 +99,7 @@ struct element<Index, T, Ts...> {
         return std::forward<T>(value);
     }
 
-    static constexpr auto ugly_Value(index_constant<Index> *) -> T;
+    constexpr static auto ugly_Value(index_constant<Index> *) -> T;
     constexpr auto ugly_Value_clvr() const & -> T const & { return value; }
     constexpr auto ugly_Value_lvr() & -> T & { return value; }
     constexpr auto ugly_Value_rvr() && -> T && {
@@ -124,7 +124,7 @@ struct element<Index, T, Ts...> {
 
 template <std::size_t Index, derivable T, typename... Ts>
 struct element<Index, T, Ts...> : T {
-    static constexpr auto ugly_Index = Index;
+    constexpr static auto ugly_Index = Index;
 
     [[nodiscard]] constexpr auto
     ugly_iGet_clvr(index_constant<Index> *) const &noexcept -> T const & {
@@ -158,7 +158,7 @@ struct element<Index, T, Ts...> : T {
         return std::move(*this);
     }
 
-    static constexpr auto ugly_Value(index_constant<Index> *) -> T;
+    constexpr static auto ugly_Value(index_constant<Index> *) -> T;
     constexpr auto ugly_Value_clvr() const & -> T const & { return *this; }
     constexpr auto ugly_Value_lvr() & -> T & { return *this; }
     constexpr auto ugly_Value_rvr() && -> T && { return std::move(*this); }
@@ -319,15 +319,15 @@ struct tuple_impl<std::index_sequence<Is...>, index_function_list<Fs...>, Ts...>
             .value;
     }
 
-    static constexpr auto size() -> std::size_t { return sizeof...(Ts); }
-    static constexpr auto ugly_Value(...) -> void;
+    constexpr static auto size() -> std::size_t { return sizeof...(Ts); }
+    constexpr static auto ugly_Value(...) -> void;
 
-    [[nodiscard]] static constexpr auto fill_inner_indices(index_pair *p)
+    [[nodiscard]] constexpr static auto fill_inner_indices(index_pair *p)
         -> index_pair * {
         ((p++->inner = Is), ...);
         return p;
     }
-    [[nodiscard]] static constexpr auto
+    [[nodiscard]] constexpr static auto
     fill_outer_indices(index_pair *p, [[maybe_unused]] std::size_t n)
         -> index_pair * {
         ((p++->outer = (static_cast<void>(Is), n)), ...);

--- a/include/container/Vector.hpp
+++ b/include/container/Vector.hpp
@@ -25,9 +25,9 @@ template <typename ValueType, size_t Capacity> class Vector {
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
     using reference = ValueType &;
-    using const_reference = const ValueType &;
+    using const_reference = ValueType const &;
     using pointer = ValueType *;
-    using const_pointer = const ValueType *;
+    using const_pointer = ValueType const *;
     using iterator = pointer;
     using const_iterator = const_pointer;
     using reverse_iterator = std::reverse_iterator<iterator>;
@@ -130,7 +130,7 @@ template <typename ValueType, size_t Capacity> class Vector {
     [[nodiscard]] friend constexpr auto operator+(Vector const &lhs,
                                                   Vector const &rhs) -> Vector {
         Vector result = lhs;
-        for (const auto &elem : rhs) {
+        for (auto const &elem : rhs) {
             result.push(elem);
         }
         return result;

--- a/include/container/queue.hpp
+++ b/include/container/queue.hpp
@@ -7,15 +7,15 @@
 #include <utility>
 
 struct unsafe_overflow_policy {
-    static constexpr auto check_push(auto...) {}
-    static constexpr auto check_pop(auto...) {}
+    constexpr static auto check_push(auto...) {}
+    constexpr static auto check_pop(auto...) {}
 };
 
 struct safe_overflow_policy {
-    static constexpr auto check_push(std::size_t size, std::size_t capacity) {
+    constexpr static auto check_push(std::size_t size, std::size_t capacity) {
         CIB_ASSERT(size < capacity);
     }
-    static constexpr auto check_pop(std::size_t size) { CIB_ASSERT(size > 0); }
+    constexpr static auto check_pop(std::size_t size) { CIB_ASSERT(size > 0); }
 };
 
 /**
@@ -36,7 +36,7 @@ class queue {
 
   public:
     [[nodiscard]] constexpr auto size() const -> std::size_t { return size_; }
-    [[nodiscard]] static constexpr auto capacity() -> std::size_t {
+    [[nodiscard]] constexpr static auto capacity() -> std::size_t {
         return Capacity;
     }
     [[nodiscard]] constexpr auto full() const -> bool {

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -54,7 +54,7 @@ class generic_builder {
      * @return
      *      True if the milestone has no incoming edges.
      */
-    static constexpr auto hasNoIncomingEdges(GraphType &graph, NodeType node)
+    constexpr static auto hasNoIncomingEdges(GraphType &graph, NodeType node)
         -> bool {
         return std::find_if(graph.begin(), graph.end(), [&](auto const &entry) {
                    return entry.value.contains(node);
@@ -233,7 +233,7 @@ class generic_builder {
     }
 
     template <typename BuilderValue>
-    [[nodiscard]] static constexpr auto build() -> FunctionPtr {
+    [[nodiscard]] constexpr static auto build() -> FunctionPtr {
         return runImpl<BuilderValue>;
     }
 };

--- a/include/interrupt/builder/irq_builder.hpp
+++ b/include/interrupt/builder/irq_builder.hpp
@@ -37,7 +37,7 @@ template <typename ConfigT> struct irq_builder {
      *      See flow::Builder<>.add()
      */
     template <typename IrqType, typename T>
-    void constexpr add(T const &flow_description) {
+    constexpr void add(T const &flow_description) {
         if constexpr (std::is_same_v<IrqCallbackType, IrqType>) {
             interrupt_service_routine.add(flow_description);
         }
@@ -47,8 +47,8 @@ template <typename ConfigT> struct irq_builder {
      * @return irq::impl specialization optimized for size and runtime.
      */
     template <typename BuilderValue>
-    [[nodiscard]] auto constexpr build() const {
-        auto constexpr run_flow = [] {
+    [[nodiscard]] constexpr auto build() const {
+        constexpr auto run_flow = [] {
             auto constexpr flow_builder =
                 BuilderValue::value.interrupt_service_routine;
             auto constexpr flow_size = flow_builder.size();
@@ -57,9 +57,9 @@ template <typename ConfigT> struct irq_builder {
             flow();
         };
 
-        auto constexpr flow_builder =
+        constexpr auto flow_builder =
             BuilderValue::value.interrupt_service_routine;
-        auto constexpr flow_size = flow_builder.size();
+        constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
             irq_impl<ConfigT,
                      flow::impl<typename IrqCallbackType::Name, flow_size>>(

--- a/include/interrupt/builder/shared_irq_builder.hpp
+++ b/include/interrupt/builder/shared_irq_builder.hpp
@@ -50,7 +50,7 @@ template <typename ConfigT> class shared_irq_builder {
     std::remove_cv_t<decltype(irqs_type)> irqs;
 
     template <typename IrqType, typename T>
-    void constexpr add(T const &flow_description) {
+    constexpr void add(T const &flow_description) {
         cib::for_each(
             [&](auto &irq) { irq.template add<IrqType>(flow_description); },
             irqs);
@@ -60,7 +60,7 @@ template <typename ConfigT> class shared_irq_builder {
      * @return shared_irq::impl specialization optimized for size and runtime.
      */
     template <typename BuilderValue>
-    [[nodiscard]] auto constexpr build() const {
+    [[nodiscard]] constexpr auto build() const {
         using irqs_t = decltype(BuilderValue::value.irqs);
         auto const sub_irq_impls = built_irqs<BuilderValue>(
             std::make_index_sequence<irqs_t::size()>{});

--- a/include/interrupt/builder/shared_sub_irq_builder.hpp
+++ b/include/interrupt/builder/shared_sub_irq_builder.hpp
@@ -40,7 +40,7 @@ template <typename ConfigT> class shared_sub_irq_builder {
     std::remove_cv_t<decltype(irqs_type)> irqs;
 
     template <typename IrqType, typename T>
-    void constexpr add(T const &flow_description) {
+    constexpr void add(T const &flow_description) {
         cib::for_each(
             [&](auto &irq) { irq.template add<IrqType>(flow_description); },
             irqs);
@@ -50,7 +50,7 @@ template <typename ConfigT> class shared_sub_irq_builder {
      * @return shared_irq::impl specialization optimized for size and runtime.
      */
     template <typename BuilderValue>
-    [[nodiscard]] auto constexpr build() const {
+    [[nodiscard]] constexpr auto build() const {
         using sub_irqs_t = decltype(BuilderValue::value.irqs);
         auto const sub_irq_impls = built_irqs<BuilderValue>(
             std::make_index_sequence<sub_irqs_t::size()>{});

--- a/include/interrupt/builder/sub_irq_builder.hpp
+++ b/include/interrupt/builder/sub_irq_builder.hpp
@@ -30,7 +30,7 @@ template <typename ConfigT> struct sub_irq_builder {
      *      See flow::Builder<>.add()
      */
     template <typename IrqType, typename T>
-    void constexpr add(T const &flow_description) {
+    constexpr void add(T const &flow_description) {
         if constexpr (std::is_same_v<IrqCallbackType, IrqType>) {
             interrupt_service_routine.add(flow_description);
         }
@@ -40,8 +40,8 @@ template <typename ConfigT> struct sub_irq_builder {
      * @return sub_irq::impl specialization optimized for size and runtime.
      */
     template <typename BuilderValue>
-    [[nodiscard]] auto constexpr build() const {
-        auto constexpr run_flow = [] {
+    [[nodiscard]] constexpr auto build() const {
+        constexpr auto run_flow = [] {
             auto constexpr flow_builder =
                 BuilderValue::value.interrupt_service_routine;
             auto constexpr flow_size = flow_builder.size();
@@ -50,9 +50,9 @@ template <typename ConfigT> struct sub_irq_builder {
             flow();
         };
 
-        auto constexpr flow_builder =
+        constexpr auto flow_builder =
             BuilderValue::value.interrupt_service_routine;
-        auto constexpr flow_size = flow_builder.size();
+        constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
             sub_irq_impl<ConfigT,
                          flow::impl<typename IrqCallbackType::Name, flow_size>>(

--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -11,7 +11,7 @@ namespace interrupt {
 enum class resource_status { OFF = 0, ON = 1 };
 
 template <typename Irq>
-static constexpr auto has_enable_field = requires { Irq::enable_field; };
+constexpr static auto has_enable_field = requires { Irq::enable_field; };
 
 template <typename RootT, typename ConcurrencyPolicyT>
 struct dynamic_controller {

--- a/include/interrupt/impl/irq_impl.hpp
+++ b/include/interrupt/impl/irq_impl.hpp
@@ -30,7 +30,7 @@ template <typename ConfigT, typename FlowTypeT> struct irq_impl {
      * This is used to optimize compiled size and runtime performance. Unused
      * Irqs should not consume any resources.
      */
-    static bool constexpr active = FlowTypeT::active;
+    constexpr static bool active = FlowTypeT::active;
 
   private:
     FunctionPtr interrupt_service_routine;

--- a/include/interrupt/impl/shared_irq_impl.hpp
+++ b/include/interrupt/impl/shared_irq_impl.hpp
@@ -23,7 +23,7 @@ template <typename ConfigT, typename... SubIrqImpls> struct shared_irq_impl {
      * This is used to optimize compiled size and runtime performance. Unused
      * irqs should not consume any resources.
      */
-    static bool constexpr active = (SubIrqImpls::active or ...);
+    constexpr static bool active = (SubIrqImpls::active or ...);
 
   private:
     cib::tuple<SubIrqImpls...> sub_irq_impls;

--- a/include/interrupt/impl/shared_sub_irq_impl.hpp
+++ b/include/interrupt/impl/shared_sub_irq_impl.hpp
@@ -17,7 +17,7 @@ struct shared_sub_irq_impl {
      * This is used to optimize compiled size and runtime performance. Unused
      * irqs should not consume any resources.
      */
-    static bool constexpr active = (SubIrqImpls::active or ...);
+    constexpr static bool active = (SubIrqImpls::active or ...);
 
   private:
     template <typename InterruptHal, bool en>

--- a/include/interrupt/impl/sub_irq_impl.hpp
+++ b/include/interrupt/impl/sub_irq_impl.hpp
@@ -22,7 +22,7 @@ template <typename ConfigT, typename FlowTypeT> struct sub_irq_impl {
      * This is used to optimize compiled size and runtime performance. Unused
      * SubIrqs should not consume any resources.
      */
-    static bool constexpr active = FlowTypeT::active;
+    constexpr static bool active = FlowTypeT::active;
 
   private:
     constexpr static auto enable_field = ConfigT::enable_field;

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -88,7 +88,7 @@ template <typename RootT, typename ConcurrencyPolicyT> class manager {
      *      See flow::Builder<>.add()
      */
     template <typename... IrqTypes, typename... Ts>
-    auto constexpr add(binding_t<IrqTypes, Ts> const &...bindings) {
+    constexpr auto add(binding_t<IrqTypes, Ts> const &...bindings) {
         cib::for_each(
             [&](auto &irq) {
                 (irq.template add<IrqTypes>(bindings.flow_description), ...);
@@ -109,7 +109,7 @@ template <typename RootT, typename ConcurrencyPolicyT> class manager {
      * @return The optimized Manager::impl to be used at runtime.
      */
     template <typename BuilderValue>
-    [[nodiscard]] static auto constexpr build() {
+    [[nodiscard]] constexpr static auto build() {
         using irqs_t = decltype(BuilderValue::value.irqs);
         auto const irq_impls = built_irqs<BuilderValue>(
             std::make_index_sequence<irqs_t::size()>{});

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -29,7 +29,7 @@ template <typename TDestinations> struct log_handler {
     template <logging::level L, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
     auto log(FilenameStringType, LineNumberType, MsgType const &msg) -> void {
-        const auto currentTime =
+        auto const currentTime =
             std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::steady_clock::now() - start_time)
                 .count();
@@ -47,7 +47,7 @@ template <typename TDestinations> struct log_handler {
     }
 
   private:
-    inline static const auto start_time = std::chrono::steady_clock::now();
+    static inline auto const start_time = std::chrono::steady_clock::now();
     TDestinations dests;
 };
 

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -14,7 +14,7 @@ struct config {
         constexpr auto log(Ts &&...) const noexcept -> void {}
     } logger;
 
-    static constexpr auto terminate() noexcept -> void {}
+    constexpr static auto terminate() noexcept -> void {}
 };
 } // namespace null
 

--- a/include/msg/disjoint_field.hpp
+++ b/include/msg/disjoint_field.hpp
@@ -16,11 +16,11 @@ template <typename NameTypeT, typename FieldsT, typename T = std::uint32_t,
           typename MatchRequirementsType = match::always_t<true>>
 class disjoint_field {
   private:
-    static constexpr FieldsT fields{};
+    constexpr static FieldsT fields{};
     T value{};
 
   public:
-    static constexpr size_t size = fields.fold_right(
+    constexpr static size_t size = fields.fold_right(
         0, [](auto f, size_t totalSize) { return totalSize + f.size; });
 
     using FieldId = disjoint_field<NameTypeT, FieldsT, T>;
@@ -29,34 +29,34 @@ class disjoint_field {
 
     using NameType = NameTypeT;
 
-    template <typename MsgType> static constexpr void fits_inside(MsgType msg) {
+    template <typename MsgType> constexpr static void fits_inside(MsgType msg) {
         cib::for_each([&](auto field) { field.fits_inside(msg); }, fields);
     }
 
-    static constexpr NameType name{};
-    static constexpr MatchRequirementsType match_requirements{};
+    constexpr static NameType name{};
+    constexpr static MatchRequirementsType match_requirements{};
 
     template <T expected_value>
-    static constexpr msg::equal_to_t<This, T, expected_value> equal_to{};
+    constexpr static msg::equal_to_t<This, T, expected_value> equal_to{};
 
-    static constexpr msg::equal_to_t<This, T, DefaultValue> match_default{};
+    constexpr static msg::equal_to_t<This, T, DefaultValue> match_default{};
 
     template <T... expected_values>
-    static constexpr msg::in_t<This, T, expected_values...> in{};
+    constexpr static msg::in_t<This, T, expected_values...> in{};
 
     template <T expected_value>
-    static constexpr msg::greater_than_t<This, T, expected_value>
+    constexpr static msg::greater_than_t<This, T, expected_value>
         greater_than{};
 
     template <T expected_value>
-    static constexpr msg::greater_than_or_equal_to_t<This, T, expected_value>
+    constexpr static msg::greater_than_or_equal_to_t<This, T, expected_value>
         greater_than_or_equal_to{};
 
     template <T expected_value>
-    static constexpr msg::less_than_t<This, T, expected_value> less_than{};
+    constexpr static msg::less_than_t<This, T, expected_value> less_than{};
 
     template <T expected_value>
-    static constexpr msg::less_than_or_equal_to_t<This, T, expected_value>
+    constexpr static msg::less_than_or_equal_to_t<This, T, expected_value>
         less_than_or_equal_to{};
 
     template <T NewDefaultValue>
@@ -84,7 +84,7 @@ class disjoint_field {
     }
 
     template <typename DataType>
-    [[nodiscard]] static constexpr auto extract(DataType const &data) -> T {
+    [[nodiscard]] constexpr static auto extract(DataType const &data) -> T {
         auto const raw =
             fields.fold_left(static_cast<std::uint64_t>(0),
                              [&](std::uint64_t extracted, auto f) {

--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -26,7 +26,7 @@ class field {
     static_assert(LsbT <= MsbT, "msb needs to be lower than or equal to lsb");
     static_assert(LsbT <= 31, "lsb needs to be lower than or equal to 31");
 
-    static constexpr size_t size = (MsbT - LsbT) + 1;
+    constexpr static size_t size = (MsbT - LsbT) + 1;
     static_assert(size <= 64, "field must be 64 bits or smaller");
 
     using FieldId = field<NameTypeT, DWordIndexT, MsbT, LsbT, T>;
@@ -34,15 +34,15 @@ class field {
                        MatchRequirementsType>;
     using ValueType = T;
 
-    template <typename MsgType> static constexpr void fits_inside(MsgType) {
+    template <typename MsgType> constexpr static void fits_inside(MsgType) {
         static_assert(DWordIndex < MsgType::NumDWords);
     }
 
     using NameType = NameTypeT;
-    static constexpr auto DWordIndex = DWordIndexT;
+    constexpr static auto DWordIndex = DWordIndexT;
 
-    static constexpr NameType name{};
-    static constexpr uint64_t bit_mask = [] {
+    constexpr static NameType name{};
+    constexpr static uint64_t bit_mask = [] {
         if constexpr (size == 64) {
             return 0xFFFFFFFFFFFFFFFFUL;
         } else {
@@ -51,31 +51,31 @@ class field {
         }
     }();
 
-    static constexpr uint64_t field_mask = bit_mask << LsbT;
+    constexpr static uint64_t field_mask = bit_mask << LsbT;
 
-    static constexpr MatchRequirementsType match_requirements{};
+    constexpr static MatchRequirementsType match_requirements{};
 
     template <T expected_value>
-    static constexpr msg::equal_to_t<This, T, expected_value> equal_to{};
+    constexpr static msg::equal_to_t<This, T, expected_value> equal_to{};
 
-    static constexpr msg::equal_to_t<This, T, DefaultValue> match_default{};
+    constexpr static msg::equal_to_t<This, T, DefaultValue> match_default{};
 
     template <T... expected_values>
-    static constexpr msg::in_t<This, T, expected_values...> in{};
+    constexpr static msg::in_t<This, T, expected_values...> in{};
 
     template <T expected_value>
-    static constexpr msg::greater_than_t<This, T, expected_value>
+    constexpr static msg::greater_than_t<This, T, expected_value>
         greater_than{};
 
     template <T expected_value>
-    static constexpr msg::greater_than_or_equal_to_t<This, T, expected_value>
+    constexpr static msg::greater_than_or_equal_to_t<This, T, expected_value>
         greater_than_or_equal_to{};
 
     template <T expected_value>
-    static constexpr msg::less_than_t<This, T, expected_value> less_than{};
+    constexpr static msg::less_than_t<This, T, expected_value> less_than{};
 
     template <T expected_value>
-    static constexpr msg::less_than_or_equal_to_t<This, T, expected_value>
+    constexpr static msg::less_than_or_equal_to_t<This, T, expected_value>
         less_than_or_equal_to{};
 
     template <T NewGreaterValue>
@@ -115,7 +115,7 @@ class field {
     constexpr field() = default;
 
     template <typename DataType>
-    [[nodiscard]] static constexpr auto extract(DataType const &data) -> T {
+    [[nodiscard]] constexpr static auto extract(DataType const &data) -> T {
         std::uint32_t const lower = data[DWordIndex] >> LsbT;
 
         std::uint64_t const mid = [&] {

--- a/include/msg/field_matchers.hpp
+++ b/include/msg/field_matchers.hpp
@@ -43,7 +43,7 @@ template <typename FieldType, typename T, T expected_value> struct equal_to_t {
 
 template <typename FieldType, typename T, T... expected_values> struct in_t {
   private:
-    template <auto Value> static constexpr auto format_value() {
+    template <auto Value> constexpr static auto format_value() {
         if constexpr (std::is_integral_v<decltype(Value)>) {
             return format("0x{:x}"_sc, Value);
         } else {
@@ -52,10 +52,10 @@ template <typename FieldType, typename T, T... expected_values> struct in_t {
         }
     }
 
-    static constexpr auto expected_value_strings_tuple =
+    constexpr static auto expected_value_strings_tuple =
         cib::make_tuple(format_value<expected_values>()...);
 
-    static constexpr auto expected_values_string =
+    constexpr static auto expected_values_string =
         expected_value_strings_tuple.fold_right(
             ""_sc, [](auto lhs, auto rhs) { return lhs + ", "_sc + rhs; });
 

--- a/include/msg/handler_builder.hpp
+++ b/include/msg/handler_builder.hpp
@@ -25,7 +25,7 @@ struct handler_builder {
                                ExtraCallbackArgsT...>{new_callbacks};
     }
 
-    template <typename BuilderValue> static constexpr auto build() {
+    template <typename BuilderValue> constexpr static auto build() {
         return handler<CallbacksT, BaseMsgT, ExtraCallbackArgsT...>{
             BuilderValue::value.callbacks};
     }

--- a/include/msg/match.hpp
+++ b/include/msg/match.hpp
@@ -10,7 +10,7 @@
 namespace match {
 template <typename NameTypeT, typename MatcherTypeT, typename ActionTypeT>
 struct event_handler {
-    static constexpr bool is_default_handler = false;
+    constexpr static bool is_default_handler = false;
     NameTypeT name;
     MatcherTypeT matcher;
     ActionTypeT action;
@@ -24,7 +24,7 @@ constexpr static auto handle(NameType const &name, MatcherType const &matcher,
 }
 
 template <typename ActionTypeT> struct default_event_handler {
-    static constexpr bool is_default_handler = true;
+    constexpr static bool is_default_handler = true;
     ActionTypeT action;
 };
 
@@ -37,7 +37,7 @@ constexpr static auto otherwise(ActionType const &action)
 template <typename NameType, typename EventType, typename... HandlerTypes>
 constexpr static void process(NameType const &name, EventType const &event,
                               HandlerTypes const &...handlers) {
-    const auto handlers_tuple = cib::make_tuple(handlers...);
+    auto const handlers_tuple = cib::make_tuple(handlers...);
 
     bool event_handled = false;
 
@@ -68,14 +68,14 @@ constexpr static void process(NameType const &name, EventType const &event,
                 },
                 handlers_tuple);
         } else {
-            const auto mismatch_descriptions = cib::transform(
+            auto const mismatch_descriptions = cib::transform(
                 [&](auto handler) {
                     return format("    {} - F:({})\n"_sc, handler.name,
                                   handler.matcher.describe_match(event));
                 },
                 handlers_tuple);
 
-            const auto mismatch_description = mismatch_descriptions.join(
+            auto const mismatch_description = mismatch_descriptions.join(
                 [](auto lhs, auto rhs) { return lhs + rhs; });
 
             CIB_ERROR("{} - Received event that does not match any known "
@@ -109,12 +109,12 @@ template <bool value> constexpr always_t<value> always{};
 
 namespace detail {
 struct any_op : std::logical_or<> {
-    static constexpr auto text = " || "_sc;
-    static constexpr auto unit = false;
+    constexpr static auto text = " || "_sc;
+    constexpr static auto unit = false;
 };
 struct all_op : std::logical_and<> {
-    static constexpr auto text = " && "_sc;
-    static constexpr auto unit = true;
+    constexpr static auto text = " && "_sc;
+    constexpr static auto unit = true;
 };
 
 template <typename TOp, typename... MatcherTypes> struct logical_matcher {
@@ -131,7 +131,7 @@ template <typename TOp, typename... MatcherTypes> struct logical_matcher {
     }
 
     [[nodiscard]] constexpr auto describe() const {
-        const auto matcher_descriptions = cib::transform(
+        auto const matcher_descriptions = cib::transform(
             [](auto m) { return "("_sc + m.describe() + ")"_sc; }, matchers);
         return matcher_descriptions.join(
             [](auto lhs, auto rhs) { return lhs + TOp::text + rhs; });
@@ -139,7 +139,7 @@ template <typename TOp, typename... MatcherTypes> struct logical_matcher {
 
     template <typename EventType>
     [[nodiscard]] constexpr auto describe_match(EventType const &event) const {
-        const auto matcher_descriptions = cib::transform(
+        auto const matcher_descriptions = cib::transform(
             [&](auto m) {
                 return format("{:c}:({})"_sc, m(event) ? 'T' : 'F',
                               m.describe_match(event));
@@ -223,7 +223,7 @@ template <typename MatcherType>
 
 template <typename EventType, typename DescType, typename PredType>
 struct simple_matcher_t {
-    static constexpr DescType description{};
+    constexpr static DescType description{};
     PredType predicate;
 
     [[nodiscard]] constexpr auto operator()(EventType const &event) const
@@ -244,7 +244,7 @@ struct simple_matcher_t {
 
 template <typename DescType, typename PredType>
 struct simple_matcher_t<void, DescType, PredType> {
-    static constexpr DescType description{};
+    constexpr static DescType description{};
     PredType predicate;
 
     template <typename... Ts>

--- a/include/sc/detail/format_spec.hpp
+++ b/include/sc/detail/format_spec.hpp
@@ -23,23 +23,23 @@ struct fast_format_spec {
     char type{};
 
     template <typename T>
-    static constexpr auto is_in_range(T value, T lower, T upper) -> bool {
+    constexpr static auto is_in_range(T value, T lower, T upper) -> bool {
         return value >= lower && value <= upper;
     }
 
-    static constexpr auto is_alpha(char value) -> bool {
+    constexpr static auto is_alpha(char value) -> bool {
         return is_in_range(value, 'A', 'Z') || is_in_range(value, 'a', 'z');
     }
 
-    static constexpr auto is_digit(char value) -> bool {
+    constexpr static auto is_digit(char value) -> bool {
         return is_in_range(value, '0', '9');
     }
 
-    static constexpr auto is_id_start(char value) -> bool {
+    constexpr static auto is_id_start(char value) -> bool {
         return is_alpha(value) || value == '_';
     }
 
-    static constexpr auto is_id_continue(char value) -> bool {
+    constexpr static auto is_id_continue(char value) -> bool {
         return is_id_start(value) || is_digit(value);
     }
 

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -32,7 +32,7 @@ class builder {
      * @return
      *      True if the step has no incoming edges.
      */
-    static constexpr auto hasNoIncomingEdges(GraphType &graph, step_base node)
+    constexpr static auto hasNoIncomingEdges(GraphType &graph, step_base node)
         -> bool {
         return std::find_if(graph.begin(), graph.end(), [&](auto const &s) {
                    return s.value.contains(node);
@@ -207,7 +207,7 @@ class builder {
     }
 
     template <typename BuilderValue>
-    [[nodiscard]] static constexpr auto build() -> func_ptr {
+    [[nodiscard]] constexpr static auto build() -> func_ptr {
         return runImpl<BuilderValue>;
     }
 };

--- a/include/seq/impl.hpp
+++ b/include/seq/impl.hpp
@@ -67,7 +67,7 @@ template <std::size_t NumSteps> struct impl {
     }
 
     template <direction dir>
-    [[nodiscard]] static constexpr auto opposite() -> direction {
+    [[nodiscard]] constexpr static auto opposite() -> direction {
         if constexpr (dir == direction::FORWARD) {
             return direction::BACKWARD;
         } else {
@@ -107,8 +107,8 @@ template <> struct impl<0u> {
     constexpr impl() = default;
     constexpr impl(step_base const *, build_status) noexcept {}
 
-    static constexpr auto forward() -> status { return status::DONE; }
-    static constexpr auto backward() -> status { return status::DONE; }
+    constexpr static auto forward() -> status { return status::DONE; }
+    constexpr static auto backward() -> status { return status::DONE; }
 };
 
 } // namespace seq

--- a/test/cib/callback.cpp
+++ b/test/cib/callback.cpp
@@ -61,7 +61,7 @@ struct CallbackNoArgsWithMultipleExtensions {
 
     static void extension_one() { is_callback_invoked<1> = true; }
 
-    static constexpr auto extension_two = []() {
+    constexpr static auto extension_two = []() {
         is_callback_invoked<2> = true;
     };
 
@@ -122,7 +122,7 @@ struct CallbackWithArgsWithMultipleExtensions {
         callback_args<1, int, bool> = cib::make_tuple(a, b);
     }
 
-    static constexpr auto extension_two = [](int a, bool b) {
+    constexpr static auto extension_two = [](int a, bool b) {
         is_callback_invoked<2> = true;
         callback_args<2, int, bool> = cib::make_tuple(a, b);
     };

--- a/test/cib/detail/type_pack_element.cpp
+++ b/test/cib/detail/type_pack_element.cpp
@@ -20,9 +20,9 @@ TEST_CASE("type pack element") {
         std::is_same_v<void,
                        cib::detail::type_pack_element<2, void, void, void>>);
     static_assert(
-        std::is_same_v<const int &,
-                       cib::detail::type_pack_element<0, const int &, void *>>);
+        std::is_same_v<int const &,
+                       cib::detail::type_pack_element<0, int const &, void *>>);
     static_assert(
         std::is_same_v<void *,
-                       cib::detail::type_pack_element<1, const int &, void *>>);
+                       cib::detail::type_pack_element<1, int const &, void *>>);
 }

--- a/test/cib/tuple.cpp
+++ b/test/cib/tuple.cpp
@@ -43,7 +43,7 @@ TEST_CASE("multi element tuple", "[tuple]") {
 }
 
 TEST_CASE("constexpr tuple of references", "[tuple]") {
-    static constexpr int x = 1;
+    constexpr static int x = 1;
     constexpr auto t = cib::tuple<int const &>{x};
     using T = std::remove_const_t<decltype(t)>;
     static_assert(cib::tuple_size_v<T> == 1);

--- a/test/cib/tuple_algorithms.cpp
+++ b/test/cib/tuple_algorithms.cpp
@@ -27,7 +27,7 @@ TEST_CASE("n-ary transform", "[tuple_algorithms]") {
 
 TEST_CASE("rvalue transform", "[tuple_algorithms]") {
     auto t = cib::tuple{1, 2, 3};
-    const auto u = cib::transform([](int &&x) { return x + 1; }, std::move(t));
+    auto const u = cib::transform([](int &&x) { return x + 1; }, std::move(t));
     CHECK(u == cib::tuple{2, 3, 4});
 }
 
@@ -78,19 +78,19 @@ TEST_CASE("join", "[tuple_algorithms]") {
 
 TEST_CASE("for_each", "[tuple_algorithms]") {
     {
-        const auto t = cib::tuple{};
+        auto const t = cib::tuple{};
         auto sum = 0;
         cib::for_each([&](auto x, auto y) { sum += x + y; }, t, t);
         CHECK(sum == 0);
     }
     {
-        const auto t = cib::tuple{1, 2, 3};
+        auto const t = cib::tuple{1, 2, 3};
         auto sum = 0;
         cib::for_each([&](auto x, auto y) { sum += x + y; }, t, t);
         CHECK(sum == 12);
     }
     {
-        const auto t = cib::tuple{1};
+        auto const t = cib::tuple{1};
         auto sum = 0;
         cib::for_each([&](auto x, auto &&y) { sum += x + y.value; }, t,
                       cib::tuple{move_only{2}});
@@ -248,7 +248,7 @@ TEST_CASE("fold_right (heterogeneous types in tuple)", "[tuple_algorithms]") {
 }
 
 template <typename T> struct is_even {
-    static constexpr auto value = T::value % 2 == 0;
+    constexpr static auto value = T::value % 2 == 0;
 };
 
 TEST_CASE("filter", "[tuple_algorithms]") {

--- a/test/container/ConstexprMap.cpp
+++ b/test/container/ConstexprMap.cpp
@@ -31,7 +31,7 @@ TEST_CASE("ContainsAndGet", "[constexpr_map]") {
 }
 
 TEST_CASE("ConstGet", "[constexpr_map]") {
-    const ConstexprMap<int, int, 64> t = [] {
+    ConstexprMap<int, int, 64> const t = [] {
         ConstexprMap<int, int, 64> m;
         m.put(10, 50);
         m.put(11, 100);

--- a/test/container/Vector.cpp
+++ b/test/container/Vector.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 TEST_CASE("EmptyVector", "[vector]") {
-    const Vector<uint32_t, 3> vector({});
+    Vector<uint32_t, 3> const vector({});
     CHECK(0u == vector.size());
     CHECK(3u == vector.getCapacity());
 }
@@ -45,7 +45,7 @@ TEST_CASE("NonConstVector", "[vector]") {
 }
 
 TEST_CASE("ConstVector", "[vector]") {
-    const Vector<uint32_t, 7> vector{0xFF0F, 0x1420, 0x5530};
+    Vector<uint32_t, 7> const vector{0xFF0F, 0x1420, 0x5530};
 
     REQUIRE(3u == vector.size());
     CHECK(0xFF0F == vector[0]);
@@ -59,7 +59,7 @@ TEST_CASE("OutOfBounds", "[vector]") {
 }
 
 TEST_CASE("OutOfBoundsConst", "[vector]") {
-    const Vector<uint32_t, 9> vector;
+    Vector<uint32_t, 9> const vector;
     CHECK_THROWS_AS(vector[8], test_log_config::exception);
 }
 
@@ -102,7 +102,7 @@ TEST_CASE("VectorIterator", "[vector]") {
 }
 
 TEST_CASE("VectorConstIterator", "[vector]") {
-    const Vector<uint32_t, 7> vector{0x54, 0x70, 0x31};
+    Vector<uint32_t, 7> const vector{0x54, 0x70, 0x31};
 
     auto iter = vector.begin();
     CHECK(0x54 == *iter);

--- a/test/container/queue.cpp
+++ b/test/container/queue.cpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 
 TEST_CASE("empty", "[queue]") {
-    const queue<std::uint32_t, 1> q({});
+    queue<std::uint32_t, 1> const q({});
     CHECK(0u == q.size());
     CHECK(1u == q.capacity());
     CHECK(q.empty());

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -28,7 +28,7 @@ struct MockIrqImpl {
     static void init() { callbackPtr->init(); }
 
     template <bool enable, int irq_number, int priorityLevel>
-    inline static void irqInit() {
+    static inline void irqInit() {
         if constexpr (enable) {
             callbackPtr->init(irq_number, priorityLevel);
         }
@@ -52,15 +52,15 @@ class InterruptManagerTest : public ::testing::Test {
     void SetUp() override { callbackPtr = &callback; }
 };
 
-static auto constexpr msg_handler = flow::action("msg_handler"_sc, [] {
+constexpr static auto msg_handler = flow::action("msg_handler"_sc, [] {
     // do nothing
 });
 
-static auto constexpr rsp_handler = flow::action("rsp_handler"_sc, [] {
+constexpr static auto rsp_handler = flow::action("rsp_handler"_sc, [] {
     // do nothing
 });
 
-static auto constexpr timer_action = flow::action("timer_action"_sc, [] {
+constexpr static auto timer_action = flow::action("timer_action"_sc, [] {
     // do nothing
 });
 
@@ -184,7 +184,7 @@ struct BasicBuilder {
     };
 
     struct test_project {
-        static constexpr auto config = cib::config(
+        constexpr static auto config = cib::config(
             cib::exports<test_service>,
             interrupt::extend<test_service, msg_handler_irq>(msg_handler),
             interrupt::extend<test_service, rsp_handler_irq>(rsp_handler),
@@ -278,7 +278,7 @@ struct NoIsrBuilder {
     };
 
     struct test_project {
-        static constexpr auto config = cib::config(cib::exports<test_service>);
+        constexpr static auto config = cib::config(cib::exports<test_service>);
     };
 
     CIB_CONSTINIT static inline cib::nexus<test_project> test_nexus{};
@@ -315,7 +315,7 @@ struct ClearStatusFirstBuilder {
     };
 
     struct test_project {
-        static constexpr auto config = cib::config(
+        constexpr static auto config = cib::config(
             cib::exports<test_service>,
             interrupt::extend<test_service, timer_irq>(timer_action));
     };
@@ -350,7 +350,7 @@ struct DontClearStatusBuilder {
     };
 
     struct test_project {
-        static constexpr auto config = cib::config(
+        constexpr static auto config = cib::config(
             cib::exports<test_service>,
             interrupt::extend<test_service, timer_irq>(timer_action));
     };
@@ -445,7 +445,7 @@ TEST_F(InterruptManagerTest, ResourceDisableEnableMultiResource) {
     BasicBuilder::Dynamic::turn_on_resource<test_resource_beta>();
 }
 
-static auto constexpr bscan =
+constexpr static auto bscan =
     flow::action("bscan"_sc, [] { callbackPtr->run(0xba5eba11); });
 
 struct hwio_int_sts_field_t
@@ -500,7 +500,7 @@ struct SharedSubIrqTest {
     };
 
     struct test_project {
-        static constexpr auto config = cib::config(
+        constexpr static auto config = cib::config(
             cib::exports<test_service>,
             interrupt::extend<test_service, i2c_handler_irq>(bscan));
     };

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -41,7 +41,7 @@ TEST_CASE("TestMsgDispatch1", "[handler]") {
 
     static auto callback = msg::callback<TestBaseMsg>(
         "TestCallback"_sc, match::always<true>,
-        [](const TestMsg &) { correctDispatch = true; });
+        [](TestMsg const &) { correctDispatch = true; });
 
     auto callbacks = cib::make_tuple(callback);
 
@@ -105,7 +105,7 @@ TEST_CASE("TestMsgWithinEnum", "[handler]") {
     auto handled = false;
     auto const callback =
         msg::callback<TestBaseMsg>("TestCallback"_sc, match::always<true>,
-                                   [&](const TestMsgOp &) { handled = true; });
+                                   [&](TestMsgOp const &) { handled = true; });
 
     auto callbacks = cib::make_tuple(callback);
     auto const handler =

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -22,7 +22,7 @@ struct test_service : ::msg::service<test_msg_t> {};
 
 static inline bool callback_success;
 
-static constexpr auto test_callback = msg::callback<test_msg_t>(
+constexpr static auto test_callback = msg::callback<test_msg_t>(
     "TestCallback"_sc, match::always<true>,
     [](test_msg_t const &) { callback_success = true; });
 

--- a/test/msg/match.cpp
+++ b/test/msg/match.cpp
@@ -18,7 +18,7 @@ template <int Value> struct Number {
     }
 };
 
-template <int Value> static constexpr Number<Value> number{};
+template <int Value> constexpr static Number<Value> number{};
 
 TEST_CASE("MatchAny", "[match]") {
     REQUIRE_FALSE(match::any()(0));


### PR DESCRIPTION
Use clang-format to order qualifiers on a declaration. The order is: `constexpr` `static` `inline` <type> `const` `volatile`.

Unenforced qualifiers include:
 - `friend` - should come first, but not supported until a later version
 - `explicit` - should come right before <type>, and preferably using [explicit(bool)](wg21.link/p0892)