### PR TITLE
:microscope: run length encoded indexed message handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(
 include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:fmtlib/fmt#f918289")
-add_versioned_package("gh:intel/cpp-std-extensions#016ff86")
+add_versioned_package("gh:intel/cpp-std-extensions#649678a")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#8d49b6d")
 
 add_library(cib INTERFACE)

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <lookup/entry.hpp>
+#include <lookup/input.hpp>
+#include <lookup/lookup.hpp>
+#include <match/ops.hpp>
+#include <msg/field_matchers.hpp>
+
+#include <stdx/bitset.hpp>
+#include <stdx/compiler.hpp>
+#include <stdx/cx_map.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace msg {
+template <typename T> using get_field_type = typename T::field_type;
+
+namespace detail {
+template <typename BuilderValue>
+CONSTEVAL auto for_each_callback(auto fn) -> void {
+    constexpr auto t = BuilderValue::value.callbacks;
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) -> void {
+        (fn(t[stdx::index<Is>], Is), ...);
+    }(std::make_index_sequence<t.size()>{});
+}
+
+} // namespace detail
+
+template <typename FieldType, std::size_t EntryCapacity,
+          std::size_t CallbackCapacity>
+struct temp_index {
+    using field_type = FieldType;
+
+    using value_t = stdx::bitset<CallbackCapacity, std::uint32_t>;
+    stdx::cx_map<uint32_t, value_t, EntryCapacity> entries{};
+    value_t default_value{};
+
+    constexpr auto operator[](auto key) -> auto & {
+        if (!entries.contains(key)) {
+            entries.put(key, value_t{});
+        }
+        return entries.get(key);
+    }
+
+    constexpr auto collect_defaults(std::size_t max) {
+        for (auto i = std::size_t{}; i < max; ++i) {
+            if (std::none_of(
+                    std::cbegin(entries), std::cend(entries),
+                    [&](auto const &entry) { return entry.value[i]; })) {
+                default_value.set(i);
+            }
+        }
+    }
+};
+
+template <template <typename, typename, typename, typename...> typename ParentT,
+          typename IndexSpec, typename CallbacksT, typename BaseMsgT,
+          typename... ExtraCallbackArgsT>
+struct indexed_builder_base {
+    CallbacksT callbacks;
+
+    template <typename... Ts> [[nodiscard]] constexpr auto add(Ts... ts) {
+        auto new_callbacks =
+            stdx::tuple_cat(callbacks, stdx::make_tuple(ts...));
+        using new_callbacks_t = decltype(new_callbacks);
+        return ParentT<IndexSpec, new_callbacks_t, BaseMsgT,
+                       ExtraCallbackArgsT...>{new_callbacks};
+    }
+
+    using callback_func_t = void (*)(BaseMsgT const &,
+                                     ExtraCallbackArgsT... args);
+
+    template <typename BuilderValue, std::size_t I>
+    constexpr static auto invoke_callback(BaseMsgT const &msg,
+                                          ExtraCallbackArgsT... args) {
+        // FIXME: incomplete message callback invocation...
+        //        1) bit_cast message argument
+        constexpr auto &orig_cb = BuilderValue::value.callbacks[stdx::index<I>];
+        constexpr auto cb = IndexSpec{}.apply([&]<typename... Indices>(
+                                                  Indices...) {
+            return remove_match_terms<typename Indices::field_type...>(orig_cb);
+        });
+        if (cb.matcher(msg)) {
+            CIB_INFO("Incoming message matched [{}], because [{}], executing "
+                     "callback",
+                     cb.name, orig_cb.matcher.describe());
+            cb.callable(msg, args...);
+        }
+    }
+
+    template <typename BuilderValue, std::size_t... Is>
+    static CONSTEVAL auto create_callback_array(std::index_sequence<Is...>)
+        -> std::array<callback_func_t, BuilderValue::value.callbacks.size()> {
+        return {invoke_callback<BuilderValue, Is>...};
+    }
+
+    template <typename BuilderValue>
+    static CONSTEVAL auto create_temp_indices() {
+        IndexSpec indices{};
+        std::size_t count{};
+        stdx::for_each(
+            [&](auto callback) {
+                build_index(
+                    callback.matcher,
+                    [&]<typename Field, typename V>(std::size_t idx,
+                                                    V expected_value) {
+                        if constexpr (stdx::contains_type<IndexSpec, Field>) {
+                            stdx::get<Field>(indices)[expected_value].set(idx);
+                        }
+                    },
+                    count);
+            },
+            BuilderValue::value.callbacks);
+        stdx::for_each(
+            [n = ++count](auto &index) { index.collect_defaults(n); }, indices);
+        return indices;
+    }
+};
+
+} // namespace msg

