### PR TITLE
:bug: Fix type-based concatenation for cib::tuple

### DIFF
--- a/include/cib/tuple.hpp
+++ b/include/cib/tuple.hpp
@@ -352,41 +352,30 @@ template <typename T> constexpr auto tuple_size_v = T::size();
 template <std::size_t I, typename T>
 using tuple_element_t = decltype(T::ugly_Value(index<I>));
 
-#if __cpp_deduction_guides < 201907L
 template <typename... Ts>
 struct tuple : detail::tuple_impl<std::index_sequence_for<Ts...>,
-                                  detail::index_function_list<>, Ts...> {};
+                                  detail::index_function_list<>, Ts...> {
+  private:
+    [[nodiscard]] friend constexpr auto operator==(tuple const &, tuple const &)
+        -> bool = default;
+    [[nodiscard]] friend constexpr auto operator<=>(tuple const &,
+                                                    tuple const &) = default;
+};
 template <typename... Ts> tuple(Ts...) -> tuple<Ts...>;
 
 template <typename IndexList, typename... Ts>
 struct indexed_tuple
-    : detail::tuple_impl<std::index_sequence_for<Ts...>, IndexList, Ts...> {};
+    : detail::tuple_impl<std::index_sequence_for<Ts...>, IndexList, Ts...> {
+  private:
+    [[nodiscard]] friend constexpr auto operator==(indexed_tuple const &,
+                                                   indexed_tuple const &)
+        -> bool = default;
+    [[nodiscard]] friend constexpr auto
+    operator<=>(indexed_tuple const &, indexed_tuple const &) = default;
+};
 
 template <typename... Ts>
 indexed_tuple(Ts...) -> indexed_tuple<detail::index_function_list<>, Ts...>;
-#else
-template <typename... Ts>
-using tuple = detail::tuple_impl<std::index_sequence_for<Ts...>,
-                                 detail::index_function_list<>, Ts...>;
-
-template <typename IndexList, typename... Ts>
-using indexed_tuple =
-    detail::tuple_impl<std::index_sequence_for<Ts...>, IndexList, Ts...>;
-
-namespace detail {
-template <std::size_t I, typename Tuple>
-[[nodiscard]] constexpr auto get(Tuple &&t)
-    -> decltype(std::forward<Tuple>(t)[index<I>]) {
-    return std::forward<Tuple>(t)[index<I>];
-}
-
-template <typename T, typename Tuple>
-[[nodiscard]] constexpr auto get(Tuple &&t)
-    -> decltype(std::forward<Tuple>(t).get(tag<T>)) {
-    return std::forward<Tuple>(t).get(tag<T>);
-}
-} // namespace detail
-#endif
 
 template <std::size_t I, typename Tuple>
 [[nodiscard]] constexpr auto get(Tuple &&t)

--- a/include/cib/tuple_destructure.hpp
+++ b/include/cib/tuple_destructure.hpp
@@ -6,7 +6,6 @@
 #include <utility>
 
 namespace std {
-#if __cpp_deduction_guides < 201907L
 template <typename... Ts>
 struct tuple_size<cib::tuple<Ts...>>
     : std::integral_constant<std::size_t, sizeof...(Ts)> {};
@@ -23,15 +22,4 @@ struct tuple_element<I, cib::indexed_tuple<IL, Ts...>>
     : std::type_identity<
           std::remove_cvref_t<decltype(std::declval<cib::indexed_tuple<
                                            IL, Ts...>>()[cib::index<I>])>> {};
-#else
-template <typename IS, typename IFL, typename... Ts>
-struct tuple_size<cib::detail::tuple_impl<IS, IFL, Ts...>>
-    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
-
-template <std::size_t I, typename IS, typename IFL, typename... Ts>
-struct tuple_element<I, cib::detail::tuple_impl<IS, IFL, Ts...>>
-    : std::type_identity<std::remove_cvref_t<
-          decltype(std::declval<cib::detail::tuple_impl<IS, IFL, Ts...>>()
-                       [cib::index<I>])>> {};
-#endif
 } // namespace std

--- a/test/cib/tuple.cpp
+++ b/test/cib/tuple.cpp
@@ -432,3 +432,25 @@ TEST_CASE("apply indices", "[tuple]") {
     constexpr auto u = cib::apply_indices<key_for>(t);
     static_assert(cib::get<X>(u).value == 42);
 }
+
+namespace detail {
+template <typename, typename> struct concat;
+
+template <template <typename...> typename L, typename... Ts>
+struct concat<L<Ts...>, L<>> {
+    using type = L<Ts...>;
+};
+
+template <template <typename...> typename L, typename... Ts, typename U,
+          typename... Us>
+struct concat<L<Ts...>, L<U, Us...>> {
+    using type = typename concat<L<Ts..., U>, L<Us...>>::type;
+};
+} // namespace detail
+
+TEST_CASE("tuple type-based concat", "[tuple]") {
+    using T = cib::tuple<int>;
+    using U = cib::tuple<float>;
+    static_assert(std::is_same_v<typename detail::concat<T, U>::type,
+                                 cib::tuple<int, float>>);
+}


### PR DESCRIPTION
On GCC, `cib::tuple<Ts...>` was an alias for `cib::tuple_impl<X, Y, Ts...>` which meant that type-based concat of `cib::tuple` didn't work. e.g.

```cpp
using T = boost::mp11::mp_append<cib::tuple<int>,
                                 cib::tuple<float>>;
```

This was different on clang because clang doesn't support template alias deduction guides yet. But it's easier all round if it's the same on both compilers, and an actual type so that type-based concatenation works.