### PR TITLE
:bug: :boom: Fix message_base size

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -15,7 +15,7 @@ namespace msg {
  * @tparam MsbT  most significant bit position for the field
  * @tparam LsbT  least significant bit position for the field
  */
-template <typename NameTypeT, std::uint32_t DWordIndexT, std::uint32_t MsbT,
+template <typename NameTypeT, std::uint32_t DWordIndex, std::uint32_t MsbT,
           std::uint32_t LsbT, typename T = std::uint32_t, T DefaultValue = T{},
           typename MatchRequirementsType = match::always_t<true>>
 class field {
@@ -29,17 +29,17 @@ class field {
     constexpr static size_t size = (MsbT - LsbT) + 1;
     static_assert(size <= 64, "field must be 64 bits or smaller");
 
-    using FieldId = field<NameTypeT, DWordIndexT, MsbT, LsbT, T>;
-    using This = field<NameTypeT, DWordIndexT, MsbT, LsbT, T, DefaultValue,
+    using FieldId = field<NameTypeT, DWordIndex, MsbT, LsbT, T>;
+    using This = field<NameTypeT, DWordIndex, MsbT, LsbT, T, DefaultValue,
                        MatchRequirementsType>;
     using ValueType = T;
 
-    template <typename MsgType> constexpr static void fits_inside(MsgType) {
-        static_assert(DWordIndex < MsgType::NumDWords);
-    }
-
     using NameType = NameTypeT;
-    constexpr static auto DWordIndex = DWordIndexT;
+    constexpr static auto MaxDWordExtent = DWordIndex + (MsbT / 32);
+
+    template <typename MsgType> constexpr static void fits_inside(MsgType) {
+        static_assert(MaxDWordExtent < MsgType::max_num_dwords);
+    }
 
     constexpr static NameType name{};
     constexpr static uint64_t bit_mask = [] {
@@ -80,34 +80,34 @@ class field {
 
     template <T NewGreaterValue>
     using WithGreaterThan =
-        field<NameTypeT, DWordIndexT, MsbT, LsbT, T, NewGreaterValue,
+        field<NameTypeT, DWordIndex, MsbT, LsbT, T, NewGreaterValue,
               msg::greater_than_t<This, T, NewGreaterValue>>;
 
     template <T NewDefaultValue>
     using WithDefault =
-        field<NameTypeT, DWordIndexT, MsbT, LsbT, T, NewDefaultValue>;
+        field<NameTypeT, DWordIndex, MsbT, LsbT, T, NewDefaultValue>;
 
     template <T NewRequiredValue>
     using WithRequired =
-        field<NameTypeT, DWordIndexT, MsbT, LsbT, T, NewRequiredValue,
+        field<NameTypeT, DWordIndex, MsbT, LsbT, T, NewRequiredValue,
               msg::equal_to_t<This, T, NewRequiredValue>>;
 
     template <T... PotentialValues>
-    using WithIn = field<NameTypeT, DWordIndexT, MsbT, LsbT, T, T{},
+    using WithIn = field<NameTypeT, DWordIndex, MsbT, LsbT, T, T{},
                          msg::in_t<This, T, PotentialValues...>>;
 
     template <typename NewRequiredMatcher>
-    using WithMatch = field<NameTypeT, DWordIndexT, MsbT, LsbT, T, DefaultValue,
+    using WithMatch = field<NameTypeT, DWordIndex, MsbT, LsbT, T, DefaultValue,
                             NewRequiredMatcher>;
 
     template <T NewGreaterValue>
     using WithGreaterThanOrEqualTo =
-        field<NameTypeT, DWordIndexT, MsbT, LsbT, T, NewGreaterValue,
+        field<NameTypeT, DWordIndex, MsbT, LsbT, T, NewGreaterValue,
               msg::greater_than_or_equal_to_t<This, T, NewGreaterValue>>;
 
     template <T NewLesserValue>
     using WithLessThanOrEqualTo =
-        field<NameTypeT, DWordIndexT, MsbT, LsbT, T, NewLesserValue,
+        field<NameTypeT, DWordIndex, MsbT, LsbT, T, NewLesserValue,
               msg::less_than_or_equal_to_t<This, T, NewLesserValue>>;
 
     constexpr explicit field(T const &new_value) : value{new_value} {}

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -14,25 +14,25 @@ using TestField2 = field<decltype("TestField2"_sc), 1, 23, 16, std::uint32_t>;
 
 using TestField3 = field<decltype("TestField3"_sc), 1, 15, 0, std::uint32_t>;
 
-using TestBaseMsg = message_data<4>;
+using TestBaseMsg = message_data<2>;
 
 using TestMsg =
-    message_base<decltype("TestMsg"_sc), 4, 2, TestIdField::WithRequired<0x80>,
+    message_base<decltype("TestMsg"_sc), 2, TestIdField::WithRequired<0x80>,
                  TestField1, TestField2, TestField3>;
 
 using TestMsgMultiCb =
-    message_base<decltype("TestMsg"_sc), 4, 2, TestIdField::WithRequired<0x81>,
+    message_base<decltype("TestMsg"_sc), 2, TestIdField::WithRequired<0x81>,
                  TestField1, TestField2, TestField3>;
 
 using TestMsgFieldRequired = message_base<decltype("TestMsgFieldRequired"_sc),
-                                          4, 2, TestIdField::WithRequired<0x44>,
+                                          2, TestIdField::WithRequired<0x44>,
                                           TestField1, TestField2, TestField3>;
 
 enum class Opcode { A = 0x8, B = 0x9, C = 0xA };
 
 using TestOpField = field<decltype("TestOpField"_sc), 0, 27, 24, Opcode>;
 
-using TestMsgOp = message_base<decltype("TestMsg"_sc), 4, 2,
+using TestMsgOp = message_base<decltype("TestMsg"_sc), 2,
                                TestOpField::WithIn<Opcode::A, Opcode::B>,
                                TestField1, TestField2>;
 

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -14,9 +14,9 @@ using test_field_2 =
 using test_field_3 =
     field<decltype("test_field_3"_sc), 1, 15, 0, std::uint32_t>;
 
-using test_msg_t = message_base<decltype("test_msg"_sc), 4, 2,
-                                test_id_field::WithRequired<0x80>, test_field_1,
-                                test_field_2, test_field_3>;
+using test_msg_t =
+    message_base<decltype("test_msg"_sc), 2, test_id_field::WithRequired<0x80>,
+                 test_field_1, test_field_2, test_field_3>;
 
 struct test_service : ::msg::service<test_msg_t> {};
 

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -12,7 +12,7 @@ using TestField2 = field<decltype("TestField2"_sc), 1, 23, 16, std::uint32_t>;
 using TestField3 = field<decltype("TestField3"_sc), 1, 15, 0, std::uint32_t>;
 
 using TestMsg =
-    message_base<decltype("TestMsg"_sc), 4, 2, TestIdField::WithRequired<0x80>,
+    message_base<decltype("TestMsg"_sc), 2, TestIdField::WithRequired<0x80>,
                  TestField1, TestField2, TestField3>;
 
 TEST_CASE("TestMessageDataFieldConstruction", "[message]") {


### PR DESCRIPTION
`message_base` size was not set correctly when constructing from a range or a variadic pack of integral types.

Remove message_base NumDWords template parameter: there was no need for it.

Closes #317 