--- a/include/msg/detail/indexed_handler_common.hpp
+++ b/include/msg/detail/indexed_handler_common.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <log/log.hpp>
+#include <msg/handler_interface.hpp>
+
+#include <stdx/compiler.hpp>
+
+namespace msg {
+
+template <typename Field, typename Lookup> struct index {
+    Lookup field_lookup;
+
+    CONSTEVAL index(Field, Lookup field_lookup_arg)
+        : field_lookup{field_lookup_arg} {}
+
+    constexpr auto operator()(auto const &data) const {
+        return field_lookup[Field::extract(data)];
+    }
+};
+
+template <typename BaseMsgT, typename... ExtraCallbackArgsT>
+struct callback_args_t {};
+
+template <typename BaseMsgT, typename... ExtraCallbackArgsT>
+constexpr callback_args_t<BaseMsgT, ExtraCallbackArgsT...> callback_args{};
+
+template <typename IndexT, typename CallbacksT, typename BaseMsgT,
+          typename... ExtraCallbackArgsT>
+struct indexed_handler : handler_interface<BaseMsgT, ExtraCallbackArgsT...> {
+    using callback_func_t = void (*)(BaseMsgT const &,
+                                     ExtraCallbackArgsT... args);
+
+    IndexT index;
+    CallbacksT callback_entries;
+
+    constexpr explicit indexed_handler(
+        callback_args_t<BaseMsgT, ExtraCallbackArgsT...>, IndexT new_index,
+        CallbacksT new_callbacks)
+        : index{new_index}, callback_entries{new_callbacks} {}
+
+    auto is_match(BaseMsgT const &msg) const -> bool final {
+        return not index(msg).none();
+    }
+
+    void handle(BaseMsgT const &msg, ExtraCallbackArgsT... args) const final {
+        auto const callback_candidates = index(msg);
+
+        for_each([&](auto i) { callback_entries[i](msg, args...); },
+                 callback_candidates);
+
+        if (callback_candidates.none()) {
+            CIB_ERROR("None of the registered callbacks claimed this message.");
+        }
+    }
+};
+
+} // namespace msg

--- a/include/msg/detail/rle_codec.hpp
+++ b/include/msg/detail/rle_codec.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#include <lookup/entry.hpp>
+#include <lookup/input.hpp>
+
+#include <stdx/bitset.hpp>
+#include <stdx/compiler.hpp>
+#include <stdx/cx_map.hpp>
+#include <stdx/cx_vector.hpp>
+#include <stdx/tuple.hpp>
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <numeric>
+#include <span>
+
+namespace msg::detail {
+
+template <std::size_t N> struct smallest_storage {
+    // select a minimum sized type for indexing into the RLE data blob
+    static CONSTEVAL auto select_index_storage() {
+        if constexpr (N <= std::numeric_limits<std::uint8_t>::max()) {
+            return std::uint8_t{};
+        } else if constexpr (N <= std::numeric_limits<std::uint16_t>::max()) {
+            return std::uint16_t{};
+        } else if constexpr (N <= std::numeric_limits<std::uint32_t>::max()) {
+            return std::uint32_t{};
+        } else {
+            return std::size_t{};
+        }
+    }
+
+    using type = decltype(select_index_storage());
+};
+
+template <std::size_t N>
+using smallest_storage_type = typename smallest_storage<N>::type;
+
+template <typename BitSetType> struct rle_codec {
+    using bitset_type = BitSetType;
+    constexpr static auto num_bits = BitSetType::size();
+
+    // assume worst case of each bitmap being alternating bit values
+    using max_rle_data_type = stdx::cx_vector<std::byte, num_bits * 2>;
+
+    constexpr static auto encode(bitset_type const &bitset)
+        -> max_rle_data_type {
+        max_rle_data_type data{};
+        std::size_t count{0};
+        bool last{false};
+        for (std::size_t bit{0}; bit < num_bits; ++bit) {
+            if (bitset[bit] != last) {
+                data.push_back(static_cast<std::byte>(count));
+                last = !last;
+                count = 1;
+            } else {
+                if (++count > 255) {
+                    // we have overflowed the max byte. we need to
+                    // reset our count and indicate there are no alternate bits
+                    data.push_back(std::byte{255});
+                    data.push_back(std::byte{0});
+                    count = 1;
+                }
+            }
+        }
+        // final byte
+        data.push_back(static_cast<std::byte>(count));
+        return data;
+    }
+
+    constexpr static auto decode(std::byte const *rle_data) -> bitset_type {
+        bitset_type result{};
+
+        std::size_t bit{0};
+        bool bit_val{false};
+
+        // accumulate the correct total number of bits
+        while (bit < num_bits) {
+            // get the next number of consecutive bits
+            auto cur_bits = static_cast<std::size_t>(*rle_data++);
+            if (bit_val) {
+                // write cur_bits of 1s
+                while (cur_bits-- > 0) {
+                    result.set(bit++);
+                }
+            } else {
+                // skip cur_bits of 0s
+                bit += cur_bits;
+            }
+            bit_val = !bit_val;
+        }
+
+        return result;
+    }
+};
+
+} // namespace msg::detail

--- a/include/msg/indexed_builder.hpp
+++ b/include/msg/indexed_builder.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
 #include <log/log.hpp>
-#include <lookup/entry.hpp>
-#include <lookup/input.hpp>
-#include <lookup/lookup.hpp>
-#include <match/ops.hpp>
-#include <msg/field_matchers.hpp>
-#include <msg/indexed_callback.hpp>
+#include <msg/detail/indexed_builder_common.hpp>
 #include <msg/indexed_handler.hpp>
 
 #include <stdx/bitset.hpp>
