### PR TITLE
:sparkles: Add error when callback matchers reduce to `never`

### DIFF
--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -11,6 +11,7 @@
 #include <stdx/cx_map.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
+#include <stdx/type_traits.hpp>
 
 #include <algorithm>
 #include <array>
@@ -113,6 +114,14 @@ struct indexed_builder_base {
                                                   Indices...) {
             return remove_match_terms<typename Indices::field_type...>(orig_cb);
         });
+
+        using CB = std::remove_cvref_t<decltype(cb)>;
+        if constexpr (not validate_matcher<typename CB::matcher_t>()) {
+            static_assert(
+                stdx::always_false_v<std::remove_cvref_t<decltype(orig_cb)>>,
+                "Indexed callback has matcher that is never matched!");
+        }
+
         if (cb.matcher(msg)) {
             CIB_INFO(
                 "Incoming message matched [{}], because [{}] (collapsed to "

--- a/include/msg/indexed_callback.hpp
+++ b/include/msg/indexed_callback.hpp
@@ -13,6 +13,27 @@
 #include <utility>
 
 namespace msg {
+struct null_matcher_validator {
+    template <match::matcher M>
+    CONSTEVAL static auto validate() noexcept -> bool {
+        return true;
+    }
+};
+
+struct never_matcher_validator {
+    template <match::matcher M>
+    CONSTEVAL static auto validate() noexcept -> bool {
+        return not std::is_same_v<M, match::never_t>;
+    }
+};
+
+template <typename...> inline auto matcher_validator = null_matcher_validator{};
+
+template <match::matcher M, typename... DummyArgs>
+CONSTEVAL auto validate_matcher() -> bool {
+    return matcher_validator<DummyArgs...>.template validate<M>();
+}
+
 template <typename Name, match::matcher M, stdx::callable F>
 struct indexed_callback_t {
     using name_t = Name;

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -40,6 +40,25 @@ template <typename Msg, match::matcher M> struct msg_matcher : M {
     [[nodiscard]] constexpr auto describe_match(auto const &base) const {
         return this->M::describe_match(Msg{base});
     }
+
+  private:
+    [[nodiscard]] friend constexpr auto tag_invoke(match::negate_t,
+                                                   msg_matcher const &self) {
+        return msg_matcher<Msg, decltype(match::negate(
+                                    static_cast<M const &>(self)))>{};
+    }
+
+    template <std::same_as<msg_matcher> Self, match::matcher Other>
+    [[nodiscard]] friend constexpr auto
+    tag_invoke(match::implies_t, Self &&self, Other const &o) {
+        return match::implies(static_cast<M const &>(self), o);
+    }
+
+    template <match::matcher Other, std::same_as<msg_matcher> Self>
+    [[nodiscard]] friend constexpr auto
+    tag_invoke(match::implies_t, Other const &o, Self &&self) {
+        return match::implies(o, static_cast<M const &>(self));
+    }
 };
 
 template <typename Msg, match::matcher M>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,3 +90,6 @@ add_unit_test(
     warnings
     catalog_lib
     catalog_strings)
+
+add_compile_fail_test(msg/impossible_match_callback.cpp LIBRARIES warnings cib)
+add_compile_fail_test(msg/impossible_match_field.cpp LIBRARIES warnings cib)

--- a/test/msg/impossible_match_callback.cpp
+++ b/test/msg/impossible_match_callback.cpp
@@ -1,0 +1,34 @@
+#include <cib/cib.hpp>
+#include <match/ops.hpp>
+#include <msg/field.hpp>
+#include <msg/indexed_callback.hpp>
+#include <msg/indexed_service.hpp>
+#include <msg/message.hpp>
+
+namespace {
+using test_id_field =
+    msg::field<decltype("test_id_field"_sc), 0, 31, 24, std::uint32_t>;
+
+using test_msg_t = msg::message_base<decltype("test_msg"_sc), 2, test_id_field>;
+
+constexpr auto test_callback = msg::indexed_callback(
+    "test_callback"_sc,
+    test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
+    [](test_msg_t const &) {});
+
+using index_spec = msg::index_spec<test_id_field>;
+struct test_service : msg::indexed_service<index_spec, test_msg_t> {};
+
+struct test_project {
+    constexpr static auto config = cib::config(
+        cib::exports<test_service>, cib::extend<test_service>(test_callback));
+};
+} // namespace
+
+template <>
+inline auto msg::matcher_validator<> = msg::never_matcher_validator{};
+
+int main() {
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+}

--- a/test/msg/impossible_match_field.cpp
+++ b/test/msg/impossible_match_field.cpp
@@ -1,0 +1,34 @@
+#include <cib/cib.hpp>
+#include <match/ops.hpp>
+#include <msg/field.hpp>
+#include <msg/indexed_callback.hpp>
+#include <msg/indexed_service.hpp>
+#include <msg/message.hpp>
+
+namespace {
+using test_id_field =
+    msg::field<decltype("test_id_field"_sc), 0, 31, 24, std::uint32_t>;
+
+using test_msg_t = msg::message_base<decltype("test_msg"_sc), 2,
+                                     test_id_field::WithRequired<0x80>>;
+
+constexpr auto test_callback =
+    msg::indexed_callback("test_callback"_sc, test_id_field::equal_to<0x81>,
+                          [](test_msg_t const &) {});
+
+using index_spec = msg::index_spec<test_id_field>;
+struct test_service : msg::indexed_service<index_spec, test_msg_t> {};
+
+struct test_project {
+    constexpr static auto config = cib::config(
+        cib::exports<test_service>, cib::extend<test_service>(test_callback));
+};
+} // namespace
+
+template <>
+inline auto msg::matcher_validator<> = msg::never_matcher_validator{};
+
+int main() {
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+}

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -328,3 +328,22 @@ TEST_CASE("match output success (message matcher)", "[handler_builder]") {
         test_msg_match_t{test_id_field{0x81}});
     CHECK(not callback_success);
 }
+
+namespace {
+constexpr auto test_callback_impossible = msg::indexed_callback(
+    "test_callback_impossible"_sc,
+    test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
+    [](test_msg_t const &) { callback_success = true; });
+
+struct test_project_impossible {
+    constexpr static auto config =
+        cib::config(cib::exports<test_service>,
+                    cib::extend<test_service>(test_callback_impossible));
+};
+} // namespace
+
+TEST_CASE("build handler impossible matcher does not fail unless configured",
+          "[indexed_builder]") {
+    cib::nexus<test_project_impossible> test_nexus{};
+    test_nexus.init();
+}


### PR DESCRIPTION
When it's not possible to match a callback, it could be an error. It might not be, depending on config. So this is controlled with an injectable config.