### PR TITLE
:bug: Take account of message/field matchers in indexed handler

### DIFF
--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -91,8 +91,10 @@ struct indexed_builder_base {
     CallbacksT callbacks;
 
     template <typename... Ts> [[nodiscard]] constexpr auto add(Ts... ts) {
+        [[maybe_unused]] auto const msg_matcher =
+            typename BaseMsgT::matcher_t{};
         auto new_callbacks =
-            stdx::tuple_cat(callbacks, separate_sum_terms(ts)...);
+            stdx::tuple_cat(callbacks, separate_sum_terms(ts, msg_matcher)...);
         using new_callbacks_t = decltype(new_callbacks);
         return ParentT<IndexSpec, new_callbacks_t, BaseMsgT,
                        ExtraCallbackArgsT...>{new_callbacks};


### PR DESCRIPTION
Indexed builder was handling callback matchers correctly but failing to account for matchers in the message fields themselves.