@@ -21,107 +16,14 @@
 #include <type_traits>
 
 namespace msg {
-template <typename T> using get_field_type = typename T::field_type;
-
-namespace detail {
-template <typename BuilderValue>
-CONSTEVAL auto for_each_callback(auto fn) -> void {
-    constexpr auto t = BuilderValue::value.callbacks;
-    [&]<std::size_t... Is>(std::index_sequence<Is...>) -> void {
-        (fn(t[stdx::index<Is>], Is), ...);
-    }(std::make_index_sequence<t.size()>{});
-}
-} // namespace detail
-
-template <typename FieldType, std::size_t EntryCapacity,
-          std::size_t CallbackCapacity>
-struct temp_index {
-    using field_type = FieldType;
-
-    using value_t = stdx::bitset<CallbackCapacity, std::uint32_t>;
-    stdx::cx_map<uint32_t, value_t, EntryCapacity> entries{};
-    value_t default_value{};
-
-    constexpr auto operator[](auto key) -> auto & {
-        if (!entries.contains(key)) {
-            entries.put(key, value_t{});
-        }
-        return entries.get(key);
-    }
-
-    constexpr auto collect_defaults(std::size_t max) {
-        for (auto i = std::size_t{}; i < max; ++i) {
-            if (std::none_of(
-                    std::cbegin(entries), std::cend(entries),
-                    [&](auto const &entry) { return entry.value[i]; })) {
-                default_value.set(i);
-            }
-        }
-    }
-};
-
 // TODO: needs index configuration
 template <typename IndexSpec, typename CallbacksT, typename BaseMsgT,
           typename... ExtraCallbackArgsT>
-struct indexed_builder {
-    CallbacksT callbacks;
-
-    template <typename... Ts> [[nodiscard]] constexpr auto add(Ts... ts) {
-        auto new_callbacks =
-            stdx::tuple_cat(callbacks, stdx::make_tuple(ts...));
-        using new_callbacks_t = decltype(new_callbacks);
-        return indexed_builder<IndexSpec, new_callbacks_t, BaseMsgT,
-                               ExtraCallbackArgsT...>{new_callbacks};
-    }
-
-    using callback_func_t = void (*)(BaseMsgT const &,
-                                     ExtraCallbackArgsT... args);
-
-    template <typename BuilderValue, std::size_t I>
-    constexpr static auto invoke_callback(BaseMsgT const &msg,
-                                          ExtraCallbackArgsT... args) {
-        // FIXME: incomplete message callback invocation...
-        //        1) bit_cast message argument
-        constexpr auto &orig_cb = BuilderValue::value.callbacks[stdx::index<I>];
-        constexpr auto cb = IndexSpec{}.apply([&]<typename... Indices>(
-                                                  Indices...) {
-            return remove_match_terms<typename Indices::field_type...>(orig_cb);
-        });
-        if (cb.matcher(msg)) {
-            CIB_INFO("Incoming message matched [{}], because [{}], executing "
-                     "callback",
-                     cb.name, orig_cb.matcher.describe());
-            cb.callable(msg, args...);
-        }
-    }
-
-    template <typename BuilderValue, std::size_t... Is>
-    static CONSTEVAL auto create_callback_array(std::index_sequence<Is...>)
-        -> std::array<callback_func_t, BuilderValue::value.callbacks.size()> {
-        return {invoke_callback<BuilderValue, Is>...};
-    }
-
-    template <typename BuilderValue>
-    static CONSTEVAL auto create_temp_indices() {
-        IndexSpec indices{};
-        std::size_t count{};
-        stdx::for_each(
-            [&](auto callback) {
-                build_index(
-                    callback.matcher,
-                    [&]<typename Field, typename V>(std::size_t idx,
-                                                    V expected_value) {
-                        if constexpr (stdx::contains_type<IndexSpec, Field>) {
-                            stdx::get<Field>(indices)[expected_value].set(idx);
-                        }
-                    },
-                    count);
-            },
-            BuilderValue::value.callbacks);
-        stdx::for_each(
-            [n = ++count](auto &index) { index.collect_defaults(n); }, indices);
-        return indices;
-    }
+struct indexed_builder
+    : indexed_builder_base<indexed_builder, IndexSpec, CallbacksT, BaseMsgT,
+                           ExtraCallbackArgsT...> {
+    using base_t = indexed_builder_base<indexed_builder, IndexSpec, CallbacksT,
+                                        BaseMsgT, ExtraCallbackArgsT...>;
 
     template <typename I>
     static CONSTEVAL auto get_default_value(auto const &indices) {
@@ -141,7 +43,7 @@ struct indexed_builder {
         struct {
             CONSTEVAL auto operator()() const noexcept {
                 constexpr IndexSpec indices =
-                    create_temp_indices<BuilderValue>();
+                    base_t::template create_temp_indices<BuilderValue>();
                 using key_type =
                     typename decltype(get<I>(indices).entries)::key_type;
                 using value_type = decltype(get<I>(indices).default_value);
@@ -154,14 +56,14 @@ struct indexed_builder {
         } val;
         return val;
     }
-
     template <typename BuilderValue> static CONSTEVAL auto build() {
         constexpr auto make_index_lookup =
             []<typename I, std::size_t... Es>(std::index_sequence<Es...>) {
                 return lookup::make(make_input<BuilderValue, I, Es...>());
             };
 
-        constexpr IndexSpec temp_indices = create_temp_indices<BuilderValue>();
+        constexpr IndexSpec temp_indices =
+            base_t::template create_temp_indices<BuilderValue>();
         auto const entry_index_seq = [&]<typename I>() {
             return std::make_index_sequence<
                 get<I>(temp_indices).entries.size()>{};
@@ -176,9 +78,10 @@ struct indexed_builder {
             });
 
         constexpr auto num_callbacks = BuilderValue::value.callbacks.size();
-        constexpr std::array<callback_func_t, num_callbacks> callback_array =
-            create_callback_array<BuilderValue>(
-                std::make_index_sequence<num_callbacks>{});
+        constexpr std::array<typename base_t::callback_func_t, num_callbacks>
+            callback_array =
+                base_t::template create_callback_array<BuilderValue>(
+                    std::make_index_sequence<num_callbacks>{});
 
         return indexed_handler{
             callback_args_t<BaseMsgT, ExtraCallbackArgsT...>{}, baked_indices,

--- a/include/msg/indexed_handler.hpp
+++ b/include/msg/indexed_handler.hpp
@@ -1,22 +1,10 @@
 #pragma once
 
-#include <log/log.hpp>
-#include <msg/handler_interface.hpp>
+#include <msg/detail/indexed_handler_common.hpp>
 
 #include <stdx/compiler.hpp>
 
 namespace msg {
-
-template <typename Field, typename Lookup> struct index {
-    Lookup field_lookup;
-
-    CONSTEVAL index(Field, Lookup field_lookup_arg)
-        : field_lookup{field_lookup_arg} {}
-
-    constexpr auto operator()(auto const &data) const {
-        return field_lookup[Field::extract(data)];
-    }
-};
 
 template <typename... IndicesT> struct indices : IndicesT... {
     CONSTEVAL explicit indices(IndicesT... index_args)
@@ -24,42 +12,6 @@ template <typename... IndicesT> struct indices : IndicesT... {
 
     constexpr auto operator()(auto const &data) const {
         return (this->IndicesT::operator()(data) & ...);
-    }
-};
-
-template <typename BaseMsgT, typename... ExtraCallbackArgsT>
-struct callback_args_t {};
-
-template <typename BaseMsgT, typename... ExtraCallbackArgsT>
-constexpr callback_args_t<BaseMsgT, ExtraCallbackArgsT...> callback_args{};
-
-template <typename IndexT, typename CallbacksT, typename BaseMsgT,
-          typename... ExtraCallbackArgsT>
-struct indexed_handler : handler_interface<BaseMsgT, ExtraCallbackArgsT...> {
-    using callback_func_t = void (*)(BaseMsgT const &,
-                                     ExtraCallbackArgsT... args);
-
-    IndexT index;
-    CallbacksT callback_entries;
-
-    constexpr explicit indexed_handler(
-        callback_args_t<BaseMsgT, ExtraCallbackArgsT...>, IndexT new_index,
-        CallbacksT new_callbacks)
-        : index{new_index}, callback_entries{new_callbacks} {}
-
-    auto is_match(BaseMsgT const &msg) const -> bool final {
-        return not index(msg).none();
-    }
-
-    void handle(BaseMsgT const &msg, ExtraCallbackArgsT... args) const final {
-        auto const callback_candidates = index(msg);
-
-        for_each([&](auto i) { callback_entries[i](msg, args...); },
-                 callback_candidates);
-
-        if (callback_candidates.none()) {
-            CIB_ERROR("None of the registered callbacks claimed this message.");
-        }
     }
 };
 

--- a/include/msg/rle_indexed_builder.hpp
+++ b/include/msg/rle_indexed_builder.hpp
@@ -1,0 +1,394 @@
+#pragma once
+
+#include <log/log.hpp>
+#include <msg/detail/indexed_builder_common.hpp>
+#include <msg/detail/rle_codec.hpp>
+#include <msg/rle_indexed_handler.hpp>
+
+#include <stdx/bitset.hpp>
+#include <stdx/compiler.hpp>
+#include <stdx/cx_map.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace msg {
+
+namespace detail {
+
+// Used to build all the individual RLE encoded bitset sequences
+// for a given index, including the default_value.
+template <typename FieldType, typename KeyType, typename BitSetType,
+          std::size_t NumBitSets>
+struct rle_index_raw_encoding {
+    using field_type = FieldType;
+    using key_type = KeyType;
+    using bitset_type = BitSetType;
+    using codec_type = rle_codec<BitSetType>;
+    using max_rle_data_type = typename codec_type::max_rle_data_type;
+
+    constexpr static auto num_bits = codec_type::num_bits;
+    constexpr static auto num_bitsets = NumBitSets;
+
+    // we want to store RLE data for each bitmap, indexed by the index key
+    using rle_index_data_type =
+        stdx::cx_map<key_type, max_rle_data_type, num_bitsets>;
+
+    constexpr explicit rle_index_raw_encoding(
+        BitSetType const &the_default_value)
+        : default_value{codec_type::encode(the_default_value)} {}
+
+    max_rle_data_type default_value;
+    rle_index_data_type rle_index{};
+};
+
+// Storage for an offset into an RLE encoded blob of a specific bitset
+// for the given field type. OffsetType is the smallest type needed to
+// offset into the full RLE blob.
+//
+// Note: the LockType is used to ensure that rle_index and rle_storage match
+template <typename LockType, typename FieldType, typename BitSetType,
+          typename OffsetType>
+struct rle_index {
+    using field_type = FieldType;
+    using bitset_type = BitSetType;
+    using offset_type = OffsetType;
+
+    offset_type offset;
+
+    constexpr rle_index() = default;
+    constexpr explicit rle_index(offset_type the_offset) : offset{the_offset} {}
+};
+
+// Storage for all the RLE encoded data with an accessor to decode an
+// rle_index into the appropriate bitset
+//
+// Note: the LockType is used to ensure that rle_index and rle_storage match
+template <typename LockType, std::size_t DataLength> struct rle_storage {
+    using storage_type = std::array<std::byte, DataLength>;
+
+    // get a bitset from an rle_index
+    template <typename FieldType, typename BitSetType, typename OffsetType>
+    constexpr auto
+    get(rle_index<LockType, FieldType, BitSetType, OffsetType> idx) const
+        -> BitSetType {
+        using codec_type = rle_codec<BitSetType>;
+        return codec_type::decode(std::next(data.begin(), idx.offset));
+    }
+
+    storage_type data;
+};
+
+// Build the encoded RLE data with a max lenght of MaxDataLen
+// Take the opportunity to reuse byte sequences where possible.
+template <std::size_t MaxDataLength> struct rle_storage_builder {
+    using offset_type = detail::smallest_storage_type<MaxDataLength>;
+
+    // add the given data into the storage, attempting to reuse previous
+    template <typename Data>
+    constexpr auto add(Data const &data) -> offset_type {
+        // check for existing matching data to reuse
+        auto found = std::search(std::begin(storage), std::end(storage),
+                                 std::begin(data), std::end(data));
+        if (found != storage.end()) {
+            // reuse existing data location
+            return static_cast<offset_type>(
+                std::distance(std::begin(storage), found));
+        }
+
+        // grab the current location and copy into the storage
+        auto const location = storage_location;
+
+        auto const next_location =
+            std::copy(std::begin(data), std::end(data),
+                      std::next(std::begin(storage), storage_location));
+
+        storage_location = std::distance(std::begin(storage), next_location);
+
+        return static_cast<offset_type>(location);
+    }
+
+    // build a temp index of key -> offset and collect all rle data
+    // into the storage builder
+    template <typename OffsetT, typename Idx>
+    constexpr auto add_index(Idx idx) {
+        constexpr auto num_entries = idx.num_bitsets;
+
+        // needs to support stdx::make_indexed_tuple<get_field_type>
+        struct storage_lookup_index {
+            using field_type [[maybe_unused]] = typename Idx::field_type;
+            using bitset_type [[maybe_unused]] = typename Idx::bitset_type;
+            using key_type = typename Idx::key_type;
+            using entry_type = lookup::entry<key_type, OffsetT>;
+
+            constexpr explicit storage_lookup_index(OffsetT the_default_value)
+                : default_value{the_default_value} {}
+
+            OffsetT default_value;
+            std::array<entry_type, num_entries> entries{};
+        };
+
+        storage_lookup_index result{add(idx.default_value)};
+
+        std::transform(std::begin(idx.rle_index), std::end(idx.rle_index),
+                       std::begin(result.entries), [&](auto const &kvp) {
+                           return lookup::entry{kvp.key, add(kvp.value)};
+                       });
+
+        return result;
+    }
+
+    [[nodiscard]] constexpr auto size() const -> std::size_t {
+        return static_cast<std::size_t>(storage_location);
+    }
+
+    // build a truncated copy of the storage accounting for the savings of
+    // reusing bitset RLE patterns
+    template <std::size_t FinalSize>
+    constexpr auto truncate() const -> std::array<std::byte, FinalSize> {
+        std::array<std::byte, FinalSize> result;
+        std::copy_n(std::begin(storage), FinalSize, std::begin(result));
+        return result;
+    }
+
+    std::array<std::byte, MaxDataLength> storage{};
+    std::ptrdiff_t storage_location{};
+};
+
+} // namespace detail
+
+// TODO: needs index configuration
+template <typename IndexSpec, typename CallbacksT, typename BaseMsgT,
+          typename... ExtraCallbackArgsT>
+struct rle_indexed_builder
+    : indexed_builder_base<rle_indexed_builder, IndexSpec, CallbacksT, BaseMsgT,
+                           ExtraCallbackArgsT...> {
+    using base_t =
+        indexed_builder_base<rle_indexed_builder, IndexSpec, CallbacksT,
+                             BaseMsgT, ExtraCallbackArgsT...>;
+
+    // encode the index I into a rle_index_raw_encoding
+    template <typename BuilderValue, typename Idx>
+    static CONSTEVAL auto raw_encode_index() {
+        constexpr auto temp_indices =
+            base_t::template create_temp_indices<BuilderValue>();
+
+        using field_type = typename Idx::field_type;
+        using bitset_type = decltype(get<Idx>(temp_indices).default_value);
+        using index_key_type =
+            typename decltype(get<Idx>(temp_indices).entries)::key_type;
+        constexpr auto num_bitsets = get<Idx>(temp_indices).entries.size();
+
+        using result_type =
+            detail::rle_index_raw_encoding<field_type, index_key_type,
+                                           bitset_type, num_bitsets>;
+        using codec_type = typename result_type::codec_type;
+
+        auto const default_value = get<Idx>(temp_indices).default_value;
+
+        result_type result{default_value};
+
+        for (auto const &kvp : get<Idx>(temp_indices).entries) {
+            auto const key = kvp.key;
+            // merge the index value with the default to ensure that
+            // unfiltered callbacks are always called.
+            auto const bs = kvp.value | default_value;
+            result.rle_index.put(key, codec_type::encode(bs));
+        }
+
+        return result;
+    }
+
+    // build a full index with RLE storage. The storage here is
+    // allocated worst case, but is likely smaller due to reuse of data.
+    // It will be shrunk and transformed later
+    template <typename BuilderValue, std::size_t MaxRleLength>
+    static CONSTEVAL auto make_full_rle_index() {
+        constexpr auto temp_indices =
+            base_t::template create_temp_indices<BuilderValue>();
+
+        constexpr auto all_rle_data =
+            temp_indices.apply([]<typename... I>(I...) {
+                // build a replacement tuple of indices, but with raw RLE
+                // encoding
+                return stdx::make_indexed_tuple<get_field_type>(
+                    raw_encode_index<BuilderValue, I>()...);
+            });
+
+        return all_rle_data.apply([]<typename... I>(I... indices) {
+            using rle_storage_type = detail::rle_storage_builder<MaxRleLength>;
+
+            using initial_offset_type =
+                typename detail::rle_storage_builder<MaxRleLength>::offset_type;
+
+            rle_storage_type storage{};
+
+            auto full_encoded_indices =
+                stdx::make_indexed_tuple<get_field_type>(
+                    storage.template add_index<initial_offset_type>(
+                        indices)...);
+
+            struct full_encoded_result {
+                decltype(full_encoded_indices) lookup;
+                rle_storage_type storage;
+            };
+
+            return full_encoded_result{full_encoded_indices, storage};
+        });
+    }
+
+    template <typename LockType, std::size_t FinalRleLength, typename Idx>
+    constexpr static auto re_encode_index(Idx idx) {
+        // idx is a storage_lookup_index from above
+
+        // recalculate the offset type based on the final rle length
+        // after reusing RLE patterns
+        using offset_type = detail::smallest_storage_type<FinalRleLength>;
+
+        constexpr auto num_entries = idx.entries.size();
+
+        // needs to support stdx::make_indexed_tuple<get_field_type>
+        struct field_lookup_index {
+            using field_type [[maybe_unused]] = typename Idx::field_type;
+            using bitset_type [[maybe_unused]] = typename Idx::bitset_type;
+            using key_type [[maybe_unused]] = typename Idx::key_type;
+            using index_type [[maybe_unused]] =
+                detail::rle_index<LockType, field_type, bitset_type,
+                                  offset_type>;
+
+            constexpr explicit field_lookup_index(index_type the_default_value)
+                : lookup_input{the_default_value} {}
+
+            lookup::input<key_type, index_type, num_entries> lookup_input;
+        };
+
+        using index_type = typename field_lookup_index::index_type;
+
+        // initialise the resulting index and then transform
+        // the passed in index into the final form using the correct
+        // rle_index proxy objects
+        field_lookup_index result{index_type{idx.default_value}};
+        std::transform(
+            std::begin(idx.entries), std::end(idx.entries),
+            std::begin(result.lookup_input.entries), [&](auto const &entry) {
+                return lookup::entry{entry.key_, index_type{entry.value_}};
+            });
+
+        return result;
+    }
+
+    template <typename LockType, std::size_t FinalRleLength, typename FullRleT>
+    static CONSTEVAL auto
+    shrink_and_transform_encoded_result(FullRleT const &full_rle) {
+        // remap the indices into the final lookup type ready to be encoded
+        // into the message decoding indices
+        auto re_encoded_lookup =
+            full_rle.lookup.apply([]<typename... I>(I... indices) {
+                return stdx::make_indexed_tuple<get_field_type>(
+                    re_encode_index<LockType, FinalRleLength>(indices)...);
+            });
+
+        struct encoded_result {
+            decltype(re_encoded_lookup) lookup;
+            detail::rle_storage<LockType, FinalRleLength> storage;
+        };
+
+        return encoded_result{
+            re_encoded_lookup,
+            full_rle.storage.template truncate<FinalRleLength>()};
+    }
+
+    template <typename BuilderValue> static CONSTEVAL auto make_rle_index() {
+        // lock the rle_index and rle_storage types for this BuilderValue
+        // so that they can't be misused by other instances.
+        struct access_lock {};
+
+        constexpr auto temp_indices =
+            base_t::template create_temp_indices<BuilderValue>();
+
+        constexpr auto all_rle_data =
+            temp_indices.apply([]<typename... I>(I...) {
+                // build a replacement tuple of indices, but with raw RLE
+                // encoding
+                return stdx::make_indexed_tuple<get_field_type>(
+                    raw_encode_index<BuilderValue, I>()...);
+            });
+
+        // compute the total length of all RLE data which we will use as
+        // the worst case encoding length
+        constexpr auto total_rle_data_length =
+            all_rle_data.apply([=]<typename... I>(I... indices) -> std::size_t {
+                // count all the lengths of the rle encoded values for the
+                // index
+                constexpr auto count_index_len = []<typename Idx>(Idx idx) {
+                    return std::accumulate(std::begin(idx), std::end(idx),
+                                           std::size_t{0},
+                                           [](auto sum, auto &kvp) {
+                                               return sum + kvp.value.size();
+                                           });
+                };
+
+                // sum all the lengths of the rle index data and the lengths
+                // of the default values.
+                return (count_index_len(indices.rle_index) + ...) +
+                       (indices.default_value.size() + ...);
+            });
+
+        // build the combined RLE data for all bitsets, and a tuple of
+        // lookup indices into that RLE data for each index and key in that
+        // index.
+        constexpr auto full_encoded_rle_indices =
+            make_full_rle_index<BuilderValue, total_rle_data_length>();
+
+        constexpr auto final_rle_length =
+            full_encoded_rle_indices.storage.size();
+
+        // shrink the storage and transform into lookup ready index types
+        return shrink_and_transform_encoded_result<access_lock,
+                                                   final_rle_length>(
+            full_encoded_rle_indices);
+    }
+
+    template <typename BuilderValue, typename I>
+    static CONSTEVAL auto make_rle_input() {
+        struct {
+            CONSTEVAL auto operator()() const noexcept {
+                constexpr auto rle = make_rle_index<BuilderValue>();
+                return get<typename I::field_type>(rle.lookup).lookup_input;
+            }
+            using cx_value_t [[maybe_unused]] = void;
+        } val;
+        return val;
+    }
+
+    template <typename BuilderValue> static CONSTEVAL auto build() {
+        constexpr auto temp_indices =
+            base_t::template create_temp_indices<BuilderValue>();
+
+        constexpr auto rle = make_rle_index<BuilderValue>();
+
+        constexpr auto baked_indices =
+            temp_indices.apply([=]<typename... I>(I...) {
+                return rle_indices{
+                    rle.storage,
+                    index{typename I::field_type{},
+                          lookup::make(make_rle_input<BuilderValue, I>())}...};
+            });
+
+        constexpr auto num_callbacks = BuilderValue::value.callbacks.size();
+
+        constexpr auto callback_array =
+            base_t::template create_callback_array<BuilderValue>(
+                std::make_index_sequence<num_callbacks>{});
+
+        return indexed_handler{
+            callback_args_t<BaseMsgT, ExtraCallbackArgsT...>{}, baked_indices,
+            callback_array};
+    }
+};
+
+} // namespace msg

--- a/include/msg/rle_indexed_handler.hpp
+++ b/include/msg/rle_indexed_handler.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <msg/detail/indexed_handler_common.hpp>
+
+#include <stdx/compiler.hpp>
+
+namespace msg {
+
+template <typename RleStorageT, typename... IndicesT>
+struct rle_indices : IndicesT... {
+    CONSTEVAL explicit rle_indices(RleStorageT data, IndicesT... index_args)
+        : IndicesT{index_args}..., storage{data} {}
+
+    constexpr auto operator()(auto const &data) const {
+        // TODO: efficient bitand that doesn't need to materialise full bitset
+
+        // use the index to decode the bitset from storage
+        return (storage.get(this->IndicesT::operator()(data)) & ...);
+    }
+
+    // index entries will map into this storage to decode RLE data
+    RleStorageT storage;
+};
+
+} // namespace msg

--- a/include/msg/rle_indexed_service.hpp
+++ b/include/msg/rle_indexed_service.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cib/builder_meta.hpp>
+#include <msg/handler_interface.hpp>
+#include <msg/rle_indexed_builder.hpp>
+
+#include <stdx/tuple.hpp>
+
+namespace msg {
+template <typename IndexSpec, typename MsgBaseT, typename... ExtraCallbackArgsT>
+struct rle_indexed_service
+    : cib::builder_meta<
+          rle_indexed_builder<IndexSpec, stdx::tuple<>, MsgBaseT,
+                              ExtraCallbackArgsT...>,
+          handler_interface<MsgBaseT, ExtraCallbackArgsT...> const *> {};
+} // namespace msg

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_tests(
     match/simplify_not
     match/simplify_or
     match/sum_of_products
+    msg/detail/rle_codec
     msg/disjoint_field
     msg/field
     msg/handler
@@ -46,6 +47,7 @@ add_tests(
     msg/indexed_builder
     msg/indexed_callback
     msg/indexed_handler
+    msg/rle_indexed_builder
     msg/message
     sc/format
     sc/string_constant

--- a/test/msg/detail/rle_codec.cpp
+++ b/test/msg/detail/rle_codec.cpp
@@ -1,0 +1,82 @@
+#include <msg/detail/rle_codec.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+#include <array>
+#include <cstddef>
+
+using Catch::Matchers::RangeEquals;
+
+namespace {
+auto operator"" _b(unsigned long long int v) -> std::byte {
+    return static_cast<std::byte>(v);
+}
+} // namespace
+
+namespace msg::detail {
+
+// Encoding starts with number of zeros (0-255)
+// followed by number of ones (0-255)
+// and repeats.
+
+TEST_CASE("rle_codec can encode all zeros", "[rle_codec]") {
+    using bs = stdx::bitset<10>;
+    using codec = rle_codec<bs>;
+
+    CHECK_THAT(codec::encode(bs{}),
+               RangeEquals(std::to_array<std::byte>({10_b})));
+}
+
+TEST_CASE("rle_codec can encode all ones", "[rle_codec]") {
+    using bs = stdx::bitset<12>;
+    using codec = rle_codec<bs>;
+
+    CHECK_THAT(codec::encode(~bs{}),
+               RangeEquals(std::to_array<std::byte>({0_b, 12_b})));
+}
+
+TEST_CASE("rle_codec can encode all zeros for large bit count", "[rle_codec]") {
+    using bs = stdx::bitset<512>;
+    using codec = rle_codec<bs>;
+
+    CHECK_THAT(codec::encode(bs{}), RangeEquals(std::to_array<std::byte>(
+                                        {255_b, 0_b, 255_b, 0_b, 2_b})));
+}
+
+TEST_CASE("rle_codec can encode all ones for large bit count", "[rle_codec]") {
+    using bs = stdx::bitset<512>;
+    using codec = rle_codec<bs>;
+
+    CHECK_THAT(codec::encode(~bs{}), RangeEquals(std::to_array<std::byte>(
+                                         {0_b, 255_b, 0_b, 255_b, 0_b, 2_b})));
+}
+
+TEST_CASE("rle_codec can encode alternating bits", "[rle_codec]") {
+    using bs = stdx::bitset<8>;
+    using codec = rle_codec<bs>;
+
+    CHECK_THAT(codec::encode(bs{stdx::place_bits, 0, 2, 4, 6}),
+               RangeEquals(std::to_array<std::byte>(
+                   {0_b, 1_b, 1_b, 1_b, 1_b, 1_b, 1_b, 1_b, 1_b})));
+
+    CHECK_THAT(codec::encode(bs{stdx::place_bits, 1, 3, 5, 7}),
+               RangeEquals(std::to_array<std::byte>(
+                   {1_b, 1_b, 1_b, 1_b, 1_b, 1_b, 1_b, 1_b})));
+}
+
+TEST_CASE("rle_codec can decode", "[rle_codec]") {
+    using bs = stdx::bitset<500>;
+    using codec = rle_codec<bs>;
+    auto const b1 = bs{stdx::place_bits, 1, 2, 3, 499};
+    auto const b2 = bs{stdx::place_bits, 2, 3, 5, 7, 11, 13, 17, 400};
+    auto const bzero = bs{};
+    auto const bone = ~bs{};
+
+    CHECK(codec::decode(codec::encode(b1).cbegin()) == b1);
+    CHECK(codec::decode(codec::encode(b2).cbegin()) == b2);
+    CHECK(codec::decode(codec::encode(bzero).cbegin()) == bzero);
+    CHECK(codec::decode(codec::encode(bone).cbegin()) == bone);
+}
+
+} // namespace msg::detail

--- a/test/msg/rle_indexed_builder.cpp
+++ b/test/msg/rle_indexed_builder.cpp
@@ -1,0 +1,184 @@
+#include <cib/cib.hpp>
+#include <log/fmt/logger.hpp>
+#include <match/ops.hpp>
+#include <msg/field.hpp>
+#include <msg/indexed_callback.hpp>
+#include <msg/message.hpp>
+#include <msg/rle_indexed_service.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+
+namespace {
+using test_id_field =
+    msg::field<decltype("test_id_field"_sc), 0, 31, 24, std::uint32_t>;
+using test_opcode_field =
+    msg::field<decltype("test_opcode_field"_sc), 0, 15, 0, std::uint32_t>;
+using test_field_2 =
+    msg::field<decltype("test_field_2"_sc), 1, 23, 16, std::uint32_t>;
+using test_field_3 =
+    msg::field<decltype("test_field_3"_sc), 1, 15, 0, std::uint32_t>;
+
+using test_msg_t =
+    msg::message_base<decltype("test_msg"_sc), 2, test_id_field,
+                      test_opcode_field, test_field_2, test_field_3>;
+
+using index_spec = decltype(stdx::make_indexed_tuple<msg::get_field_type>(
+    msg::temp_index<test_id_field, 256, 32>{},
+    msg::temp_index<test_opcode_field, 256, 32>{}));
+
+struct test_service : msg::rle_indexed_service<index_spec, test_msg_t> {};
+
+bool callback_success;
+
+constexpr auto test_callback =
+    msg::indexed_callback("TestCallback"_sc, test_id_field::in<0x80>,
+                          [](test_msg_t const &) { callback_success = true; });
+
+struct test_project {
+    constexpr static auto config = cib::config(
+        cib::exports<test_service>, cib::extend<test_service>(test_callback));
+};
+
+std::string log_buffer{};
+} // namespace
+
+template <>
+inline auto logging::config<> =
+    logging::fmt::config{std::back_inserter(log_buffer)};
+
+TEST_CASE("build rle handler", "[rle_indexed_builder]") {
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x80}});
+    CHECK(callback_success);
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
+    CHECK(not callback_success);
+}
+
+TEST_CASE("match rle output success", "[rle_handler_builder]") {
+    log_buffer.clear();
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x80}});
+    CAPTURE(log_buffer);
+    CHECK(log_buffer.find("Incoming message matched") != std::string::npos);
+    CHECK(log_buffer.find("[TestCallback]") != std::string::npos);
+    CHECK(log_buffer.find("[test_id_field == 0x80]") != std::string::npos);
+}
+
+TEST_CASE("match rle output failure", "[rle_handler_builder]") {
+    log_buffer.clear();
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
+    CHECK(log_buffer.find(
+              "None of the registered callbacks claimed this message") !=
+          std::string::npos);
+}
+
+namespace {
+constexpr auto test_callback_equals =
+    msg::indexed_callback("TestCallback"_sc, test_id_field::equal_to<0x80>,
+                          [](test_msg_t const &) { callback_success = true; });
+
+struct test_project_equals {
+    constexpr static auto config =
+        cib::config(cib::exports<test_service>,
+                    cib::extend<test_service>(test_callback_equals));
+};
+} // namespace
+
+TEST_CASE("build rle handler field equal_to", "[rle_indexed_builder]") {
+    cib::nexus<test_project_equals> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x80}});
+    CHECK(callback_success);
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
+    CHECK(not callback_success);
+}
+
+namespace {
+constexpr auto test_callback_multi_field = msg::indexed_callback(
+    "test_callback_multi_field"_sc,
+    test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+    [](test_msg_t const &) { callback_success = true; });
+
+bool callback_success_single_field;
+
+constexpr auto test_callback_single_field = msg::indexed_callback(
+    "test_callback_single_field"_sc, test_id_field::equal_to<0x50>,
+    [](test_msg_t const &) { callback_success_single_field = true; });
+
+struct test_project_multi_field {
+    constexpr static auto config =
+        cib::config(cib::exports<test_service>,
+                    cib::extend<test_service>(test_callback_multi_field,
+                                              test_callback_single_field));
+};
+} // namespace
+
+TEST_CASE("build rle handler multi fields", "[rle_indexed_builder]") {
+    cib::nexus<test_project_multi_field> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    callback_success_single_field = false;
+    cib::service<test_service>->handle(
+        test_msg_t{test_id_field{0x80}, test_opcode_field{1}});
+    CHECK(callback_success);
+    CHECK(not callback_success_single_field);
+
+    callback_success = false;
+    callback_success_single_field = false;
+    cib::service<test_service>->handle(test_msg_t{test_id_field{0x81}});
+    CHECK(not callback_success);
+    CHECK(not callback_success_single_field);
+
+    // make sure an unconstrained field in a callback doesn't cause a mismatch
+    callback_success = false;
+    callback_success_single_field = false;
+    cib::service<test_service>->handle(
+        test_msg_t{test_id_field{0x50}, test_opcode_field{1}});
+    CHECK(not callback_success);
+    CHECK(callback_success_single_field);
+}
+
+namespace {
+using partial_index_spec =
+    decltype(stdx::make_indexed_tuple<msg::get_field_type>(
+        msg::temp_index<test_id_field, 256, 32>{}));
+
+struct partially_indexed_test_service
+    : msg::rle_indexed_service<partial_index_spec, test_msg_t> {};
+
+struct partially_indexed_test_project {
+    constexpr static auto config = cib::config(
+        cib::exports<partially_indexed_test_service>,
+        cib::extend<partially_indexed_test_service>(test_callback_multi_field));
+};
+} // namespace
+
+TEST_CASE("message matching partial rle index but not callback matcher",
+          "[rle_indexed_builder]") {
+    cib::nexus<partially_indexed_test_project> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<partially_indexed_test_service>->handle(
+        test_msg_t{test_id_field{0x80}, test_opcode_field{2}});
+    CHECK(not callback_success);
+}


### PR DESCRIPTION
I have implemented a `rle_indexed_service` and `rle_indexed_builder` to provide a RLE blob version of the existing ones. 

This provides a compressed message field index lookup mechanism to reduce overall storage requirements, especially on large indices.
