### PR TITLE
:art: Simplify message catalog types

### DIFF
--- a/include/log/catalog/catalog.hpp
+++ b/include/log/catalog/catalog.hpp
@@ -4,6 +4,11 @@
 
 #include <cstdint>
 
+namespace sc {
+template <typename...> struct args;
+template <typename, typename T, T...> struct undefined;
+} // namespace sc
+
 template <logging::level level, typename MessageString> struct message {};
 
 using string_id = std::uint32_t;


### PR DESCRIPTION
The types used to encode messages for overload in the catalog don't need to be instantiable. This simplifies what `strings.cpp` needs to include, and what the generation script needs to handle.