### PR TITLE
:new: Add resize_and_overwrite for vector

### DIFF
--- a/include/container/vector.hpp
+++ b/include/container/vector.hpp
@@ -16,10 +16,7 @@ namespace cib {
  * @tparam Capacity  Maximum amount of elements the vector can hold.
  */
 template <typename ValueType, std::size_t Capacity> class vector {
-  protected:
-    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
     std::array<ValueType, Capacity> storage{};
-    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
     std::size_t current_size{};
 
   public:
@@ -116,6 +113,12 @@ template <typename ValueType, std::size_t Capacity> class vector {
             return {};
         }
         return storage[--current_size];
+    }
+
+    template <typename F>
+    friend constexpr auto resize_and_overwrite(vector &v, F &&f) -> void {
+        v.current_size =
+            std::forward<F>(f)(std::data(v.storage), std::size(v.storage));
     }
 
   private:

--- a/test/container/vector.cpp
+++ b/test/container/vector.cpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace {
 TEST_CASE("EmptyVector", "[vector]") {
     cib::vector<uint32_t, 3> const vector{};
     CHECK(0u == vector.size());
@@ -201,4 +200,14 @@ TEST_CASE("CapacityZeroVector", "[vector]") {
     CHECK(vector.begin() == vector.end());
     CHECK(vector == cib::vector<int, 0>{});
 }
-} // namespace
+
+TEST_CASE("Overwrite", "[vector]") {
+    cib::vector<int, 5> v{1, 2, 3, 4, 5};
+    resize_and_overwrite(v, [](int *dest, std::size_t max_size) {
+        CHECK(max_size == 5);
+        *dest = 42;
+        return 1u;
+    });
+    REQUIRE(v.size() == 1u);
+    CHECK(v[0] == 42);
+}

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -18,179 +18,193 @@ using TestMsg =
 TEST_CASE("TestMessageDataFieldConstruction", "[message]") {
     TestMsg msg{TestField1{0xba11}, TestField2{0x42}, TestField3{0xd00d}};
 
-    REQUIRE(0xba11 == msg.get<TestField1>());
-    REQUIRE(0x42 == msg.get<TestField2>());
-    REQUIRE(0xd00d == msg.get<TestField3>());
+    CHECK(0xba11 == msg.get<TestField1>());
+    CHECK(0x42 == msg.get<TestField2>());
+    CHECK(0xd00d == msg.get<TestField3>());
 
-    REQUIRE(0x8000ba11 == msg[0]);
-    REQUIRE(0x0042d00d == msg[1]);
+    CHECK(0x8000ba11 == msg[0]);
+    CHECK(0x0042d00d == msg[1]);
 }
 
-TEST_CASE("TestMessageDataFieldDefaultConstruction", "[message]") {
+TEST_CASE("TestMessageDataDefaultConstruction", "[message]") {
     TestMsg msg{};
 
-    REQUIRE(0x80 == msg.get<TestIdField>());
-    REQUIRE(0x0 == msg.get<TestField1>());
-    REQUIRE(0x0 == msg.get<TestField2>());
-    REQUIRE(0x0 == msg.get<TestField3>());
+    CHECK(0x80 == msg.get<TestIdField>());
+    CHECK(0x0 == msg.get<TestField1>());
+    CHECK(0x0 == msg.get<TestField2>());
+    CHECK(0x0 == msg.get<TestField3>());
 
-    REQUIRE(0x80000000 == msg[0]);
-    REQUIRE(0x0 == msg[1]);
+    CHECK(0x80000000 == msg[0]);
+    CHECK(0x0 == msg[1]);
 }
 
-TEST_CASE("TestMessageDataFieldInitializerConstruction", "[message]") {
+TEST_CASE("TestMessageDataRawValuesConstruction", "[message]") {
     TestMsg msg{0x8000ba11, 0x0042d00d};
 
-    REQUIRE(0x80 == msg.get<TestIdField>());
-    REQUIRE(0xba11 == msg.get<TestField1>());
-    REQUIRE(0x42 == msg.get<TestField2>());
-    REQUIRE(0xd00d == msg.get<TestField3>());
+    CHECK(0x80 == msg.get<TestIdField>());
+    CHECK(0xba11 == msg.get<TestField1>());
+    CHECK(0x42 == msg.get<TestField2>());
+    CHECK(0xd00d == msg.get<TestField3>());
 
-    REQUIRE(0x8000ba11 == msg[0]);
-    REQUIRE(0x0042d00d == msg[1]);
+    CHECK(0x8000ba11 == msg[0]);
+    CHECK(0x0042d00d == msg[1]);
 }
 
-TEST_CASE("TestMessageDataDWordConstruction", "[message]") {
+TEST_CASE("TestMessageDataRangeConstruction", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE(0xba11 == msg.get<TestField1>());
-    REQUIRE(0x42 == msg.get<TestField2>());
-    REQUIRE(0xd00d == msg.get<TestField3>());
+    CHECK(0xba11 == msg.get<TestField1>());
+    CHECK(0x42 == msg.get<TestField2>());
+    CHECK(0xd00d == msg.get<TestField3>());
 
-    REQUIRE(0x8000ba11 == msg[0]);
-    REQUIRE(0x0042d00d == msg[1]);
+    REQUIRE(msg.size() == 2u);
+    CHECK(0x8000ba11 == msg[0]);
+    CHECK(0x0042d00d == msg[1]);
+}
+
+TEST_CASE("TestMessageDataPartialRangeConstruction", "[message]") {
+    TestMsg msg{std::array<uint32_t, 4>{0x8000ba11, 0x0042d00d, 0xffffffff,
+                                        0xffffffff}};
+
+    CHECK(0xba11 == msg.get<TestField1>());
+    CHECK(0x42 == msg.get<TestField2>());
+    CHECK(0xd00d == msg.get<TestField3>());
+
+    REQUIRE(msg.size() == 2u);
+    CHECK(0x8000ba11 == msg[0]);
+    CHECK(0x0042d00d == msg[1]);
 }
 
 TEST_CASE("EqualToMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE(TestIdField::equal_to<0x80>(msg));
-    REQUIRE(TestField1::equal_to<0xba11>(msg));
-    REQUIRE(TestField2::equal_to<0x42>(msg));
-    REQUIRE(TestField3::equal_to<0xd00d>(msg));
+    CHECK(TestIdField::equal_to<0x80>(msg));
+    CHECK(TestField1::equal_to<0xba11>(msg));
+    CHECK(TestField2::equal_to<0x42>(msg));
+    CHECK(TestField3::equal_to<0xd00d>(msg));
 
-    REQUIRE_FALSE(TestIdField::equal_to<0x0>(msg));
-    REQUIRE_FALSE(TestField1::equal_to<0x0>(msg));
-    REQUIRE_FALSE(TestField2::equal_to<0x0>(msg));
-    REQUIRE_FALSE(TestField3::equal_to<0x0>(msg));
+    CHECK_FALSE(TestIdField::equal_to<0x0>(msg));
+    CHECK_FALSE(TestField1::equal_to<0x0>(msg));
+    CHECK_FALSE(TestField2::equal_to<0x0>(msg));
+    CHECK_FALSE(TestField3::equal_to<0x0>(msg));
 }
 
 TEST_CASE("DefaultMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x0, 0x00}};
 
-    REQUIRE(true == TestIdField::match_default(msg));
-    REQUIRE(true == TestField1::match_default(msg));
-    REQUIRE(true == TestField2::match_default(msg));
-    REQUIRE(true == TestField3::match_default(msg));
+    CHECK(true == TestIdField::match_default(msg));
+    CHECK(true == TestField1::match_default(msg));
+    CHECK(true == TestField2::match_default(msg));
+    CHECK(true == TestField3::match_default(msg));
 }
 
 TEST_CASE("DefaultMatcherNoMatch", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE(false == TestIdField::match_default(msg));
-    REQUIRE(false == TestField1::match_default(msg));
-    REQUIRE(false == TestField2::match_default(msg));
-    REQUIRE(false == TestField3::match_default(msg));
+    CHECK(false == TestIdField::match_default(msg));
+    CHECK(false == TestField1::match_default(msg));
+    CHECK(false == TestField2::match_default(msg));
+    CHECK(false == TestField3::match_default(msg));
 }
 
 TEST_CASE("InMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE((TestIdField::in<0x80>(msg)));
-    REQUIRE((TestField1::in<0xba11>(msg)));
-    REQUIRE((TestField2::in<0x42>(msg)));
-    REQUIRE((TestField3::in<0xd00d>(msg)));
+    CHECK((TestIdField::in<0x80>(msg)));
+    CHECK((TestField1::in<0xba11>(msg)));
+    CHECK((TestField2::in<0x42>(msg)));
+    CHECK((TestField3::in<0xd00d>(msg)));
 
-    REQUIRE_FALSE((TestIdField::in<0x11>(msg)));
-    REQUIRE_FALSE((TestField1::in<0x1111>(msg)));
-    REQUIRE_FALSE((TestField2::in<0x11>(msg)));
-    REQUIRE_FALSE((TestField3::in<0x1111>(msg)));
+    CHECK_FALSE((TestIdField::in<0x11>(msg)));
+    CHECK_FALSE((TestField1::in<0x1111>(msg)));
+    CHECK_FALSE((TestField2::in<0x11>(msg)));
+    CHECK_FALSE((TestField3::in<0x1111>(msg)));
 
-    REQUIRE((TestIdField::in<0x80, 0x0>(msg)));
-    REQUIRE((TestField1::in<0xba11, 0x0>(msg)));
-    REQUIRE((TestField2::in<0x42, 0x0>(msg)));
-    REQUIRE((TestField3::in<0xd00d, 0x0>(msg)));
+    CHECK((TestIdField::in<0x80, 0x0>(msg)));
+    CHECK((TestField1::in<0xba11, 0x0>(msg)));
+    CHECK((TestField2::in<0x42, 0x0>(msg)));
+    CHECK((TestField3::in<0xd00d, 0x0>(msg)));
 
-    REQUIRE_FALSE((TestIdField::in<0x11, 0x0>(msg)));
-    REQUIRE_FALSE((TestField1::in<0x1111, 0x0>(msg)));
-    REQUIRE_FALSE((TestField2::in<0x11, 0x0>(msg)));
-    REQUIRE_FALSE((TestField3::in<0x1111, 0x0>(msg)));
+    CHECK_FALSE((TestIdField::in<0x11, 0x0>(msg)));
+    CHECK_FALSE((TestField1::in<0x1111, 0x0>(msg)));
+    CHECK_FALSE((TestField2::in<0x11, 0x0>(msg)));
+    CHECK_FALSE((TestField3::in<0x1111, 0x0>(msg)));
 
-    REQUIRE((TestIdField::in<0x80, 0x0, 0xE>(msg)));
-    REQUIRE((TestField1::in<0xba11, 0x0, 0xEEEE>(msg)));
-    REQUIRE((TestField2::in<0x42, 0x0, 0xEE>(msg)));
-    REQUIRE((TestField3::in<0xd00d, 0x0, 0xEEEE>(msg)));
+    CHECK((TestIdField::in<0x80, 0x0, 0xE>(msg)));
+    CHECK((TestField1::in<0xba11, 0x0, 0xEEEE>(msg)));
+    CHECK((TestField2::in<0x42, 0x0, 0xEE>(msg)));
+    CHECK((TestField3::in<0xd00d, 0x0, 0xEEEE>(msg)));
 
-    REQUIRE_FALSE((TestIdField::in<0x11, 0x0, 0xE>(msg)));
-    REQUIRE_FALSE((TestField1::in<0x1111, 0x0, 0xEEEE>(msg)));
-    REQUIRE_FALSE((TestField2::in<0x11, 0x0, 0xEE>(msg)));
-    REQUIRE_FALSE((TestField3::in<0x1111, 0x0, 0xEEEE>(msg)));
+    CHECK_FALSE((TestIdField::in<0x11, 0x0, 0xE>(msg)));
+    CHECK_FALSE((TestField1::in<0x1111, 0x0, 0xEEEE>(msg)));
+    CHECK_FALSE((TestField2::in<0x11, 0x0, 0xEE>(msg)));
+    CHECK_FALSE((TestField3::in<0x1111, 0x0, 0xEEEE>(msg)));
 }
 
 TEST_CASE("GreaterThanMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE_FALSE(TestIdField::greater_than<0x80>(msg));
-    REQUIRE_FALSE(TestField1::greater_than<0xba11>(msg));
-    REQUIRE_FALSE(TestField2::greater_than<0x42>(msg));
-    REQUIRE_FALSE(TestField3::greater_than<0xd00d>(msg));
+    CHECK_FALSE(TestIdField::greater_than<0x80>(msg));
+    CHECK_FALSE(TestField1::greater_than<0xba11>(msg));
+    CHECK_FALSE(TestField2::greater_than<0x42>(msg));
+    CHECK_FALSE(TestField3::greater_than<0xd00d>(msg));
 
-    REQUIRE(TestIdField::greater_than<0x11>(msg));
-    REQUIRE(TestField1::greater_than<0x1111>(msg));
-    REQUIRE(TestField2::greater_than<0x11>(msg));
-    REQUIRE(TestField3::greater_than<0x1111>(msg));
+    CHECK(TestIdField::greater_than<0x11>(msg));
+    CHECK(TestField1::greater_than<0x1111>(msg));
+    CHECK(TestField2::greater_than<0x11>(msg));
+    CHECK(TestField3::greater_than<0x1111>(msg));
 }
 
 TEST_CASE("GreaterThanOrEqualToMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE_FALSE(TestIdField::greater_than_or_equal_to<0xEE>(msg));
-    REQUIRE_FALSE(TestField1::greater_than_or_equal_to<0xEEEE>(msg));
-    REQUIRE_FALSE(TestField2::greater_than_or_equal_to<0xEE>(msg));
-    REQUIRE_FALSE(TestField3::greater_than_or_equal_to<0xEEEE>(msg));
+    CHECK_FALSE(TestIdField::greater_than_or_equal_to<0xEE>(msg));
+    CHECK_FALSE(TestField1::greater_than_or_equal_to<0xEEEE>(msg));
+    CHECK_FALSE(TestField2::greater_than_or_equal_to<0xEE>(msg));
+    CHECK_FALSE(TestField3::greater_than_or_equal_to<0xEEEE>(msg));
 
-    REQUIRE(TestIdField::greater_than_or_equal_to<0x80>(msg));
-    REQUIRE(TestField1::greater_than_or_equal_to<0xba11>(msg));
-    REQUIRE(TestField2::greater_than_or_equal_to<0x42>(msg));
-    REQUIRE(TestField3::greater_than_or_equal_to<0xd00d>(msg));
+    CHECK(TestIdField::greater_than_or_equal_to<0x80>(msg));
+    CHECK(TestField1::greater_than_or_equal_to<0xba11>(msg));
+    CHECK(TestField2::greater_than_or_equal_to<0x42>(msg));
+    CHECK(TestField3::greater_than_or_equal_to<0xd00d>(msg));
 
-    REQUIRE(TestIdField::greater_than_or_equal_to<0x11>(msg));
-    REQUIRE(TestField1::greater_than_or_equal_to<0x1111>(msg));
-    REQUIRE(TestField2::greater_than_or_equal_to<0x11>(msg));
-    REQUIRE(TestField3::greater_than_or_equal_to<0x1111>(msg));
+    CHECK(TestIdField::greater_than_or_equal_to<0x11>(msg));
+    CHECK(TestField1::greater_than_or_equal_to<0x1111>(msg));
+    CHECK(TestField2::greater_than_or_equal_to<0x11>(msg));
+    CHECK(TestField3::greater_than_or_equal_to<0x1111>(msg));
 }
 
 TEST_CASE("LessThanMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE_FALSE(TestIdField::less_than<0x80>(msg));
-    REQUIRE_FALSE(TestField1::less_than<0xba11>(msg));
-    REQUIRE_FALSE(TestField2::less_than<0x42>(msg));
-    REQUIRE_FALSE(TestField3::less_than<0xd00d>(msg));
+    CHECK_FALSE(TestIdField::less_than<0x80>(msg));
+    CHECK_FALSE(TestField1::less_than<0xba11>(msg));
+    CHECK_FALSE(TestField2::less_than<0x42>(msg));
+    CHECK_FALSE(TestField3::less_than<0xd00d>(msg));
 
-    REQUIRE(TestIdField::less_than<0xEE>(msg));
-    REQUIRE(TestField1::less_than<0xEEEE>(msg));
-    REQUIRE(TestField2::less_than<0xEE>(msg));
-    REQUIRE(TestField3::less_than<0xEEEE>(msg));
+    CHECK(TestIdField::less_than<0xEE>(msg));
+    CHECK(TestField1::less_than<0xEEEE>(msg));
+    CHECK(TestField2::less_than<0xEE>(msg));
+    CHECK(TestField3::less_than<0xEEEE>(msg));
 }
 
 TEST_CASE("LessThanOrEqualToMatcher", "[message]") {
     TestMsg msg{std::array<uint32_t, 2>{0x8000ba11, 0x0042d00d}};
 
-    REQUIRE(TestIdField::less_than_or_equal_to<0xEE>(msg));
-    REQUIRE(TestField1::less_than_or_equal_to<0xEEEE>(msg));
-    REQUIRE(TestField2::less_than_or_equal_to<0xEE>(msg));
-    REQUIRE(TestField3::less_than_or_equal_to<0xEEEE>(msg));
+    CHECK(TestIdField::less_than_or_equal_to<0xEE>(msg));
+    CHECK(TestField1::less_than_or_equal_to<0xEEEE>(msg));
+    CHECK(TestField2::less_than_or_equal_to<0xEE>(msg));
+    CHECK(TestField3::less_than_or_equal_to<0xEEEE>(msg));
 
-    REQUIRE(TestIdField::less_than_or_equal_to<0x80>(msg));
-    REQUIRE(TestField1::less_than_or_equal_to<0xba11>(msg));
-    REQUIRE(TestField2::less_than_or_equal_to<0x42>(msg));
-    REQUIRE(TestField3::less_than_or_equal_to<0xd00d>(msg));
+    CHECK(TestIdField::less_than_or_equal_to<0x80>(msg));
+    CHECK(TestField1::less_than_or_equal_to<0xba11>(msg));
+    CHECK(TestField2::less_than_or_equal_to<0x42>(msg));
+    CHECK(TestField3::less_than_or_equal_to<0xd00d>(msg));
 
-    REQUIRE_FALSE(TestIdField::less_than_or_equal_to<0x11>(msg));
-    REQUIRE_FALSE(TestField1::less_than_or_equal_to<0x1111>(msg));
-    REQUIRE_FALSE(TestField2::less_than_or_equal_to<0x11>(msg));
-    REQUIRE_FALSE(TestField3::less_than_or_equal_to<0x1111>(msg));
+    CHECK_FALSE(TestIdField::less_than_or_equal_to<0x11>(msg));
+    CHECK_FALSE(TestField1::less_than_or_equal_to<0x1111>(msg));
+    CHECK_FALSE(TestField2::less_than_or_equal_to<0x11>(msg));
+    CHECK_FALSE(TestField3::less_than_or_equal_to<0x1111>(msg));
 }
 
 } // namespace msg


### PR DESCRIPTION
There are several use cases where `resize_and_overwrite` is a useful function for message data. With static capacity, the interface is not quite the same as on `std::string`, hence it's a free function. But `resize_and_overwrite` is still a good name, because that's what it does.

Also, simplify constructors for message_base.