### PR TITLE
:alien: Update how cmake finds python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,10 @@ if(PROJECT_IS_TOP_LEVEL)
     add_subdirectory(examples)
 
     # Build single-header release.
-    find_package(PythonInterp 3 REQUIRED)
+    find_package(
+        Python3
+        COMPONENTS Interpreter
+        REQUIRED)
 
     file(GLOB_RECURSE include_files
          "${CMAKE_CURRENT_SOURCE_DIR}/include/cib/*.hpp")

--- a/include/msg/detail/func_traits.hpp
+++ b/include/msg/detail/func_traits.hpp
@@ -19,9 +19,9 @@ template <typename F>
 using func_t = function_type<decltype(std::function{std::declval<F>()})>;
 
 template <typename Callable>
-using func_args_t = typename func_t<CallableT>::args_type;
+using func_args_t = typename func_t<Callable>::args_type;
 
-template <typename Callable> constexpr func_args_t<CallableT> func_args_v{};
+template <typename Callable> constexpr func_args_t<Callable> func_args_v{};
 
 template <typename Callable>
 using msg_type_t = typename func_t<Callable>::msg_type;


### PR DESCRIPTION
The `FindPythonInterp` module was deprecated in cmake 3.12 and removed in cmake 3.27. It was replaced by `FindPython3` and friends.

See output of: `$ cmake --help-policy CMP0148`