### PR TITLE
:art: Inject the interrupt HAL

### DIFF
--- a/include/interrupt/config/irq.hpp
+++ b/include/interrupt/config/irq.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <interrupt/fwd.hpp>
+#include <interrupt/hal.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -24,9 +25,9 @@ namespace interrupt {
 template <std::size_t IrqNumberT, std::size_t IrqPriorityT,
           typename IrqCallbackT, typename PoliciesT>
 struct irq {
-    template <typename InterruptHal, bool en>
+    template <bool en>
     constexpr static FunctionPtr enable_action =
-        InterruptHal::template irqInit<en, IrqNumberT, IrqPriorityT>;
+        hal::irq_init<en, IrqNumberT, IrqPriorityT>;
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
                                                            clear_status_first>;
     constexpr static auto resources =

--- a/include/interrupt/config/root.hpp
+++ b/include/interrupt/config/root.hpp
@@ -7,9 +7,7 @@
 #include <stdx/tuple_algorithms.hpp>
 
 namespace interrupt {
-template <typename InterruptHalT, typename... IrqsT> struct root {
-    using InterruptHal = InterruptHalT;
-
+template <typename... IrqsT> struct root {
     template <typename T, bool en>
     constexpr static FunctionPtr enable_action = [] {};
     using StatusPolicy = clear_status_first;

--- a/include/interrupt/config/shared_irq.hpp
+++ b/include/interrupt/config/shared_irq.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <interrupt/fwd.hpp>
+#include <interrupt/hal.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/tuple.hpp>
@@ -30,9 +31,9 @@ template <std::size_t IrqNumberT, std::size_t IrqPriorityT, typename PoliciesT,
           typename... SubIrqs>
 struct shared_irq {
   public:
-    template <typename InterruptHal, bool en>
+    template <bool en>
     constexpr static FunctionPtr enable_action =
-        InterruptHal::template irqInit<en, IrqNumberT, IrqPriorityT>;
+        hal::irq_init<en, IrqNumberT, IrqPriorityT>;
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
                                                            clear_status_first>;
     constexpr static auto resources =

--- a/include/interrupt/config/shared_sub_irq.hpp
+++ b/include/interrupt/config/shared_sub_irq.hpp
@@ -9,8 +9,7 @@ namespace interrupt {
 template <typename EnableField, typename StatusField, typename PoliciesT,
           typename... SubIrqs>
 struct shared_sub_irq {
-    template <typename InterruptHal, bool en>
-    constexpr static FunctionPtr enable_action = [] {};
+    template <bool en> constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,

--- a/include/interrupt/config/sub_irq.hpp
+++ b/include/interrupt/config/sub_irq.hpp
@@ -23,8 +23,7 @@ namespace interrupt {
 template <typename EnableField, typename StatusField, typename IrqCallbackT,
           typename PoliciesT>
 struct sub_irq {
-    template <typename InterruptHal, bool en>
-    constexpr static FunctionPtr enable_action = [] {};
+    template <bool en> constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
     using StatusPolicy = typename PoliciesT::template type<status_clear_policy,

--- a/include/interrupt/hal.hpp
+++ b/include/interrupt/hal.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <interrupt/policies.hpp>
+
+#include <stdx/concepts.hpp>
+#include <stdx/type_traits.hpp>
+
+namespace interrupt {
+template <typename T>
+concept hal_interface = requires(T const &t, void (*isr)()) {
+    { t.init() } -> stdx::same_as<void>;
+    {
+        t.template irq_init<true, std::size_t{}, std::size_t{}>()
+    } -> stdx::same_as<void>;
+    {
+        t.template run<dont_clear_status>(std::size_t{}, isr)
+    } -> stdx::same_as<void>;
+};
+
+template <typename...> struct null_hal {
+    static auto init() -> void { undefined(); }
+
+    template <bool Enable, int IrqNumber, int PriorityLevel>
+    static auto irq_init() -> void {
+        undefined();
+    }
+
+    template <status_policy>
+    static auto run(std::size_t, stdx::invocable auto const &) -> void {
+        undefined();
+    }
+
+  private:
+    static auto undefined() -> void {
+        static_assert(stdx::always_false_v<null_hal>,
+                      "No interrupt HAL defined: inject one");
+    }
+};
+static_assert(hal_interface<null_hal<>>);
+
+template <typename...> inline auto injected_hal = null_hal{};
+
+struct hal {
+    template <typename... Ts>
+        requires(sizeof...(Ts) == 0)
+    static auto init() -> void {
+        injected_hal<Ts...>.init();
+    }
+
+    template <bool Enable, int IrqNumber, int Priority, typename... Ts>
+        requires(sizeof...(Ts) == 0)
+    static auto irq_init() -> void {
+        injected_hal<Ts...>.template irq_init<Enable, IrqNumber, Priority>();
+    }
+
+    template <status_policy P, typename... Ts>
+        requires(sizeof...(Ts) == 0)
+    static auto run(std::size_t irq, stdx::invocable auto const &isr) -> void {
+        injected_hal<Ts...>.template run<P>(irq, isr);
+    }
+};
+
+static_assert(hal_interface<hal>);
+} // namespace interrupt

--- a/include/interrupt/impl/shared_sub_irq_impl.hpp
+++ b/include/interrupt/impl/shared_sub_irq_impl.hpp
@@ -21,9 +21,9 @@ struct shared_sub_irq_impl {
     constexpr static bool active = (SubIrqImpls::active or ...);
 
   private:
-    template <typename InterruptHal, bool en>
+    template <bool en>
     constexpr static FunctionPtr enable_action =
-        ConfigT::template enable_action<InterruptHal, en>;
+        ConfigT::template enable_action<en>;
 
     constexpr static auto enable_field = ConfigT::enable_field;
     constexpr static auto status_field = ConfigT::status_field;

--- a/include/interrupt/impl/sub_irq_impl.hpp
+++ b/include/interrupt/impl/sub_irq_impl.hpp
@@ -46,9 +46,6 @@ template <typename ConfigT, typename FlowTypeT> struct sub_irq_impl {
      *
      * This should be used only by interrupt::Manager.
      *
-     * @tparam InterruptHal
-     *      The hardware abstraction layer that knows how to clear pending
-     * interrupt status.
      */
     inline void run() const {
         if constexpr (active) {

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -9,6 +9,7 @@
 #include <interrupt/builder/sub_irq_builder.hpp>
 #include <interrupt/config.hpp>
 #include <interrupt/dynamic_controller.hpp>
+#include <interrupt/hal.hpp>
 #include <interrupt/impl/manager_impl.hpp>
 #include <interrupt/manager_interface.hpp>
 #include <interrupt/policies.hpp>
@@ -42,10 +43,6 @@ CONSTEVAL auto extend(T flow_description) {
  * Declare one or more Irqs, SharedIrqs, and their corresponding interrupt
  * service routine attachment points.
  *
- * @tparam InterruptHal
- *      The hardware abstraction layer that knows how to clear pending interrupt
- * status.
- *
  * @tparam IRQs
  */
 template <typename RootT> class manager {
@@ -62,8 +59,6 @@ template <typename RootT> class manager {
     }
 
   public:
-    using InterruptHal = typename RootT::InterruptHal;
-
     constexpr static auto irqs_type = stdx::transform(
         [](auto child) {
             if constexpr (decltype(child.children)::size() > 0u) {
@@ -116,8 +111,8 @@ template <typename RootT> class manager {
             std::make_index_sequence<irqs_t::size()>{});
 
         return irq_impls.apply([](auto... irq_impl_args) {
-            return manager_impl<InterruptHal, Dynamic,
-                                decltype(irq_impl_args)...>(irq_impl_args...);
+            return manager_impl<Dynamic, decltype(irq_impl_args)...>(
+                irq_impl_args...);
         });
     }
 };


### PR DESCRIPTION
Carrying the (global) interrupt HAL dependency through all the interrupt types is an artifact; this change injects it.