### PR TITLE
:sparkles: Add ability to destructure cib::tuple

### DIFF
--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -372,6 +372,20 @@ using tuple = detail::tuple_impl<std::index_sequence_for<Ts...>,
 template <typename IndexList, typename... Ts>
 using indexed_tuple =
     detail::tuple_impl<std::index_sequence_for<Ts...>, IndexList, Ts...>;
+
+namespace detail {
+template <std::size_t I, typename Tuple>
+[[nodiscard]] constexpr auto get(Tuple &&t)
+    -> decltype(std::forward<Tuple>(t)[index<I>]) {
+    return std::forward<Tuple>(t)[index<I>];
+}
+
+template <typename T, typename Tuple>
+[[nodiscard]] constexpr auto get(Tuple &&t)
+    -> decltype(std::forward<Tuple>(t).get(tag<T>)) {
+    return std::forward<Tuple>(t).get(tag<T>);
+}
+} // namespace detail
 #endif
 
 template <std::size_t I, typename Tuple>

--- a/include/cib/tuple_destructure.hpp
+++ b/include/cib/tuple_destructure.hpp
@@ -1,0 +1,37 @@
+#include <cib/tuple.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace std {
+#if __cpp_deduction_guides < 201907L
+template <typename... Ts>
+struct tuple_size<cib::tuple<Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+template <std::size_t I, typename... Ts>
+struct tuple_element<I, cib::tuple<Ts...>>
+    : std::type_identity<std::remove_cvref_t<
+          decltype(std::declval<cib::tuple<Ts...>>()[cib::index<I>])>> {};
+
+template <typename IL, typename... Ts>
+struct tuple_size<cib::indexed_tuple<IL, Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+template <std::size_t I, typename IL, typename... Ts>
+struct tuple_element<I, cib::indexed_tuple<IL, Ts...>>
+    : std::type_identity<
+          std::remove_cvref_t<decltype(std::declval<cib::indexed_tuple<
+                                           IL, Ts...>>()[cib::index<I>])>> {};
+#else
+template <typename IS, typename IFL, typename... Ts>
+struct tuple_size<cib::detail::tuple_impl<IS, IFL, Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+template <std::size_t I, typename IS, typename IFL, typename... Ts>
+struct tuple_element<I, cib::detail::tuple_impl<IS, IFL, Ts...>>
+    : std::type_identity<std::remove_cvref_t<
+          decltype(std::declval<cib::detail::tuple_impl<IS, IFL, Ts...>>()
+                       [cib::index<I>])>> {};
+#endif
+} // namespace std

--- a/test/cib/tuple.cpp
+++ b/test/cib/tuple.cpp
@@ -1,6 +1,7 @@
 #include "special_members.hpp"
 
 #include <cib/tuple.hpp>
+#include <cib/tuple_destructure.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -68,6 +69,24 @@ TEST_CASE("free get", "[tuple]") {
     static_assert(cib::get<long>(t) == 10);
 }
 
+TEST_CASE("free get (ADL)", "[tuple]") {
+    constexpr auto t = cib::tuple{5, true, 10l};
+
+    REQUIRE(get<0>(t) == 5);
+    REQUIRE(get<1>(t) == true);
+    REQUIRE(get<2>(t) == 10);
+    static_assert(get<0>(t) == 5);
+    static_assert(get<1>(t) == true);
+    static_assert(get<2>(t) == 10);
+
+    REQUIRE(get<int>(t) == 5);
+    REQUIRE(get<bool>(t) == true);
+    REQUIRE(get<long>(t) == 10);
+    static_assert(get<int>(t) == 5);
+    static_assert(get<bool>(t) == true);
+    static_assert(get<long>(t) == 10);
+}
+
 TEST_CASE("free get value categories", "[tuple]") {
     {
         auto const t = cib::tuple{42};
@@ -127,6 +146,13 @@ TEST_CASE("tuple size/elements", "[tuple]") {
     static_assert(std::is_same_v<cib::tuple_element_t<0, B>, int const &>);
     using C = cib::tuple<int &&>;
     static_assert(std::is_same_v<cib::tuple_element_t<0, C>, int &&>);
+}
+
+TEST_CASE("destructuring", "[tuple]") {
+    auto const t = cib::tuple{1, 3.14f};
+    auto const [i, f] = t;
+    CHECK(i == 1);
+    CHECK(f == 3.14f);
 }
 
 namespace {
@@ -342,6 +368,13 @@ TEST_CASE("make_indexed_tuple", "[tuple]") {
     static_assert(cib::make_indexed_tuple<>(1, 2, 3) == cib::tuple{1, 2, 3});
 }
 
+TEST_CASE("indexed_tuple destructuring", "[tuple]") {
+    auto const t = cib::make_indexed_tuple<>(1, 3.14f);
+    auto const [i, f] = t;
+    CHECK(i == 1);
+    CHECK(f == 3.14f);
+}
+
 TEST_CASE("tuple with user index", "[tuple]") {
     struct X;
     struct Y;
@@ -356,6 +389,15 @@ TEST_CASE("tuple with user index", "[tuple]") {
                                   map_entry<X, int>, map_entry<Y, int>>>);
     static_assert(cib::tuple_size_v<T> == 2);
     static_assert(T::size() == 2);
+}
+
+TEST_CASE("indexed_tuple ADL get", "[tuple]") {
+    struct X;
+    struct Y;
+    constexpr auto t = cib::make_indexed_tuple<key_for>(map_entry<X, int>{42},
+                                                        map_entry<Y, int>{17});
+    static_assert(get<X>(t).value == 42);
+    static_assert(get<Y>(t).value == 17);
 }
 
 namespace {


### PR DESCRIPTION
Destructuring is in a separate header to avoid otherwise unwarranted inclusion of `<tuple>`.

Closes #307