### PR TITLE
:construction: Forks build on GitHub hosted Runners

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   configure:
     name: Configure Github Pages Publishing
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     outputs:
       enable_publish: ${{ steps.check.outputs.isfork == 'NO' }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   build:
     needs: configure
     name: Build Documentation
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
     environment:
       name: github-pages
       url: $${{ steps.deployment.outputs.page_url }}
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     steps:
       - name: Deploy to github pages
         id: deployment

--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   performance_test:
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   release:
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/single_header.yml
+++ b/.github/workflows/single_header.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build_single_header:
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +123,7 @@ jobs:
         run: ctest -j $(nproc) -C ${{matrix.build_type}}
 
   quality_checks_pass:
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -147,7 +147,7 @@ jobs:
         run: cmake --build ${{github.workspace}}/build -t quality
 
   sanitize:
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,7 @@ jobs:
         run: cmake --build ${{github.workspace}}/build -t unit_tests
 
   valgrind:
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -222,7 +222,7 @@ jobs:
           test $FAILSIZE = "0"
 
   merge_ok:
-    runs-on: intel-ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     needs: [build_and_test, quality_checks_pass, sanitize, valgrind]
     if: ${{ always() }}
     steps:


### PR DESCRIPTION
When a contributor forks the repository, it is not possible to use the Intel runners.

Detect the repository owner and only use the Intel runners when the workflow is running from the Intel repository.