### PR TITLE
Small cleanups

### DIFF
--- a/include/interrupt/config/fwd.hpp
+++ b/include/interrupt/config/fwd.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace interrupt {
-using EnableActionType = auto (*)() -> void;
-} // namespace interrupt

--- a/include/interrupt/config/irq.hpp
+++ b/include/interrupt/config/irq.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -25,7 +25,7 @@ template <std::size_t IrqNumberT, std::size_t IrqPriorityT,
           typename IrqCallbackT, typename PoliciesT>
 struct irq {
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action =
+    constexpr static FunctionPtr enable_action =
         InterruptHal::template irqInit<en, IrqNumberT, IrqPriorityT>;
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
                                                            clear_status_first>;

--- a/include/interrupt/config/root.hpp
+++ b/include/interrupt/config/root.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -11,7 +11,7 @@ template <typename InterruptHalT, typename... IrqsT> struct root {
     using InterruptHal = InterruptHalT;
 
     template <typename T, bool en>
-    constexpr static EnableActionType enable_action = []() {};
+    constexpr static FunctionPtr enable_action = [] {};
     using StatusPolicy = clear_status_first;
     constexpr static auto resources = stdx::make_tuple();
     using IrqCallbackType = void;

--- a/include/interrupt/config/shared_irq.hpp
+++ b/include/interrupt/config/shared_irq.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -31,7 +31,7 @@ template <std::size_t IrqNumberT, std::size_t IrqPriorityT, typename PoliciesT,
 struct shared_irq {
   public:
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action =
+    constexpr static FunctionPtr enable_action =
         InterruptHal::template irqInit<en, IrqNumberT, IrqPriorityT>;
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
                                                            clear_status_first>;

--- a/include/interrupt/config/shared_sub_irq.hpp
+++ b/include/interrupt/config/shared_sub_irq.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -10,7 +10,7 @@ template <typename EnableField, typename StatusField, typename PoliciesT,
           typename... SubIrqs>
 struct shared_sub_irq {
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action = []() {};
+    constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,

--- a/include/interrupt/config/sub_irq.hpp
+++ b/include/interrupt/config/sub_irq.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -24,7 +24,7 @@ template <typename EnableField, typename StatusField, typename IrqCallbackT,
           typename PoliciesT>
 struct sub_irq {
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action = []() {};
+    constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,

--- a/include/interrupt/impl/irq_impl.hpp
+++ b/include/interrupt/impl/irq_impl.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
 #include <interrupt/fwd.hpp>
 
 #include <stdx/tuple.hpp>
@@ -18,7 +17,7 @@ namespace interrupt {
 template <typename ConfigT, typename FlowTypeT> struct irq_impl {
   public:
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action =
+    constexpr static FunctionPtr enable_action =
         ConfigT::template enable_action<InterruptHal, en>;
     using StatusPolicy = typename ConfigT::StatusPolicy;
 

--- a/include/interrupt/impl/shared_irq_impl.hpp
+++ b/include/interrupt/impl/shared_irq_impl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
@@ -11,7 +11,7 @@ namespace interrupt {
 template <typename ConfigT, typename... SubIrqImpls> struct shared_irq_impl {
   public:
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action =
+    constexpr static FunctionPtr enable_action =
         ConfigT::template enable_action<InterruptHal, en>;
     using StatusPolicy = typename ConfigT::StatusPolicy;
 

--- a/include/interrupt/impl/shared_sub_irq_impl.hpp
+++ b/include/interrupt/impl/shared_sub_irq_impl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <interrupt/config/fwd.hpp>
+#include <interrupt/fwd.hpp>
 
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
@@ -22,7 +22,7 @@ struct shared_sub_irq_impl {
 
   private:
     template <typename InterruptHal, bool en>
-    constexpr static EnableActionType enable_action =
+    constexpr static FunctionPtr enable_action =
         ConfigT::template enable_action<InterruptHal, en>;
 
     constexpr static auto enable_field = ConfigT::enable_field;

--- a/include/interrupt/policies.hpp
+++ b/include/interrupt/policies.hpp
@@ -8,7 +8,7 @@ namespace interrupt {
 struct status_clear_policy {};
 
 struct clear_status_first {
-    using PolicyType = status_clear_policy;
+    using policy_type = status_clear_policy;
 
     template <typename ClearStatusCallable, typename RunCallable>
     static void run(ClearStatusCallable const &clear_status,
@@ -19,7 +19,7 @@ struct clear_status_first {
 };
 
 struct clear_status_last {
-    using PolicyType = status_clear_policy;
+    using policy_type = status_clear_policy;
 
     template <typename ClearStatusCallable, typename RunCallable>
     static void run(ClearStatusCallable const &clear_status,
@@ -30,7 +30,7 @@ struct clear_status_last {
 };
 
 struct dont_clear_status {
-    using PolicyType = status_clear_policy;
+    using policy_type = status_clear_policy;
 
     template <typename ClearStatusCallable, typename RunCallable>
     static void run(ClearStatusCallable const &, RunCallable const &run) {
@@ -41,12 +41,12 @@ struct dont_clear_status {
 struct required_resources_policy {};
 
 template <typename... ResourcesT> struct required_resources {
-    using PolicyType = required_resources_policy;
+    using policy_type = required_resources_policy;
 
     constexpr static stdx::tuple<ResourcesT...> resources{};
 };
 
-template <typename... PoliciesT> class policies {
+template <typename... Policies> class policies {
     template <typename Key, typename Value> struct type_pair {};
     template <typename... Ts> struct type_map : Ts... {};
 
@@ -56,14 +56,14 @@ template <typename... PoliciesT> class policies {
     constexpr static auto lookup(type_pair<K, V>) -> V;
 
   public:
-    template <typename PolicyType, typename DefaultPolicy>
+    template <typename PolicyType, typename Default>
     constexpr static auto get() {
         using M =
-            type_map<type_pair<typename PoliciesT::PolicyType, PoliciesT>...>;
-        return decltype(lookup<PolicyType, DefaultPolicy>(std::declval<M>())){};
+            type_map<type_pair<typename Policies::policy_type, Policies>...>;
+        return decltype(lookup<PolicyType, Default>(std::declval<M>())){};
     }
 
-    template <typename PolicyType, typename DefaultPolicy>
-    using type = decltype(get<PolicyType, DefaultPolicy>());
+    template <typename PolicyType, typename Default>
+    using type = decltype(get<PolicyType, Default>());
 };
 } // namespace interrupt

--- a/include/match/implies.hpp
+++ b/include/match/implies.hpp
@@ -9,16 +9,7 @@ constexpr inline class implies_t {
     template <matcher X, matcher Y>
     [[nodiscard]] friend constexpr auto tag_invoke(implies_t, X const &,
                                                    Y const &) -> bool {
-        return false;
-    }
-
-    // NOTE: This overload takes two arguments and uses a requires clause. It
-    // does not just take one template argument in order to avoid ambiguity.
-    template <matcher M, matcher N>
-        requires(std::is_same_v<M, N>)
-    [[nodiscard]] friend constexpr auto tag_invoke(implies_t, M const &,
-                                                   N const &) -> bool {
-        return true;
+        return std::is_same_v<X, Y>;
     }
 
   public:

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -1,5 +1,4 @@
 #include <cib/cib.hpp>
-#include <conc/concurrency.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>


### PR DESCRIPTION
- simplify `implies`
- remove a header that contained Yet Another typedef for pointer-to-function-returning-void
- remove an unused header from a test
- use conventional type spellings