### PR TITLE
:art: :recycle: Refactor messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(
 include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:fmtlib/fmt#f918289")
-add_versioned_package("gh:intel/cpp-std-extensions#649678a")
+add_versioned_package("gh:intel/cpp-std-extensions#c6e4dae")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#8d49b6d")
 
 add_library(cib INTERFACE)

--- a/docs/message.adoc
+++ b/docs/message.adoc
@@ -59,26 +59,79 @@ has a certain value) and `in_t` (for testing if a field value lies within a set)
 
 === Messages
 
-A message is a collection of field types together with the storage that contains
-them. Messages are usually aliases for specializations of `message_base` which
-allows these things to be specified.
-
-`message_base` provides a default matcher that reflects all of the field
-matchers, but can also be supplied with an extra matcher to differentiate
-message types based on field values.
+A message is a named collection of field types. A message can be associated with
+the storage that contains it in two ways: owning, i.e. containing an array, or
+as a view, i.e. containing a span.
 
 For example, a message type looks like this:
 [source,cpp]
 ----
-using my_message =  msg::message_base<
-    decltype("TestMsg"_sc),             // name
-    2,                                  // storage size in 32-bit words
-    my_field::WithRequired<0x80>>;      // field(s)
+using my_message_defn = msg::message<
+    "my_message",                      // name
+    my_field::WithRequired<0x80>>;     // field(s)
+
+using my_message = msg::owning<my_message_defn>;
 ----
 
 Here the message has only one field. `WithRequired<0x80>` is an alias
 specialization that expresses `my_field` with a matcher that is
 `equal_to_t<0x80>`.
+
+==== Owning vs view types
+
+An owning message uses underlying storage: by default, this is a `std::array` of
+`std::uint32_t` whose size is enough to hold all the fields in the message.
+[source,cpp]
+----
+// by default, my_message will contain a std::array<std::uint32_t, 1>
+using my_message = msg::owning<my_message_defn>;
+
+// two corresponding default view types:
+
+// holds a stdx::span<std::uint32_t, 1>
+using mutable_view = msg::mutable_view<my_message_defn>;
+
+// holds a stdx::span<std::uint32_t const, 1>
+using const_view = msg::const_view<my_message_defn>;
+----
+
+The storage for a message can be customized with a tailored `std::array`:
+[source,cpp]
+----
+// an owning message with the same fields and access, but different storage:
+auto msg = my_message_defn::owner_t{std::array<std::uint8_t, 4>{}};
+
+// another way to get the view types from that owning message
+auto mut_view = msg.as_mutable_view();
+auto const_view = msg.as_const_view();
+----
+
+View types are implicitly constructible from the corresponding owning types, or
+from an appropriate `std::array` or `stdx::span`, where they are const. A
+mutable view type must be constructed explicitly.
+
+Owning types can also be constructed from views, arrays and spans - but always
+explicitly: since they are owning, they always incur a copy.
+
+Fields can be set and retrieved in a message, including on construction:
+[source,cpp]
+----
+auto msg = my_message{"my_field"_field = 42};
+auto f = my_message.get("my_field"_field);    // 42
+my_message.set("my_field"_field = 17);
+----
+
+Fields can also be set and retrieved on mutable view type messages. For obvious
+reasons, calling `set` on a const view type is a compile error. Likewise,
+setting a field during construction of a const view type is not possible.
+
+The raw data underlying a message can be obtained with a call to `data`:
+[source,cpp]
+----
+auto data = msg.data();
+----
+
+This always returns a (const-observing) `stdx::span` over the underlying data.
 
 === Handling messages with callbacks
 
@@ -126,6 +179,11 @@ callback:
 // because my_message's field matcher does not match
 cib::service<my_service>->handle(my_message{"my_field"_field = 0x81});
 ----
+
+NOTE: Because message view types are implicitly constructible from an owning
+message type, or from an appropriate `std::array`, it is possible to set up a
+service and handler that works with "raw data" in the form of a `std::array`,
+but whose callbacks and matchers take the appropriate message view types.
 
 This machinery for handling messages with callbacks is fairly basic and can be
 found in

