### PR TITLE
Fix disjoint_field use in message

### DIFF
--- a/include/msg/disjoint_field.hpp
+++ b/include/msg/disjoint_field.hpp
@@ -28,6 +28,12 @@ class disjoint_field {
                                 MatchRequirementsType>;
 
     using NameType = NameTypeT;
+    using ValueType = T;
+    constexpr static size_t MaxDWordExtent =
+        fields.fold_right(size_t{}, [](auto f, size_t maxExtent) {
+            using FieldType = decltype(f);
+            return std::max(size_t{FieldType::MaxDWordExtent}, maxExtent);
+        });
 
     template <typename MsgType> constexpr static void fits_inside(MsgType msg) {
         cib::for_each([&](auto field) { field.fits_inside(msg); }, fields);
@@ -98,10 +104,10 @@ class disjoint_field {
         (void)fields.fold_right(static_cast<uint64_t>(value),
                                 [&](auto fieldPrototype, uint64_t remaining) {
                                     using FieldType = decltype(fieldPrototype);
-                                    using ValueType =
+                                    using FieldValueType =
                                         typename FieldType::ValueType;
                                     decltype(fieldPrototype) const f{
-                                        static_cast<ValueType>(remaining)};
+                                        static_cast<FieldValueType>(remaining)};
                                     f.insert(data);
                                     return remaining >> f.size;
                                 });

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -1,3 +1,4 @@
+#include <msg/disjoint_field.hpp>
 #include <msg/message.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -9,7 +10,14 @@ using TestField1 = field<decltype("TestField1"_sc), 0, 15, 0, std::uint32_t>;
 
 using TestField2 = field<decltype("TestField2"_sc), 1, 23, 16, std::uint32_t>;
 
-using TestField3 = field<decltype("TestField3"_sc), 1, 15, 0, std::uint32_t>;
+using TestFieldLower =
+    field<decltype("TestFieldLower"_sc), 1, 15, 8, std::uint32_t>;
+
+using TestFieldUpper =
+    field<decltype("TestFieldUpper"_sc), 1, 7, 0, std::uint32_t>;
+
+using TestField3 = disjoint_field<decltype("TestField4"_sc),
+                                  cib::tuple<TestFieldLower, TestFieldUpper>>;
 
 using TestMsg =
     message_base<decltype("TestMsg"_sc), 2, TestIdField::WithRequired<0x80>,


### PR DESCRIPTION
Add `MaxDWordExtent` member to `disjoint_field` to fulfill the requirement introduced by #320.

Add `ValueType` alias to `disjoint_field`.