### PR TITLE
:construction_worker: Prevent publish GitHub Pages on Forks

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -9,7 +9,26 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
+  configure:
+    name: Configure Github Pages Publishing
+    runs-on: ubuntu-22.04
+    outputs:
+      enable_publish: ${{ steps.check.outputs.isfork == 'NO' }}
+    steps:
+      - id: check
+        name: Check if Fork
+        run: |
+          if [ "${{ github.repository }}" = "intel/compile-time-init-build" ]; then
+            echo "This is the main repository, **enabling publishing**" >> "$GITHUB_STEP_SUMMARY"
+            echo "isfork=NO" >> "$GITHUB_OUTPUT"
+          else
+            echo "This is a fork, **disabling publishing**" >> "$GITHUB_STEP_SUMMARY"
+            echo "isfork=YES" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: configure
+    name: Build Documentation
     runs-on: ubuntu-22.04
 
     steps:
@@ -32,6 +51,7 @@ jobs:
           cat ./generated-html/index.html
 
       - name: Setup github pages
+        if: needs.configure.outputs.enable_publish == 'true'
         uses: actions/configure-pages@v3
 
       - name: Upload artifacts
@@ -40,7 +60,9 @@ jobs:
           path: ./generated-html
 
   deploy:
-    needs: build
+    needs: [configure, build]
+    if: needs.configure.outputs.enable_publish == 'true'
+    name: Deploy Documentation
 
     permissions:
       contents: read


### PR DESCRIPTION
Added conditional check for the GitHub pages build to prevent the steps and jobs that interact with GitHub pages from running on any forked copy.

The actual documentation build step is still executed, just no publishing steps.

This caused an issue when I updated my fork because it would crash out trying to setup the GitHub pages, and then when I enabled that it would publish to my personal site, so I have disabled the publishing steps for all forks.

It might be possible to move the `Setup GitHub Pages` step up into the `configure` job, but not sure if that makes sense as I've not used these actions before.