### PR TITLE
:construction_worker: Split sanitizer checks

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -99,6 +99,11 @@ jobs:
 
   sanitize:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [undefined, address, thread]
+
     steps:
       - uses: actions/checkout@v3
 
@@ -112,7 +117,7 @@ jobs:
           CC: "/usr/lib/llvm-15/bin/clang"
           CXX: "/usr/lib/llvm-15/bin/clang++"
           CXX_STANDARD: 20
-          SANITIZERS: "undefined,address"
+          SANITIZERS: ${{matrix.sanitizer}}
         run: cmake -B ${{github.workspace}}/build
 
       - name: Build Unit Tests

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -16,7 +16,8 @@ if(SANITIZERS)
                                INTERFACE -fsanitize-memory-track-origins)
     endif()
 
-    string(REGEX MATCH "address|memory" SANITIZER_NEW_DEL "${SANITIZERS}")
+    string(REGEX MATCH "address|memory|thread" SANITIZER_NEW_DEL
+                 "${SANITIZERS}")
     if(SANITIZER_NEW_DEL)
         target_compile_definitions(sanitizers INTERFACE SANITIZER_NEW_DEL)
     endif()


### PR DESCRIPTION
Use a matrix to build sanitized tests using UBSan, ASan and TSan.