### PR TITLE
:bug: Fix issue #370

### DIFF
--- a/include/msg/handler_interface.hpp
+++ b/include/msg/handler_interface.hpp
@@ -5,7 +5,7 @@ template <typename MsgBaseT, typename... ExtraCallbackArgsT>
 struct handler_interface {
     virtual auto is_match(MsgBaseT const &msg) const -> bool = 0;
 
-    virtual void handle(MsgBaseT const &msg,
-                        ExtraCallbackArgsT... extra_args) const = 0;
+    virtual auto handle(MsgBaseT const &msg,
+                        ExtraCallbackArgsT... extra_args) const -> void = 0;
 };
 } // namespace msg

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -35,7 +35,7 @@ struct test_project {
 };
 } // namespace
 
-TEST_CASE("build handler", "[indexed_builder]") {
+TEST_CASE("build handler", "[handler_builder]") {
     cib::nexus<test_project> test_nexus{};
     test_nexus.init();
 

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -39,7 +39,7 @@ struct test_project {
 };
 } // namespace
 
-TEST_CASE("build handler", "[handler_builder]") {
+TEST_CASE("build handler", "[indexed_builder]") {
     cib::nexus<test_project> test_nexus{};
     test_nexus.init();
 
@@ -52,7 +52,8 @@ TEST_CASE("build handler", "[handler_builder]") {
     CHECK(not callback_success);
 }
 
-constexpr static auto test_callback_equals = msg::indexed_callback_t(
+namespace {
+constexpr auto test_callback_equals = msg::indexed_callback_t(
     "TestCallback"_sc, test_id_field::equal_to<0x80>,
     [](test_msg_t const &) { callback_success = true; });
 
@@ -61,34 +62,31 @@ struct test_project_equals {
         cib::config(cib::exports<test_service>,
                     cib::extend<test_service>(test_callback_equals));
 };
+} // namespace
 
-TEST_CASE("build handler field equal_to", "[handler_builder]") {
+TEST_CASE("build handler field equal_to", "[indexed_builder]") {
     cib::nexus<test_project_equals> test_nexus{};
     test_nexus.init();
 
     callback_success = false;
     cib::service<test_service>->handle(test_msg_t{test_id_field{0x80}});
-    REQUIRE(callback_success);
+    CHECK(callback_success);
 
     callback_success = false;
     cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
-    REQUIRE_FALSE(callback_success);
+    CHECK(not callback_success);
 }
 
-constexpr static auto test_callback_multi_field = msg::indexed_callback_t(
+namespace {
+constexpr auto test_callback_multi_field = msg::indexed_callback_t(
     "test_callback_multi_field"_sc,
-
     match::all(test_id_field::in<0x80, 0x42>, test_opcode_field::equal_to<1>),
-
     [](test_msg_t const &) { callback_success = true; });
 
-static inline bool callback_success_single_field;
+bool callback_success_single_field;
 
-constexpr static auto test_callback_single_field = msg::indexed_callback_t(
-    "test_callback_single_field"_sc,
-
-    match::all(test_id_field::equal_to<0x50>),
-
+constexpr auto test_callback_single_field = msg::indexed_callback_t(
+    "test_callback_single_field"_sc, match::all(test_id_field::equal_to<0x50>),
     [](test_msg_t const &) { callback_success_single_field = true; });
 
 struct test_project_multi_field {
@@ -97,8 +95,9 @@ struct test_project_multi_field {
                     cib::extend<test_service>(test_callback_multi_field,
                                               test_callback_single_field));
 };
+} // namespace
 
-TEST_CASE("build handler multi fields", "[handler_builder]") {
+TEST_CASE("build handler multi fields", "[indexed_builder]") {
     cib::nexus<test_project_multi_field> test_nexus{};
     test_nexus.init();
 
@@ -106,20 +105,46 @@ TEST_CASE("build handler multi fields", "[handler_builder]") {
     callback_success_single_field = false;
     cib::service<test_service>->handle(
         test_msg_t{test_id_field{0x80}, test_opcode_field{1}});
-    REQUIRE(callback_success);
-    REQUIRE_FALSE(callback_success_single_field);
+    CHECK(callback_success);
+    CHECK(not callback_success_single_field);
 
     callback_success = false;
     callback_success_single_field = false;
     cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
-    REQUIRE_FALSE(callback_success);
-    REQUIRE_FALSE(callback_success_single_field);
+    CHECK(not callback_success);
+    CHECK(not callback_success_single_field);
 
     // make sure an unconstrained field in a callback doesn't cause a mismatch
     callback_success = false;
     callback_success_single_field = false;
     cib::service<test_service>->handle(
         test_msg_t{test_id_field{0x50}, test_opcode_field{1}});
-    REQUIRE_FALSE(callback_success);
-    REQUIRE(callback_success_single_field);
+    CHECK(not callback_success);
+    CHECK(callback_success_single_field);
+}
+
+namespace {
+using partial_index_spec =
+    decltype(stdx::make_indexed_tuple<msg::get_field_type>(
+        msg::temp_index<test_id_field, 256, 32>{}));
+
+struct partially_indexed_test_service
+    : msg::indexed_service<partial_index_spec, test_msg_t> {};
+
+struct partially_indexed_test_project {
+    constexpr static auto config = cib::config(
+        cib::exports<partially_indexed_test_service>,
+        cib::extend<partially_indexed_test_service>(test_callback_multi_field));
+};
+} // namespace
+
+TEST_CASE("message matching partial index but not callback matcher",
+          "[indexed_builder]") {
+    cib::nexus<partially_indexed_test_project> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<partially_indexed_test_service>->handle(
+        test_msg_t{test_id_field{0x80}, test_opcode_field{2}});
+    CHECK(not callback_success);
 }


### PR DESCRIPTION
If a message matches on indexed fields, but doesn't match the full matcher in the callback, the callback shouldn't be called.