### PR TITLE
:recycle: Flow building: tidy up and make safer

### DIFF
--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <container/constexpr_multimap.hpp>
+#include <container/vector.hpp>
 #include <flow/common.hpp>
 
 #include <algorithm>
 #include <array>
 #include <concepts>
 #include <cstddef>
+#include <span>
 
 namespace flow {
 namespace detail {
@@ -133,13 +135,12 @@ class graph_builder {
               std::size_t Capacity>
     [[nodiscard]] constexpr auto topo_sort() const -> Output<Name, Capacity> {
         graph_t g = graph;
-        std::array<Node, NodeCapacity> ordered_list{};
-        std::size_t list_size{};
+        cib::vector<Node, NodeCapacity> ordered_list{};
 
         auto sources = get_sources();
         while (not sources.empty()) {
             auto n = sources.pop();
-            ordered_list[list_size++] = n;
+            ordered_list.push_back(n);
 
             if (g.contains(n)) {
                 auto ms = g.get(n);
@@ -159,7 +160,9 @@ class graph_builder {
 
         auto buildStatus = g.empty() ? build_status::SUCCESS
                                      : build_status::HAS_CIRCULAR_DEPENDENCY;
-        return Output<Name, Capacity>(ordered_list.data(), buildStatus);
+        return Output<Name, Capacity>(
+            std::span{std::cbegin(ordered_list), std::size(ordered_list)},
+            buildStatus);
     }
 
     /**

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -33,8 +33,8 @@ TEST_CASE("add single action", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 1>();
     flow();
 
-    REQUIRE(flow.getBuildStatus() == flow::build_status::SUCCESS);
-    REQUIRE(actual == "a");
+    CHECK(flow.getBuildStatus() == flow::build_status::SUCCESS);
+    CHECK(actual == "a");
 }
 
 TEST_CASE("two milestone linear before dependency", "[flow]") {
@@ -57,7 +57,7 @@ TEST_CASE("two milestone linear before dependency", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 2>();
     flow();
 
-    REQUIRE(actual == "a");
+    CHECK(actual == "a");
 }
 
 TEST_CASE("actions get executed once", "[flow]") {
@@ -71,7 +71,7 @@ TEST_CASE("actions get executed once", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual == "a");
+    CHECK(actual == "a");
 }
 
 TEST_CASE("two milestone linear after dependency", "[flow]") {
@@ -87,7 +87,7 @@ TEST_CASE("two milestone linear after dependency", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 4>();
     flow();
 
-    REQUIRE(actual == "ab");
+    CHECK(actual == "ab");
 }
 
 TEST_CASE("three milestone linear before and after dependency", "[flow]") {
@@ -99,7 +99,7 @@ TEST_CASE("three milestone linear before and after dependency", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual == "abc");
+    CHECK(actual == "abc");
 }
 
 TEST_CASE("just two actions in order", "[flow]") {
@@ -111,7 +111,7 @@ TEST_CASE("just two actions in order", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 2>();
     flow();
 
-    REQUIRE(actual == "ab");
+    CHECK(actual == "ab");
 }
 
 TEST_CASE("insert action between two actions", "[flow]") {
@@ -125,7 +125,7 @@ TEST_CASE("insert action between two actions", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual == "abc");
+    CHECK(actual == "abc");
 }
 
 TEST_CASE("add single parallel 2", "[flow]") {
@@ -137,9 +137,9 @@ TEST_CASE("add single parallel 2", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 2>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.size() == 2);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.size() == 2);
 }
 
 TEST_CASE("add single parallel 3", "[flow]") {
@@ -151,10 +151,10 @@ TEST_CASE("add single parallel 3", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add single parallel 3 with later dependency 1", "[flow]") {
@@ -167,11 +167,11 @@ TEST_CASE("add single parallel 3 with later dependency 1", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.find('c') < actual.find('a'));
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.find('c') < actual.find('a'));
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add single parallel 3 with later dependency 2", "[flow]") {
@@ -184,11 +184,11 @@ TEST_CASE("add single parallel 3 with later dependency 2", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.find('a') < actual.find('c'));
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.find('a') < actual.find('c'));
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add parallel rhs", "[flow]") {
@@ -200,12 +200,12 @@ TEST_CASE("add parallel rhs", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.find('a') < actual.find('b'));
-    REQUIRE(actual.find('a') < actual.find('c'));
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.find('a') < actual.find('b'));
+    CHECK(actual.find('a') < actual.find('c'));
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add parallel lhs", "[flow]") {
@@ -217,12 +217,12 @@ TEST_CASE("add parallel lhs", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.find('a') < actual.find('c'));
-    REQUIRE(actual.find('b') < actual.find('c'));
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.find('a') < actual.find('c'));
+    CHECK(actual.find('b') < actual.find('c'));
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add parallel in the middle", "[flow]") {
@@ -234,18 +234,18 @@ TEST_CASE("add parallel in the middle", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 4>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
-    REQUIRE(actual.find('d') != std::string::npos);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
+    CHECK(actual.find('d') != std::string::npos);
 
-    REQUIRE(actual.find('a') < actual.find('b'));
-    REQUIRE(actual.find('a') < actual.find('c'));
+    CHECK(actual.find('a') < actual.find('b'));
+    CHECK(actual.find('a') < actual.find('c'));
 
-    REQUIRE(actual.find('b') < actual.find('d'));
-    REQUIRE(actual.find('c') < actual.find('d'));
+    CHECK(actual.find('b') < actual.find('d'));
+    CHECK(actual.find('c') < actual.find('d'));
 
-    REQUIRE(actual.size() == 4);
+    CHECK(actual.size() == 4);
 }
 
 TEST_CASE("add dependency lhs", "[flow]") {
@@ -257,13 +257,13 @@ TEST_CASE("add dependency lhs", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
 
-    REQUIRE(actual.find('a') < actual.find('b'));
+    CHECK(actual.find('a') < actual.find('b'));
 
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.size() == 3);
 }
 
 TEST_CASE("add dependency rhs", "[flow]") {
@@ -275,13 +275,13 @@ TEST_CASE("add dependency rhs", "[flow]") {
     auto const flow = builder.topo_sort<flow::impl, 3>();
     flow();
 
-    REQUIRE(actual.find('a') != std::string::npos);
-    REQUIRE(actual.find('b') != std::string::npos);
-    REQUIRE(actual.find('c') != std::string::npos);
+    CHECK(actual.find('a') != std::string::npos);
+    CHECK(actual.find('b') != std::string::npos);
+    CHECK(actual.find('c') != std::string::npos);
 
-    REQUIRE(actual.find('b') < actual.find('c'));
+    CHECK(actual.find('b') < actual.find('c'));
 
-    REQUIRE(actual.size() == 3);
+    CHECK(actual.size() == 3);
 }
 
 struct TestFlowAlpha : public flow::service<> {};
@@ -298,7 +298,7 @@ TEST_CASE("add single action through cib::nexus", "[flow]") {
 
     nexus.service<TestFlowAlpha>();
 
-    REQUIRE(actual == "a");
+    CHECK(actual == "a");
 }
 
 struct MultiFlowMultiActionConfig {
@@ -317,7 +317,7 @@ TEST_CASE("add multi action through cib::nexus", "[flow]") {
     nexus.service<TestFlowAlpha>();
     nexus.service<TestFlowBeta>();
 
-    REQUIRE(actual == "abcd");
+    CHECK(actual == "abcd");
 }
 
 TEST_CASE("add multi action through cib::nexus, run through cib::service",
@@ -330,6 +330,6 @@ TEST_CASE("add multi action through cib::nexus, run through cib::service",
     cib::service<TestFlowAlpha>();
     cib::service<TestFlowBeta>();
 
-    REQUIRE(actual == "abcd");
+    CHECK(actual == "abcd");
 }
 } // namespace

--- a/test/seq/sequencer.cpp
+++ b/test/seq/sequencer.cpp
@@ -1,4 +1,3 @@
-#include <cib/cib.hpp>
 #include <seq/builder.hpp>
 #include <seq/impl.hpp>
 
@@ -7,359 +6,146 @@
 #include <string>
 
 namespace {
-
-TEST_CASE("construct empty sequencer", "[seq]") {
-    seq::impl<void, 0> seq_impl{};
-
-    SECTION("forward can be called without issue") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-    }
-
-    SECTION("backward can be called without issue") {
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-    }
-}
-
-std::string result;
-
-TEST_CASE("construct sequencer with a single step", "[seq]") {
-    result = "";
-
-    seq::func_ptr forward_steps[] = {[]() -> seq::status {
-        result += "F0";
-        return seq::status::DONE;
-    }};
-
-    seq::func_ptr backward_steps[] = {[]() -> seq::status {
-        result += "B0";
-        return seq::status::DONE;
-    }};
-
-    seq::impl<void, 1> seq_impl{forward_steps, backward_steps};
-
-    SECTION("forward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0");
-    }
-
-    SECTION("backward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0B0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0B0");
-    }
-
-    SECTION("forward and backwards can be called multiple times") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0B0");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0B0F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0B0F0B0");
-    }
-}
-
-TEST_CASE("construct sequencer with multiple steps", "[seq]") {
-    result = "";
-
-    seq::func_ptr forward_steps[] = {[]() -> seq::status {
-                                         result += "F0";
-                                         return seq::status::DONE;
-                                     },
-
-                                     []() -> seq::status {
-                                         result += "F1";
-                                         return seq::status::DONE;
-                                     },
-
-                                     []() -> seq::status {
-                                         result += "F2";
-                                         return seq::status::DONE;
-                                     }};
-
-    seq::func_ptr backward_steps[] = {[]() -> seq::status {
-                                          result += "B0";
-                                          return seq::status::DONE;
-                                      },
-
-                                      []() -> seq::status {
-                                          result += "B1";
-                                          return seq::status::DONE;
-                                      },
-
-                                      []() -> seq::status {
-                                          result += "B2";
-                                          return seq::status::DONE;
-                                      }};
-
-    seq::impl<void, 3> seq_impl{forward_steps, backward_steps};
-
-    SECTION("forward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2");
-    }
-
-    SECTION("backward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B0");
-    }
-
-    SECTION("forward and backwards can be called multiple times") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B0");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B0F0F1F2");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B0F0F1F2B2B1B0");
-    }
-}
-
 int attempt_count;
-
-TEST_CASE("construct sequencer with a single step that never finishes",
-          "[seq]") {
-    result = "";
-    attempt_count = 0;
-
-    seq::func_ptr forward_steps[] = {[]() -> seq::status {
-        if (attempt_count < 3) {
-            result += "F0";
-            attempt_count++;
-            return seq::status::NOT_DONE;
-        } else {
-            return seq::status::DONE;
-        }
-    }};
-
-    seq::func_ptr backward_steps[] = {[]() -> seq::status {
-        result += "B0";
-        return seq::status::DONE;
-    }};
-
-    seq::impl<void, 1> seq_impl{forward_steps, backward_steps};
-
-    SECTION("forward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F0");
-
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F0F0");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F0F0");
-    }
-
-    SECTION("backward can be called, but will not proceed") {
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F0F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F0F0B0");
-    }
-}
-
-TEST_CASE("construct sequencer with a single backward step that never finishes",
-          "[seq]") {
-    result = "";
-    attempt_count = 0;
-
-    seq::func_ptr forward_steps[] = {[]() -> seq::status {
-        result += "F0";
-        return seq::status::DONE;
-    }};
-
-    seq::func_ptr backward_steps[] = {[]() -> seq::status {
-        if (attempt_count < 3) {
-            result += "B0";
-            attempt_count++;
-            return seq::status::NOT_DONE;
-        } else {
-            return seq::status::DONE;
-        }
-    }};
-
-    seq::impl<void, 1> seq_impl{forward_steps, backward_steps};
-
-    SECTION("backward can be called") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0B0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0B0B0");
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0B0B0B0");
-    }
-
-    SECTION("forward can be called, but will not proceed") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0");
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0");
-
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0B0");
-
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0B0B0B0");
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0B0B0B0F0");
-    }
-}
-
-seq::status f0_step_status = seq::status::DONE;
-seq::status f1_step_status = seq::status::DONE;
-seq::status f2_step_status = seq::status::DONE;
-seq::status b0_step_status = seq::status::DONE;
-seq::status b1_step_status = seq::status::DONE;
-seq::status b2_step_status = seq::status::DONE;
-
-TEST_CASE("run sequencer with multiple steps", "[seq]") {
-    result = "";
-    f0_step_status = seq::status::DONE;
-    f1_step_status = seq::status::DONE;
-    f2_step_status = seq::status::DONE;
-    b0_step_status = seq::status::DONE;
-    b1_step_status = seq::status::DONE;
-    b2_step_status = seq::status::DONE;
-
-    seq::func_ptr forward_steps[] = {[]() -> seq::status {
-                                         result += "F0";
-                                         return f0_step_status;
-                                     },
-
-                                     []() -> seq::status {
-                                         result += "F1";
-                                         return f1_step_status;
-                                     },
-
-                                     []() -> seq::status {
-                                         result += "F2";
-                                         return f2_step_status;
-                                     }};
-
-    seq::func_ptr backward_steps[] = {[]() -> seq::status {
-                                          result += "B0";
-                                          return b0_step_status;
-                                      },
-
-                                      []() -> seq::status {
-                                          result += "B1";
-                                          return b1_step_status;
-                                      },
-
-                                      []() -> seq::status {
-                                          result += "B2";
-                                          return b2_step_status;
-                                      }};
-
-    seq::impl<void, 3> seq_impl{forward_steps, backward_steps};
-
-    SECTION("backward can be called after second forward step") {
-        f1_step_status = seq::status::NOT_DONE;
-        REQUIRE(seq_impl.forward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F1");
-
-        f1_step_status = seq::status::DONE;
-
-        REQUIRE(seq_impl.backward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F1B1B0");
-    }
-
-    SECTION("forward can be called after second backward step") {
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2");
-
-        b1_step_status = seq::status::NOT_DONE;
-
-        REQUIRE(seq_impl.backward() == seq::status::NOT_DONE);
-        REQUIRE(result == "F0F1F2B2B1");
-
-        b1_step_status = seq::status::DONE;
-
-        REQUIRE(seq_impl.forward() == seq::status::DONE);
-        REQUIRE(result == "F0F1F2B2B1B1F1F2");
-    }
-}
+std::string result;
+} // namespace
 
 TEST_CASE("build and run empty seq", "[seq]") {
     seq::builder<> builder;
     auto seq_impl = builder.topo_sort<seq::impl, 0>();
-    REQUIRE(seq_impl.forward() == seq::status::DONE);
+    CHECK(seq_impl.forward() == seq::status::DONE);
+    CHECK(seq_impl.backward() == seq::status::DONE);
 }
 
 TEST_CASE("build seq with one step and run forwards and backwards", "[seq]") {
     result = "";
-
     seq::builder<> builder;
 
-    auto s1 = seq::step(
-        "S1"_sc,
+    auto s = seq::step(
+        "S"_sc,
         []() -> seq::status {
-            result += "F1";
+            result += "F";
             return seq::status::DONE;
         },
         []() -> seq::status {
-            result += "B1";
+            result += "B";
             return seq::status::DONE;
         });
 
-    builder.add(s1);
+    builder.add(s);
 
     auto seq_impl = builder.topo_sort<seq::impl, 1>();
 
-    REQUIRE(seq_impl.forward() == seq::status::DONE);
-    REQUIRE(result == "F1");
+    CHECK(seq_impl.forward() == seq::status::DONE);
+    CHECK(result == "F");
 
-    REQUIRE(seq_impl.backward() == seq::status::DONE);
-    REQUIRE(result == "F1B1");
+    CHECK(seq_impl.backward() == seq::status::DONE);
+    CHECK(result == "FB");
+}
+
+TEST_CASE("build seq with a forward step that takes a while to finish",
+          "[seq]") {
+    result = "";
+    attempt_count = 0;
+    seq::builder<> builder;
+
+    auto s = seq::step(
+        "S"_sc,
+        []() -> seq::status {
+            if (attempt_count++ < 3) {
+                result += "F";
+                return seq::status::NOT_DONE;
+            } else {
+                return seq::status::DONE;
+            }
+        },
+        []() -> seq::status {
+            result += "B";
+            return seq::status::DONE;
+        });
+
+    builder.add(s);
+
+    auto seq_impl = builder.topo_sort<seq::impl, 1>();
+
+    SECTION("forward can be called") {
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "F");
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "FF");
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "FFF");
+        CHECK(seq_impl.forward() == seq::status::DONE);
+        CHECK(result == "FFF");
+    }
+    SECTION(
+        "backward can be called, but will not proceed until forward is done") {
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "F");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FF");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FFF");
+        CHECK(seq_impl.backward() == seq::status::DONE);
+        CHECK(result == "FFFB");
+    }
+}
+
+TEST_CASE("build seq with a backward step that takes a while to finish",
+          "[seq]") {
+    result = "";
+    attempt_count = 0;
+    seq::builder<> builder;
+
+    auto s = seq::step(
+        "S"_sc,
+        []() -> seq::status {
+            result += "F";
+            return seq::status::DONE;
+        },
+        []() -> seq::status {
+            if (attempt_count++ < 3) {
+                result += "B";
+                return seq::status::NOT_DONE;
+            } else {
+                return seq::status::DONE;
+            }
+        });
+
+    builder.add(s);
+
+    auto seq_impl = builder.topo_sort<seq::impl, 1>();
+
+    SECTION("backward can be called") {
+        CHECK(seq_impl.forward() == seq::status::DONE);
+        CHECK(result == "F");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FB");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FBB");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FBBB");
+        CHECK(seq_impl.backward() == seq::status::DONE);
+        CHECK(result == "FBBB");
+    }
+    SECTION(
+        "forward can be called, but will not proceed until backward is done") {
+        CHECK(seq_impl.forward() == seq::status::DONE);
+        CHECK(result == "F");
+        CHECK(seq_impl.backward() == seq::status::NOT_DONE);
+        CHECK(result == "FB");
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "FBB");
+        CHECK(seq_impl.forward() == seq::status::NOT_DONE);
+        CHECK(result == "FBBB");
+        CHECK(seq_impl.forward() == seq::status::DONE);
+        CHECK(result == "FBBBF");
+    }
 }
 
 TEST_CASE("build seq with three steps and run forwards and backwards",
           "[seq]") {
     result = "";
-
     seq::builder<> builder;
 
     auto s1 = seq::step(
@@ -399,10 +185,8 @@ TEST_CASE("build seq with three steps and run forwards and backwards",
 
     auto seq_impl = builder.topo_sort<seq::impl, 3>();
 
-    REQUIRE(seq_impl.forward() == seq::status::DONE);
-    REQUIRE(result == "F1F2F3");
-
-    REQUIRE(seq_impl.backward() == seq::status::DONE);
-    REQUIRE(result == "F1F2F3B3B2B1");
+    CHECK(seq_impl.forward() == seq::status::DONE);
+    CHECK(result == "F1F2F3");
+    CHECK(seq_impl.backward() == seq::status::DONE);
+    CHECK(result == "F1F2F3B3B2B1");
 }
-} // namespace


### PR DESCRIPTION
Building flows/sequences was not safe without right-sizing the output structure. Now it is safe:
- asserts when providing a structure that's too small
- uses only the initialized storage when providing a structure that's larger than necessary

Removed some duplicated seq tests and unused (/only test-supporting) seq constructors.