--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -14,7 +14,7 @@
 namespace msg {
 namespace detail {
 template <typename Callable>
-void dispatch_single_callable(Callable const &callable, auto const &base_msg,
+void dispatch_single_callable(Callable const &callable, auto const &msg,
                               auto const &...args) {
     auto const provided_args_tuple = stdx::make_tuple(args...);
     auto const required_args_tuple = stdx::transform(
@@ -23,21 +23,14 @@ void dispatch_single_callable(Callable const &callable, auto const &base_msg,
         },
         detail::func_args_v<Callable>);
 
-    required_args_tuple.apply([&](auto const &...requiredArgs) {
-        using MsgType = detail::msg_type_t<Callable>;
-        MsgType const msg{base_msg};
-
-        if (typename MsgType::matcher_t{}(msg)) {
-            callable(msg, requiredArgs...);
-        }
-    });
+    required_args_tuple.apply(
+        [&](auto const &...requiredArgs) { callable(msg, requiredArgs...); });
 }
 
 template <typename T>
 concept not_nullptr = not std::is_null_pointer_v<T>;
-} // namespace detail
 
-template <typename...> struct callback_impl;
+template <typename...> struct callback;
 
 template <typename...> struct extra_callback_args {};
 
@@ -45,62 +38,61 @@ template <typename...> struct extra_callback_args {};
  * A Class that defines a message callback and provides methods for validating
  * and handling incoming messages.
  */
-template <typename BaseMsg, typename... ExtraCallbackArgs, typename Name,
+template <typename MsgDefn, typename... ExtraCallbackArgs, typename Name,
           match::matcher M, detail::not_nullptr... Callables>
-struct callback_impl<BaseMsg, extra_callback_args<ExtraCallbackArgs...>, Name,
-                     M, Callables...> {
+struct callback<MsgDefn, extra_callback_args<ExtraCallbackArgs...>, Name, M,
+                Callables...> {
   private:
     constexpr static Name name{};
 
-    [[nodiscard]] constexpr static auto match_any_callback() {
-        return match::any(
-            typename detail::msg_type_t<Callables>::matcher_t{}...);
-    }
-
-    decltype(std::declval<M>() and match_any_callback()) matcher;
+    decltype(std::declval<M>() and typename MsgDefn::matcher_t{}) matcher;
     stdx::tuple<Callables...> callbacks;
 
-    void dispatch(BaseMsg const &msg, ExtraCallbackArgs const &...args) const {
+    template <typename Msg>
+    void dispatch(Msg const &m, ExtraCallbackArgs const &...args) const {
         stdx::for_each(
-            [&](auto const &callback) {
-                detail::dispatch_single_callable(callback, msg, args...);
+            [&](auto const &cb) {
+                detail::dispatch_single_callable(cb, m, args...);
             },
             callbacks);
     }
 
   public:
     template <typename... CBs>
-    constexpr explicit callback_impl(M const &m, CBs &&...cbs)
-        : matcher{m and match_any_callback()},
+    constexpr explicit callback(M const &m, CBs &&...cbs)
+        : matcher{m and typename MsgDefn::matcher_t{}},
           callbacks{std::forward<CBs>(cbs)...} {}
 
-    [[nodiscard]] auto is_match(BaseMsg const &msg) const -> bool {
-        return matcher(msg);
+    template <typename Msg>
+    [[nodiscard]] auto is_match(Msg const &m) const -> bool {
+        return matcher(m);
     }
 
-    [[nodiscard]] auto handle(BaseMsg const &msg,
+    template <typename Msg>
+    [[nodiscard]] auto handle(Msg const &m,
                               ExtraCallbackArgs const &...args) const -> bool {
-        if (matcher(msg)) {
+        if (matcher(m)) {
             CIB_INFO("Incoming message matched [{}], because [{}], executing "
                      "callback",
                      name, matcher.describe());
-
-            dispatch(msg, args...);
+            dispatch(m, args...);
             return true;
         }
         return false;
     }
 
-    auto log_mismatch(BaseMsg const &msg) const -> void {
-        CIB_INFO("    {} - F:({})", name, matcher.describe_match(msg));
+    template <typename Msg> auto log_mismatch(Msg const &m) const -> void {
+        CIB_INFO("    {} - F:({})", name, matcher.describe_match(m));
     }
 };
+} // namespace detail
 
-template <typename BaseMsg, typename... ExtraCallbackArgs>
+template <typename MsgDefn, typename... ExtraCallbackArgs>
 constexpr auto callback = []<typename Name, match::matcher M, typename... CBs>(
                               Name, M const &m, CBs &&...callbacks) {
-    return callback_impl<BaseMsg, extra_callback_args<ExtraCallbackArgs...>,
-                         Name, M, std::remove_cvref_t<CBs>...>{
+    return detail::callback<MsgDefn,
+                            detail::extra_callback_args<ExtraCallbackArgs...>,
+                            Name, M, std::remove_cvref_t<CBs>...>{
         m, std::forward<CBs>(callbacks)...};
 };
 } // namespace msg

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -93,7 +93,7 @@ struct indexed_builder_base {
 
     template <typename... Ts> [[nodiscard]] constexpr auto add(Ts... ts) {
         [[maybe_unused]] auto const msg_matcher =
-            typename BaseMsgT::matcher_t{};
+            typename BaseMsgT::definition_t::matcher_t{};
         auto new_callbacks =
             stdx::tuple_cat(callbacks, separate_sum_terms(ts, msg_matcher)...);
         using new_callbacks_t = decltype(new_callbacks);

--- a/include/msg/detail/indexed_handler_common.hpp
+++ b/include/msg/detail/indexed_handler_common.hpp
@@ -13,8 +13,8 @@ template <typename Field, typename Lookup> struct index {
     CONSTEVAL index(Field, Lookup field_lookup_arg)
         : field_lookup{field_lookup_arg} {}
 
-    constexpr auto operator()(auto const &data) const {
-        return field_lookup[Field::extract(data)];
+    constexpr auto operator()(auto const &msg) const {
+        return field_lookup[Field::extract(msg.data())];
     }
 };
 

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -5,7 +5,9 @@
 #include <sc/format.hpp>
 #include <sc/fwd.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/cx_vector.hpp>
+#include <stdx/span.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 
@@ -15,25 +17,18 @@
 #include <type_traits>
 
 namespace msg {
-namespace detail {
-template <typename T>
-using iterator_t = decltype(std::begin(std::declval<T &>()));
-
-template <typename T, typename V>
-concept convertible_range_of =
-    range<T> and std::convertible_to<std::iter_value_t<iterator_t<T>>, V>;
-} // namespace detail
-
-template <std::uint32_t Capacity>
-using message_data = stdx::cx_vector<std::uint32_t, Capacity>;
-
 template <typename Msg, match::matcher M> struct msg_matcher : M {
-    [[nodiscard]] constexpr auto operator()(auto const &base) const -> bool {
-        return this->M::operator()(Msg{base});
+
+    template <typename Data>
+    [[nodiscard]] constexpr auto operator()(Data const &d) const -> bool {
+        auto view = typename Msg::view_t{d};
+        return this->M::operator()(view);
     }
 
-    [[nodiscard]] constexpr auto describe_match(auto const &base) const {
-        return this->M::describe_match(Msg{base});
+    template <typename Data>
+    [[nodiscard]] constexpr auto describe_match(Data const &d) const {
+        auto view = typename Msg::view_t{d};
+        return this->M::describe_match(view);
     }
 
   private:
@@ -56,12 +51,12 @@ template <typename Msg, match::matcher M> struct msg_matcher : M {
     }
 };
 
-template <typename Msg, match::matcher M>
+template <typename MsgDefn, match::matcher M>
 constexpr auto make_msg_matcher() -> match::matcher auto {
     if constexpr (std::is_same_v<M, match::always_t>) {
         return M{};
     } else {
-        return msg_matcher<Msg, M>{};
+        return msg_matcher<MsgDefn, M>{};
     }
 }
 
@@ -91,67 +86,86 @@ concept field_value = requires(T const &t) {
     typename T::name_t;
 };
 
-template <typename NameType, std::uint32_t Capacity, typename... Fields>
-struct message_base : public message_data<Capacity> {
-    constexpr static NameType name{};
-    static_assert((... and Fields::template fits_inside<message_base>()),
-                  "Fields overflow message storage!");
+namespace detail {
+template <typename... Fields> struct storage_size {
+    template <typename T>
+    constexpr static std::size_t in =
+        std::max({std::size_t{}, Fields::template extent_in<T>()...});
+};
 
-    using matcher_t = decltype(match::all(
-        make_msg_matcher<message_base, typename Fields::matcher_t>()...));
+template <stdx::ct_string Name, typename... Fields> class message_access {
+    template <typename F> using name_for = typename F::name_t;
+    using FieldsTuple =
+        decltype(stdx::make_indexed_tuple<name_for>(Fields{}...));
 
-    // TODO: need a static_assert to check that fields are not overlapping
-
-    constexpr message_base() {
-        resize_and_overwrite(
-            *this, [](std::uint32_t *, std::size_t) { return Capacity; });
-        (..., set<Fields>());
-    }
-
-    template <detail::convertible_range_of<std::uint32_t> R>
-    explicit constexpr message_base(R const &r) {
-        resize_and_overwrite(
-            *this, [&](std::uint32_t *dest, std::size_t max_size) {
-                auto const size = std::min(std::size(r), max_size);
-                std::copy_n(std::begin(r), size, dest);
-                return size;
-            });
-    }
-
-    template <field_value... Vs>
-    explicit constexpr message_base(Vs... vs) : message_base{} {
-        (..., set(vs));
-    }
-
-    template <std::integral... Vs> explicit constexpr message_base(Vs... vs) {
-        static_assert(sizeof...(Vs) <= Capacity);
-        resize_and_overwrite(*this, [&](std::uint32_t *dest, std::size_t) {
-            ((*dest++ = static_cast<std::uint32_t>(vs)), ...);
-            return sizeof...(Vs);
-        });
-    }
-
-    template <typename Field>
-    constexpr auto set(typename Field::value_type v) -> void {
-        static_assert(is_valid_for_message<Field>(),
-                      "Field does not belong to this message!");
-        static_assert(Field::template fits_inside<message_base>(),
+    template <typename Field, detail::range R> constexpr static auto check() {
+        constexpr auto belongs = (std::is_same_v<typename Field::field_id,
+                                                 typename Fields::field_id> or
+                                  ...);
+        static_assert(belongs, "Field does not belong to this message!");
+        static_assert(Field::template fits_inside<std::remove_cvref_t<R>>(),
                       "Field does not fit inside message!");
-        Field::insert(*this, v);
     }
 
-    template <typename Field> [[nodiscard]] constexpr auto get() const {
-        static_assert(is_valid_for_message<Field>(),
-                      "Field does not belong to this message!");
-        static_assert(Field::template fits_inside<message_base>(),
-                      "Field does not fit inside message!");
-        return Field::extract(*this);
+    template <range R, msg::field_value V>
+    constexpr static auto set1(R &&r, V v) -> void {
+        using Field =
+            std::remove_cvref_t<decltype(stdx::get<typename V::name_t>(
+                FieldsTuple{}))>;
+        check<Field, std::remove_cvref_t<R>>();
+        Field::insert(std::forward<R>(r),
+                      static_cast<typename Field::value_type>(v.value));
     }
 
-    [[nodiscard]] constexpr auto describe() const {
+    template <typename N, range R>
+    constexpr static auto set_default(R &&r) -> void {
+        using Field =
+            std::remove_cvref_t<decltype(stdx::get<N>(FieldsTuple{}))>;
+        check<Field, std::remove_cvref_t<R>>();
+        Field::insert(
+            std::forward<R>(r),
+            static_cast<typename Field::value_type>(Field::default_value));
+    }
+
+    template <typename N, range R> constexpr static auto get(R &&r) {
+        using Field =
+            std::remove_cvref_t<decltype(stdx::get<N>(FieldsTuple{}))>;
+        check<Field, std::remove_cvref_t<R>>();
+        return Field::extract(std::forward<R>(r));
+    }
+
+  public:
+    template <range R, typename... Ns>
+    constexpr static auto set(R &&r, field_name<Ns>...) -> void {
+        (set_default<Ns>(r), ...);
+    }
+
+    template <range R, msg::field_value... Vs>
+    constexpr static auto set(R &&r, Vs... vs) -> void {
+        (set1(r, vs), ...);
+    }
+
+    template <range R, typename... Fs>
+    constexpr static auto set(R &&r, Fs...) -> void {
+        (set_default<typename Fs::name_t>(r), ...);
+    }
+
+    template <range R, typename N>
+    constexpr static auto get(R &&r, field_name<N>) {
+        return get<N>(std::forward<R>(r));
+    }
+
+    template <range R, typename F> constexpr static auto get(R &&r, F) {
+        return get<typename F::name_t>(std::forward<R>(r));
+    }
+
+    template <detail::range R>
+    [[nodiscard]] constexpr static auto describe(R &&r) {
+        using msg_name =
+            decltype(stdx::ct_string_to_type<Name, sc::string_constant>());
         auto const descs = [&] {
             auto const field_descriptions =
-                stdx::tuple{Fields::describe(Fields::extract(*this))...};
+                stdx::tuple{Fields::describe(Fields::extract(r))...};
             if constexpr (sizeof...(Fields) > 0) {
                 return field_descriptions.join(
                     [](auto lhs, auto rhs) { return lhs + ", "_sc + rhs; });
@@ -159,31 +173,162 @@ struct message_base : public message_data<Capacity> {
                 return ""_sc;
             }
         }();
-        return format("{}({})"_sc, name, descs);
+        return format("{}({})"_sc, msg_name{}, descs);
     }
 
-  private:
-    template <typename Field>
-    [[nodiscard]] constexpr static auto is_valid_for_message() -> bool {
-        return (std::is_same_v<typename Field::field_id,
-                               typename Fields::field_id> or
-                ...);
-    }
+    using default_value_type = std::uint32_t;
 
-    template <typename Field> constexpr auto set() -> void {
-        set<Field>(Field::default_value);
-    }
+    template <template <typename, std::size_t> typename C, typename T>
+    using storage_t = C<T, storage_size<Fields...>::template in<T>>;
+    using default_storage_t = storage_t<std::array, default_value_type>;
 
-    template <field_value V> constexpr void set(V v) {
-        auto const set_by_name = [&]<typename F>() -> bool {
-            if constexpr (std::is_same_v<typename V::name_t,
-                                         typename F::name_t>) {
-                set<F>(static_cast<typename F::value_type>(v.value));
-                return true;
-            }
-            return false;
-        };
-        (... or set_by_name.template operator()<Fields>());
-    }
+    template <typename T>
+    using span_t = stdx::span<T, storage_size<Fields...>::template in<T>>;
+    using default_span_t = span_t<default_value_type>;
+    using default_const_span_t = span_t<default_value_type const>;
 };
+
+template <typename T>
+concept storage_like = range<T> and requires {
+    { capacity<T>() } -> std::same_as<std::size_t>;
+    typename T::value_type;
+};
+} // namespace detail
+
+template <stdx::ct_string Name, typename... Fields> struct message {
+    using access_t = detail::message_access<Name, Fields...>;
+    using default_storage_t = typename access_t::default_storage_t;
+    using default_span_t = typename access_t::default_span_t;
+    using default_const_span_t = typename access_t::default_const_span_t;
+
+    template <typename T> struct base {
+        constexpr auto as_derived() const -> T const & {
+            return static_cast<T const &>(*this);
+        }
+        constexpr auto as_derived() -> T & { return static_cast<T &>(*this); }
+
+        [[nodiscard]] constexpr auto get(auto f) const {
+            return access_t::get(as_derived().data(), f);
+        }
+        constexpr auto set(auto... fs) -> void {
+            access_t::set(as_derived().data(), fs...);
+        }
+        constexpr auto set() -> void {}
+
+        [[nodiscard]] constexpr auto describe() const {
+            return access_t::describe(as_derived().data());
+        }
+    };
+
+    template <typename> struct owner_t;
+
+    template <typename Span> struct view_t : base<view_t<Span>> {
+        using definition_t = message;
+
+        template <detail::storage_like S>
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        view_t(S const &s) : storage{s} {}
+
+        template <detail::storage_like S, field_value... Vs>
+        constexpr explicit view_t(S &s, Vs... vs) : storage{s} {
+            this->set(vs...);
+        }
+
+        template <typename S>
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        constexpr view_t(owner_t<S> const &s) : storage{s.data()} {}
+
+        template <typename S, field_value... Vs>
+        explicit constexpr view_t(owner_t<S> &s, Vs... vs) : storage{s.data()} {
+            this->set(vs...);
+        }
+
+        [[nodiscard]] constexpr auto data() const { return storage; }
+
+      private:
+        static_assert((... and Fields::template fits_inside<Span>()),
+                      "Fields overflow message storage!");
+        Span storage{};
+    };
+    using const_view_t = view_t<default_const_span_t>;
+    using mutable_view_t = view_t<default_span_t>;
+
+    template <typename Storage = default_storage_t>
+    struct owner_t : base<owner_t<Storage>> {
+        using definition_t = message;
+        using storage_t = Storage;
+
+        constexpr owner_t() { this->set(Fields{}...); }
+
+        template <field_value... Vs>
+        explicit constexpr owner_t(Vs... vs) : owner_t{} {
+            this->set(vs...);
+        }
+
+        template <detail::storage_like S, field_value... Vs>
+        explicit constexpr owner_t(S const &s, Vs... vs) {
+            std::copy(std::begin(s), std::end(s), std::begin(storage));
+            this->set(vs...);
+        }
+
+        template <detail::storage_like S, field_value... Vs>
+        explicit constexpr owner_t(view_t<S> &s, Vs... vs) {
+            std::copy(std::begin(s.data()), std::end(s.data()),
+                      std::begin(storage));
+            this->set(vs...);
+        }
+
+        [[nodiscard]] constexpr auto data() { return stdx::span{storage}; }
+        [[nodiscard]] constexpr auto data() const {
+            return stdx::span{storage};
+        }
+
+        [[nodiscard]] constexpr auto as_mutable_view() { return view_t{*this}; }
+        [[nodiscard]] constexpr auto as_const_view() const {
+            return view_t{*this};
+        }
+
+      private:
+        static_assert((... and Fields::template fits_inside<storage_t>()),
+                      "Fields overflow message storage!");
+        storage_t storage{};
+    };
+
+    template <detail::storage_like S>
+    owner_t(S const &, auto &&...)
+        -> owner_t<std::array<typename S::value_type, detail::capacity<S>()>>;
+    template <field_value... Vs> owner_t(Vs...) -> owner_t<default_storage_t>;
+    template <typename S>
+    owner_t(view_t<S> &, auto &&...)
+        -> owner_t<std::array<typename S::value_type, detail::capacity<S>()>>;
+
+    template <detail::storage_like S>
+    view_t(S const &)
+        -> view_t<stdx::span<std::add_const_t<typename S::value_type>,
+                             detail::capacity<S>()>>;
+    template <detail::storage_like S>
+    view_t(S &)
+        -> view_t<stdx::span<typename S::value_type, detail::capacity<S>()>>;
+
+    template <typename T, std::size_t N>
+        requires(std::is_const_v<T>)
+    view_t(stdx::span<T, N>) -> view_t<stdx::span<T, N>>;
+    template <typename T, std::size_t N>
+        requires(not std::is_const_v<T>)
+    view_t(stdx::span<T, N>, auto &&...) -> view_t<stdx::span<T, N>>;
+
+    template <typename S>
+    view_t(owner_t<S> const &) -> view_t<
+        stdx::span<typename S::value_type const, detail::capacity<S>()>>;
+    template <typename S>
+    view_t(owner_t<S> &, auto &&...)
+        -> view_t<stdx::span<typename S::value_type, detail::capacity<S>()>>;
+
+    using matcher_t = decltype(match::all(
+        make_msg_matcher<message, typename Fields::matcher_t>()...));
+};
+
+template <typename T> using owning = typename T::template owner_t<>;
+template <typename T> using mutable_view = typename T::mutable_view_t;
+template <typename T> using const_view = typename T::const_view_t;
 } // namespace msg

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_tests(
     match/simplify_not
     match/simplify_or
     match/sum_of_products
+    msg/callback
     msg/detail/rle_codec
     msg/field_extract
     msg/field_insert

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -1,0 +1,107 @@
+#include <log/fmt/logger.hpp>
+#include <msg/callback.hpp>
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdint>
+#include <iterator>
+#include <string>
+
+namespace {
+using namespace msg;
+
+bool dispatched = false;
+
+using id_field = field<"id", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using field1 = field<"f1", std::uint32_t>::located<at{0_dw, 15_msb, 0_lsb}>;
+using field2 = field<"f2", std::uint32_t>::located<at{1_dw, 23_msb, 16_lsb}>;
+using field3 = field<"f3", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
+
+using msg_defn =
+    message<"msg", id_field::WithRequired<0x80>, field1, field2, field3>;
+
+std::string log_buffer{};
+} // namespace
+
+template <>
+inline auto logging::config<> =
+    logging::fmt::config{std::back_inserter(log_buffer)};
+
+TEST_CASE("callback matches message", "[handler]") {
+    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
+    CHECK(callback.is_match(msg_match));
+}
+
+TEST_CASE("callback matches message (alternative range)", "[handler]") {
+    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto const msg_match = std::array<std::uint8_t, 8>{0x11, 0xba, 0x00, 0x80,
+                                                       0x0d, 0xd0, 0x42, 0x00};
+    CHECK(callback.is_match(msg_match));
+}
+
+TEST_CASE("callback matches message (typed message)", "[handler]") {
+    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
+    CHECK(callback.is_match(msg_match));
+}
+
+TEST_CASE("callback logs mismatch (raw)", "[handler]") {
+    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto const msg_nomatch = std::array{0x8100ba11u, 0x0042d00du};
+    CHECK(not callback.is_match(msg_nomatch));
+
+    log_buffer.clear();
+    callback.log_mismatch(msg_nomatch);
+    CAPTURE(log_buffer);
+    CHECK(log_buffer.find("cb - F:(id (0x81) == 0x80)") != std::string::npos);
+}
+
+TEST_CASE("callback logs mismatch (typed)", "[handler]") {
+    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto const msg_nomatch = msg::owning<msg_defn>{"id"_field = 0x81};
+    CHECK(not callback.is_match(msg_nomatch));
+
+    log_buffer.clear();
+    callback.log_mismatch(msg_nomatch);
+    CAPTURE(log_buffer);
+    CHECK(log_buffer.find("cb - F:(id (0x81) == 0x80)") != std::string::npos);
+}
+
+TEST_CASE("callback handles message (raw)", "[handler]") {
+    auto callback = msg::callback<msg_defn>(
+        ""_sc, match::always,
+        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
+
+    dispatched = false;
+    CHECK(callback.handle(msg_match));
+    CHECK(dispatched);
+}
+
+TEST_CASE("callback handles message (typed)", "[handler]") {
+    auto callback = msg::callback<msg_defn>(
+        ""_sc, match::always,
+        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
+
+    dispatched = false;
+    CHECK(callback.handle(msg_match));
+    CHECK(dispatched);
+}
+
+TEST_CASE("callback logs match", "[handler]") {
+    auto callback = msg::callback<msg_defn>(
+        "cb"_sc, match::always,
+        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
+
+    log_buffer.clear();
+    CHECK(callback.handle(msg_match));
+    CAPTURE(log_buffer);
+    CHECK(log_buffer.find("matched [cb], because [id == 0x80]") !=
+          std::string::npos);
+}

--- a/test/msg/fail/impossible_match_callback.cpp
+++ b/test/msg/fail/impossible_match_callback.cpp
@@ -5,6 +5,7 @@
 #include <msg/indexed_service.hpp>
 #include <msg/message.hpp>
 
+// EXPECT: Indexed callback has matcher that is never matched
 namespace {
 using namespace msg;
 
@@ -12,7 +13,8 @@ using test_id_field =
     msg::field<"test_id_field",
                std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
 
-using test_msg_t = msg::message_base<decltype("test_msg"_sc), 2, test_id_field>;
+using msg_defn = message<"test_msg", test_id_field>;
+using test_msg_t = owning<msg_defn>;
 
 constexpr auto test_callback = msg::indexed_callback(
     "test_callback"_sc,

--- a/test/msg/fail/impossible_match_field.cpp
+++ b/test/msg/fail/impossible_match_field.cpp
@@ -5,6 +5,7 @@
 #include <msg/indexed_service.hpp>
 #include <msg/message.hpp>
 
+// EXPECT: Indexed callback has matcher that is never matched
 namespace {
 using namespace msg;
 
@@ -12,8 +13,8 @@ using test_id_field =
     msg::field<"test_id_field",
                std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
 
-using test_msg_t = msg::message_base<decltype("test_msg"_sc), 2,
-                                     test_id_field::WithRequired<0x80>>;
+using msg_defn = message<"test_msg", test_id_field::WithRequired<0x80>>;
+using test_msg_t = owning<msg_defn>;
 
 constexpr auto test_callback =
     msg::indexed_callback("test_callback"_sc, test_id_field::equal_to<0x81>,

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -24,8 +24,9 @@ using test_field_2 =
 using test_field_3 =
     field<"test_field_3", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
 
-using test_msg_t = message_base<decltype("test_msg"_sc), 2, test_id_field,
-                                test_opcode_field, test_field_2, test_field_3>;
+using msg_defn = message<"test_msg", test_id_field, test_opcode_field,
+                         test_field_2, test_field_3>;
+using test_msg_t = owning<msg_defn>;
 
 using index_spec = index_spec<test_id_field, test_opcode_field>;
 struct test_service : indexed_service<index_spec, test_msg_t> {};
@@ -156,7 +157,7 @@ TEST_CASE("build handler multi fields", "[indexed_builder]") {
     CHECK(not callback_success);
     CHECK(not callback_success_single_field);
 
-    // make sure an unconstrained field in a callback doesn't cause a mismatch
+    // make sure an unconstrained field in a callback doesn't cause a  mismatch
     log_buffer.clear();
     callback_success = false;
     callback_success_single_field = false;
@@ -307,8 +308,9 @@ TEST_CASE("build handler disjunction", "[indexed_builder]") {
 }
 
 namespace {
-using test_msg_match_t = msg::message_base<decltype("test_msg"_sc), 2,
-                                           test_id_field::WithRequired<0x80>>;
+using msg_match_defn = message<"test_msg", test_id_field::WithRequired<0x80>>;
+using test_msg_match_t = owning<msg_match_defn>;
+
 using msg_match_index_spec = msg::index_spec<test_id_field>;
 struct test_msg_match_service
     : msg::indexed_service<msg_match_index_spec, test_msg_match_t> {};

--- a/test/msg/indexed_handler.cpp
+++ b/test/msg/indexed_handler.cpp
@@ -38,8 +38,9 @@ using field_3 =
 using field_4 =
     msg::field<"field_5", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
 
-using test_msg = message_base<decltype("test_msg"_sc), 2, opcode_field,
-                              sub_opcode_field, field_3, field_4>;
+using msg_defn =
+    message<"test_msg", opcode_field, sub_opcode_field, field_3, field_4>;
+using test_msg = owning<msg_defn>;
 
 template <auto N> using bitset = stdx::bitset<N, std::uint32_t>;
 

--- a/test/msg/rle_indexed_builder.cpp
+++ b/test/msg/rle_indexed_builder.cpp
@@ -24,8 +24,9 @@ using test_field_2 =
 using test_field_3 =
     field<"test_field_3", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
 
-using test_msg_t = message_base<decltype("test_msg"_sc), 2, test_id_field,
-                                test_opcode_field, test_field_2, test_field_3>;
+using msg_defn = message<"test_msg", test_id_field, test_opcode_field,
+                         test_field_2, test_field_3>;
+using test_msg_t = owning<msg_defn>;
 
 using index_spec = index_spec<test_id_field, test_opcode_field>;
 struct test_service : rle_indexed_service<index_spec, test_msg_t> {};


### PR DESCRIPTION
Messages are reworked:
 - separate definition from storage
 - owning, mutable view and const view types
 - construction from arrays and/or by setting fields
 - get and set fields by name

Handlers, matchers and callbacks don't incur any copying any more; message views
can be constructed cheaply over raw arrays.

Closes: #315
Closes: #394
Closes: #395
Closes: #398 