### PR TITLE
:art: Remove clumsy decltyping of string constants

### DIFF
--- a/examples/flow_daily_routine/main.cpp
+++ b/examples/flow_daily_routine/main.cpp
@@ -61,13 +61,13 @@
 /*
   Service definitions
 */
-// decltype("morning_routine_log_t"_sc) - used during the logging
+// "morning_routine_log_t" - used during the logging
 // struct morning_routine_log_t
-//     : public flow::service<decltype("morning_routine_log_t"_sc)> {};
+//     : public flow::service<"morning_routine_log_t"> {};
 struct morning_routine_t : public flow::service<> {};
 
 // struct evening_routine_t : public
-// flow::service<decltype("evening_routine_t"_sc)>
+// flow::service<"evening_routine_t">
 struct evening_routine_t : public flow::service<> {};
 
 /*
@@ -77,22 +77,20 @@ struct self_care_component_t {
     /*
       Actions: WAKE_UP, EXERCISE, GO_TO_BED, RELAX, TAKE_BATH
     */
-    constexpr static auto WAKE_UP = flow::action(
-        "WakeUp"_sc, []() { std::cout << "Wake up at 6:00 AM" << std::endl; });
+    constexpr static auto WAKE_UP = flow::action<"WakeUp">(
+        []() { std::cout << "Wake up at 6:00 AM" << std::endl; });
 
-    constexpr static auto EXERCISE = flow::action(
-        "Exercise"_sc, []() { std::cout << "Gym activities" << std::endl; });
+    constexpr static auto EXERCISE = flow::action<"Exercise">(
+        []() { std::cout << "Gym activities" << std::endl; });
 
-    constexpr static auto GO_TO_BED = flow::action("GoToBed"_sc, []() {
-        std::cout << "Go to bed at 10:00 PM" << std::endl;
-    });
+    constexpr static auto GO_TO_BED = flow::action<"GoToBed">(
+        []() { std::cout << "Go to bed at 10:00 PM" << std::endl; });
 
-    constexpr static auto RELAX = flow::action("Relax"_sc, []() {
-        std::cout << "Have relax before Dinner" << std::endl;
-    });
+    constexpr static auto RELAX = flow::action<"Relax">(
+        []() { std::cout << "Have relax before Dinner" << std::endl; });
 
-    constexpr static auto TAKE_BATH = flow::action(
-        "TakeBath"_sc, []() { std::cout << "Take a bath" << std::endl; });
+    constexpr static auto TAKE_BATH = flow::action<"TakeBath">(
+        []() { std::cout << "Take a bath" << std::endl; });
 
     // Extend flow services
     constexpr static auto config = cib::config(
@@ -111,12 +109,11 @@ struct food_component_t {
     /*
       Actions: BREAKFAST, DINNER
     */
-    constexpr static auto BREAKFAST = flow::action("Breakfast"_sc, []() {
-        std::cout << "Have healthy breakfast" << std::endl;
-    });
+    constexpr static auto BREAKFAST = flow::action<"Breakfast">(
+        []() { std::cout << "Have healthy breakfast" << std::endl; });
 
-    constexpr static auto DINNER = flow::action(
-        "Dinner"_sc, []() { std::cout << "Have early dinner" << std::endl; });
+    constexpr static auto DINNER = flow::action<"Dinner">(
+        []() { std::cout << "Have early dinner" << std::endl; });
 
     // Extend flow services
     constexpr static auto config = cib::config(
@@ -134,11 +131,11 @@ struct dress_up_component_t {
       Actions: GET_READY_FOR_EXERCISE, GET_READY_TO_WORK
     */
     constexpr static auto GET_READY_FOR_EXERCISE =
-        flow::action("GetReadyForExercise"_sc,
-                     []() { std::cout << "Sports wear" << std::endl; });
+        flow::action<"GetReadyForExercise">(
+            []() { std::cout << "Sports wear" << std::endl; });
 
-    constexpr static auto GET_READY_TO_WORK = flow::action(
-        "GetReadyToWork"_sc, []() { std::cout << "Office wear" << std::endl; });
+    constexpr static auto GET_READY_TO_WORK = flow::action<"GetReadyToWork">(
+        []() { std::cout << "Office wear" << std::endl; });
 
     // Extend flow services
     constexpr static auto config = cib::config(
@@ -160,12 +157,11 @@ struct commute_component_t {
     /*
       Actions: GO_TO_OFFICE, RETURN_HOME
     */
-    constexpr static auto GO_TO_OFFICE = flow::action("GoToOffice"_sc, []() {
-        std::cout << "Commute to office" << std::endl;
-    });
+    constexpr static auto GO_TO_OFFICE = flow::action<"GoToOffice">(
+        []() { std::cout << "Commute to office" << std::endl; });
 
-    constexpr static auto RETURN_HOME = flow::action(
-        "ReturnHome"_sc, []() { std::cout << "Commute to home" << std::endl; });
+    constexpr static auto RETURN_HOME = flow::action<"ReturnHome">(
+        []() { std::cout << "Commute to home" << std::endl; });
 
     // Extend flow services
     constexpr static auto config = cib::config(
@@ -179,31 +175,30 @@ struct commute_component_t {
 };
 
 struct daily_routine_component_t {
-    constexpr static auto DAILY_ROUTINES =
-        flow::action("Daily Routines"_sc, []() {
-            static const auto ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+    constexpr static auto DAILY_ROUTINES = flow::action<"Daily Routines">([]() {
+        static const auto ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
-            static bool daysRoutineComplete = false;
-            static uint32_t dayCount = 1;
-            static auto startTime = std::chrono::system_clock::now();
+        static bool daysRoutineComplete = false;
+        static uint32_t dayCount = 1;
+        static auto startTime = std::chrono::system_clock::now();
 
-            if (!daysRoutineComplete) {
-                std::cout << "----- Day: " << dayCount << " -----\n";
-                flow::run<morning_routine_t>();
-                flow::run<evening_routine_t>();
-                daysRoutineComplete = true;
-            }
+        if (!daysRoutineComplete) {
+            std::cout << "----- Day: " << dayCount << " -----\n";
+            flow::run<morning_routine_t>();
+            flow::run<evening_routine_t>();
+            daysRoutineComplete = true;
+        }
 
-            auto currentTime = std::chrono::system_clock::now();
-            auto elapsedTime =
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    currentTime - startTime);
-            if (elapsedTime.count() >= ONE_DAY_IN_MILLISECONDS) {
-                dayCount++;
-                startTime = currentTime;
-                daysRoutineComplete = false;
-            }
-        });
+        auto currentTime = std::chrono::system_clock::now();
+        auto elapsedTime =
+            std::chrono::duration_cast<std::chrono::milliseconds>(currentTime -
+                                                                  startTime);
+        if (elapsedTime.count() >= ONE_DAY_IN_MILLISECONDS) {
+            dayCount++;
+            startTime = currentTime;
+            daysRoutineComplete = false;
+        }
+    });
 
     constexpr static auto config = cib::config(
 

--- a/include/flow/README.md
+++ b/include/flow/README.md
@@ -9,7 +9,7 @@ point to register callbacks at compile-time. Flow implements the constexpr init(
 Flow extension points are declared by extending the `flow::service`.
 
 ```c++
-struct MorningRoutine : public flow::service<decltype("MorningRoutine"_sc)> {}; 
+struct MorningRoutine : public flow::service<"MorningRoutine"> {}; 
 ```
 
 The builder is used during the constexpr init() phase to define and extend the flow. Actions to be added to the flow are
@@ -17,11 +17,11 @@ declared and defined as constexpr constants. all_t actions added to a flow will 
 
 ```c++
 namespace food { 
-    constexpr static auto MAKE_COFFEE = flow::action("MAKE_COFFEE"_sc, [] { 
+    constexpr static auto MAKE_COFFEE = flow::action<"MAKE_COFFEE">([] { 
         coffee_maker.start(ground_coffee.take(100_grams), water.take(16_ounces)); 
     }); 
     
-    constexpr static auto DRINK_COFFEE = flow::action("DRINK_COFFEE"_sc, [] { 
+    constexpr static auto DRINK_COFFEE = flow::action<"DRINK_COFFEE">([] { 
         ...
     }); 
 } 
@@ -74,11 +74,11 @@ inserting additional actions with new dependencies.
 
 ```c++
 struct childcare { 
-    constexpr static auto PACK_SCHOOL_LUNCHES = flow::action("PACK_SCHOOL_LUNCHES"_sc, [] { 
+    constexpr static auto PACK_SCHOOL_LUNCHES = flow::action<"PACK_SCHOOL_LUNCHES">([] { 
         ...
     }); 
     
-    constexpr static auto SEND_KIDS_TO_SCHOOL = flow::action("SEND_KIDS_TO_SCHOOL"_sc, [] { 
+    constexpr static auto SEND_KIDS_TO_SCHOOL = flow::action<"SEND_KIDS_TO_SCHOOL">([] { 
         ...
     }); 
     
@@ -134,7 +134,7 @@ extended by multiple independent components to create new functionality.
 
 ```c++
 namespace exercise { 
-    constexpr static auto RIDE_STATIONARY_BIKE = flow::action("RIDE_STATIONARY_BIKE"_sc, [] { 
+    constexpr static auto RIDE_STATIONARY_BIKE = flow::action<"RIDE_STATIONARY_BIKE">([] { 
         ...
     }); 
     
@@ -213,7 +213,7 @@ defines the various extension points and ensures they get executed over and over
 ```c++
 // simple component for scheduling daily activities.
 struct day_cycle {
-    constexpr static auto DAY_CYCLE = flow::action("DAY_CYCLE"_sc, [] { 
+    constexpr static auto DAY_CYCLE = flow::action<"DAY_CYCLE">([] { 
         flow::run<MorningRoutine>();
         flow::run<DaytimeRoutine>();
         flow::run<EveningRoutine>();
@@ -266,7 +266,7 @@ automatically log the beginning and end of the `flow` as well as all actions.
 struct MyFlow : public flow::service<> {};
 
 // declare a flow with automatic logging enabled
-struct MyFlowWithLogging : public flow::service<decltype("MyFlowWithLogging"_sc)> {}; 
+struct MyFlowWithLogging : public flow::service<"MyFlowWithLogging"> {}; 
 ```
 
 ### `flow::action`
@@ -278,7 +278,7 @@ than once, but can be referenced by other actions when adding dependencies.
 #### Example
 
 ```c++
-constexpr static auto MY_ACTION_NAME = flow::action("MY_ACTION_NAME"_sc, [] {
+constexpr static auto MY_ACTION_NAME = flow::action<"MY_ACTION_NAME">([] {
     // do useful stuff
 }); 
 ```
@@ -291,7 +291,7 @@ within a `flow` in which other actions may base their dependencies on.
 #### Example
 
 ```c++
-constexpr static auto MY_MILESTONE_NAME = flow::milestone("MY_MILESTONE_NAME"_sc); 
+constexpr static auto MY_MILESTONE_NAME = flow::milestone<"MY_MILESTONE_NAME">(); 
 ```
 
 ### `flow::run`

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -6,6 +6,8 @@
 #include <flow/impl.hpp>
 #include <flow/milestone.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <cstddef>
 
 namespace flow {
@@ -22,11 +24,11 @@ namespace flow {
  * @see flow::graph_builder
  */
 
-template <typename Name = void, std::size_t NodeCapacity = 64,
+template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
 struct builder : graph_builder<node, Name, NodeCapacity, EdgeCapacity,
                                builder<Name, NodeCapacity, EdgeCapacity>> {
-    template <typename N, std::size_t Capacity>
+    template <stdx::ct_string N, std::size_t Capacity>
     using impl_t = flow::impl<N, Capacity>;
 };
 
@@ -39,7 +41,7 @@ struct builder : graph_builder<node, Name, NodeCapacity, EdgeCapacity,
  * @see cib::exports
  * @see cib::extend
  */
-template <typename Name = void, std::size_t NodeCapacity = 64,
+template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
 struct service : cib::builder_meta<builder<Name, NodeCapacity, EdgeCapacity>,
                                    FunctionPtr> {};

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -2,6 +2,7 @@
 
 #include <flow/common.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/cx_multimap.hpp>
 #include <stdx/cx_vector.hpp>
 
@@ -35,7 +36,7 @@ concept walkable = std::same_as<T, Node> or
  *         another.
  * @tparam Derived The class that uses graph_builder with CRTP.
  */
-template <typename Node, typename NameT, std::size_t NodeCapacity,
+template <typename Node, stdx::ct_string Name, std::size_t NodeCapacity,
           std::size_t EdgeCapacity, typename Derived>
 class graph_builder {
     using graph_t = stdx::cx_multimap<Node, Node, NodeCapacity, EdgeCapacity>;
@@ -76,7 +77,7 @@ class graph_builder {
     }
 
     template <typename BuilderValue,
-              template <typename, std::size_t> typename Output>
+              template <stdx::ct_string, std::size_t> typename Output>
     static auto run_impl() -> void {
         constexpr auto builder = BuilderValue::value;
         constexpr auto size = builder.size();
@@ -86,8 +87,7 @@ class graph_builder {
     }
 
   public:
-    using Name = NameT;
-
+    constexpr static auto name = Name;
     /**
      * Add flow descriptions. A flow description describes the dependencies
      * between two or more nodes.
@@ -132,7 +132,7 @@ class graph_builder {
      *
      * @return An object with all dependencies and requirements resolved.
      */
-    template <template <typename, std::size_t> typename Output,
+    template <template <stdx::ct_string, std::size_t> typename Output,
               std::size_t Capacity>
     [[nodiscard]] constexpr auto topo_sort() const
         -> std::optional<Output<Name, Capacity>> {

--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -35,9 +35,10 @@ struct interface {
  *
  * @see flow::builder
  */
-template <typename Name, std::size_t NumSteps> class impl : public interface {
+template <stdx::ct_string Name, std::size_t NumSteps>
+class impl : public interface {
   private:
-    constexpr static bool loggingEnabled = not std::is_void_v<Name>;
+    constexpr static bool loggingEnabled = not Name.empty();
 
     constexpr static auto capacity = [] {
         if constexpr (loggingEnabled) {
@@ -80,8 +81,10 @@ template <typename Name, std::size_t NumSteps> class impl : public interface {
      * Execute the entire flow in order.
      */
     auto operator()() const -> void final {
+        constexpr auto name =
+            stdx::ct_string_to_type<Name, sc::string_constant>();
         if constexpr (loggingEnabled) {
-            CIB_TRACE("flow.start({})", Name{});
+            CIB_TRACE("flow.start({})", name);
         }
 
         for (auto const func : functionPtrs) {
@@ -89,7 +92,7 @@ template <typename Name, std::size_t NumSteps> class impl : public interface {
         }
 
         if constexpr (loggingEnabled) {
-            CIB_TRACE("flow.end({})", Name{});
+            CIB_TRACE("flow.end({})", name);
         }
     }
 };

--- a/include/flow/milestone.hpp
+++ b/include/flow/milestone.hpp
@@ -3,6 +3,8 @@
 #include <flow/common.hpp>
 #include <log/log.hpp>
 
+#include <stdx/ct_string.hpp>
+
 namespace flow {
 struct node {
     using is_node = void;
@@ -23,16 +25,23 @@ struct node {
  * @return
  *      Node that will execute the given function pointer, f.
  */
-template <typename Name>
-[[nodiscard]] constexpr auto action(Name, FunctionPtr f) -> node {
-    return {.run = f, .log_name = [] { CIB_TRACE("flow.action({})", Name{}); }};
+template <stdx::ct_string Name>
+[[nodiscard]] constexpr auto action(FunctionPtr f) -> node {
+    return {.run = f, .log_name = [] {
+                CIB_TRACE("flow.action({})",
+                          stdx::ct_string_to_type<Name, sc::string_constant>());
+            }};
 }
 
 /**
  * @return
  *      Node with no associated action.
  */
-template <typename Name> [[nodiscard]] constexpr auto milestone(Name) -> node {
-    return {.log_name = [] { CIB_TRACE("flow.milestone({})", Name{}); }};
+template <stdx::ct_string Name>
+[[nodiscard]] constexpr auto milestone() -> node {
+    return {.log_name = [] {
+        CIB_TRACE("flow.milestone({})",
+                  stdx::ct_string_to_type<Name, sc::string_constant>());
+    }};
 }
 } // namespace flow

--- a/include/interrupt/builder/irq_builder.hpp
+++ b/include/interrupt/builder/irq_builder.hpp
@@ -61,8 +61,7 @@ template <typename ConfigT> struct irq_builder {
             BuilderValue::value.interrupt_service_routine;
         constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
-            irq_impl<ConfigT,
-                     flow::impl<typename IrqCallbackType::Name, flow_size>>(
+            irq_impl<ConfigT, flow::impl<IrqCallbackType::name, flow_size>>(
                 run_flow);
 
         return optimized_irq_impl;

--- a/include/interrupt/builder/sub_irq_builder.hpp
+++ b/include/interrupt/builder/sub_irq_builder.hpp
@@ -54,8 +54,7 @@ template <typename ConfigT> struct sub_irq_builder {
             BuilderValue::value.interrupt_service_routine;
         constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
-            sub_irq_impl<ConfigT,
-                         flow::impl<typename IrqCallbackType::Name, flow_size>>(
+            sub_irq_impl<ConfigT, flow::impl<IrqCallbackType::name, flow_size>>(
                 run_flow);
 
         return optimized_irq_impl;

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -15,6 +15,7 @@
 #include <interrupt/policies.hpp>
 
 #include <stdx/compiler.hpp>
+#include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
 
 #include <cstddef>
@@ -22,7 +23,8 @@
 #include <utility>
 
 namespace interrupt {
-template <typename Name = void> using irq_flow = flow::builder<Name, 16, 8>;
+template <stdx::ct_string Name = "">
+using irq_flow = flow::builder<Name, 16, 8>;
 
 template <typename FlowT, typename FlowDescriptionT> struct binding_t {
     FlowDescriptionT flow_description;

--- a/include/match/and.hpp
+++ b/include/match/and.hpp
@@ -15,8 +15,7 @@
 namespace match {
 template <matcher, matcher> struct or_t;
 
-template <matcher L, matcher R>
-struct and_t : bin_op_t<and_t, decltype(" and "_sc), L, R> {
+template <matcher L, matcher R> struct and_t : bin_op_t<and_t, " and ", L, R> {
     [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
         return this->lhs(event) and this->rhs(event);
     }

--- a/include/match/bin_op.hpp
+++ b/include/match/bin_op.hpp
@@ -6,11 +6,12 @@
 #include <match/simplify.hpp>
 #include <sc/string_constant.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/type_traits.hpp>
 
 namespace match {
-template <template <matcher, matcher> typename Term, typename OpName, matcher L,
-          matcher R>
+template <template <matcher, matcher> typename Term, stdx::ct_string OpName,
+          matcher L, matcher R>
 struct bin_op_t {
     using is_matcher = void;
 
@@ -38,7 +39,9 @@ struct bin_op_t {
                 return "("_sc + f(m) + ")"_sc;
             }
         };
-        return desc(lhs) + OpName{} + desc(rhs);
+        return desc(lhs) +
+               stdx::ct_string_to_type<OpName, sc::string_constant>() +
+               desc(rhs);
     }
 };
 

--- a/include/match/or.hpp
+++ b/include/match/or.hpp
@@ -14,8 +14,7 @@
 namespace match {
 template <matcher, matcher> struct and_t;
 
-template <matcher L, matcher R>
-struct or_t : bin_op_t<or_t, decltype(" or "_sc), L, R> {
+template <matcher L, matcher R> struct or_t : bin_op_t<or_t, " or ", L, R> {
     [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
         return this->lhs(event) or this->rhs(event);
     }

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -5,9 +5,11 @@
 #include <lookup/lookup.hpp>
 #include <match/ops.hpp>
 #include <msg/field_matchers.hpp>
+#include <sc/string_constant.hpp>
 
 #include <stdx/bitset.hpp>
 #include <stdx/compiler.hpp>
+#include <stdx/ct_string.hpp>
 #include <stdx/cx_map.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
@@ -126,7 +128,8 @@ struct indexed_builder_base {
             CIB_INFO(
                 "Incoming message matched [{}], because [{}] (collapsed to "
                 "[{}]), executing callback",
-                cb.name, orig_cb.matcher.describe(), cb.matcher.describe());
+                stdx::ct_string_to_type<cb.name, sc::string_constant>(),
+                orig_cb.matcher.describe(), cb.matcher.describe());
             cb.callable(msg, args...);
         }
     }

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -6,6 +6,8 @@
 #include <seq/impl.hpp>
 #include <seq/step.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <cstddef>
 
 namespace seq {
@@ -22,12 +24,12 @@ namespace seq {
  * @see flow::graph_builder
  */
 
-template <typename Name = void, std::size_t NodeCapacity = 64,
+template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
 struct builder
     : flow::graph_builder<step_base, Name, NodeCapacity, EdgeCapacity,
                           builder<Name, NodeCapacity, EdgeCapacity>> {
-    template <typename N, std::size_t Capacity>
+    template <stdx::ct_string N, std::size_t Capacity>
     using impl_t = seq::impl<N, Capacity>;
 };
 
@@ -40,7 +42,7 @@ struct builder
  * @see cib::exports
  * @see cib::extend
  */
-template <typename Name = void, std::size_t NodeCapacity = 64,
+template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
 struct service : cib::builder_meta<builder<Name, NodeCapacity, EdgeCapacity>,
                                    flow::FunctionPtr> {};

--- a/include/seq/impl.hpp
+++ b/include/seq/impl.hpp
@@ -3,6 +3,7 @@
 #include <log/log.hpp>
 #include <seq/step.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/cx_vector.hpp>
 
 #include <array>
@@ -13,7 +14,7 @@
 namespace seq {
 enum struct direction { FORWARD = 0, BACKWARD = 1 };
 
-template <typename, std::size_t NumSteps> struct impl {
+template <stdx::ct_string, std::size_t NumSteps> struct impl {
     stdx::cx_vector<func_ptr, NumSteps> _forward_steps{};
     stdx::cx_vector<func_ptr, NumSteps> _backward_steps{};
     std::size_t next_step{};

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -8,13 +8,13 @@
 namespace {
 auto actual = std::string("");
 
-constexpr auto milestone0 = flow::milestone("milestone0"_sc);
-constexpr auto milestone1 = flow::milestone("milestone1"_sc);
+constexpr auto milestone0 = flow::milestone<"milestone0">();
+constexpr auto milestone1 = flow::milestone<"milestone1">();
 
-constexpr auto a = flow::action("a"_sc, [] { actual += "a"; });
-constexpr auto b = flow::action("b"_sc, [] { actual += "b"; });
-constexpr auto c = flow::action("c"_sc, [] { actual += "c"; });
-constexpr auto d = flow::action("d"_sc, [] { actual += "d"; });
+constexpr auto a = flow::action<"a">([] { actual += "a"; });
+constexpr auto b = flow::action<"b">([] { actual += "b"; });
+constexpr auto c = flow::action<"c">([] { actual += "c"; });
+constexpr auto d = flow::action<"d">([] { actual += "d"; });
 
 TEST_CASE("build and run empty flow", "[flow]") {
     flow::builder<> builder;
@@ -224,7 +224,7 @@ TEST_CASE("add parallel lhs", "[flow]") {
 }
 
 TEST_CASE("add parallel in the middle", "[flow]") {
-    flow::builder<decltype("MiddleParallelFlow"_sc)> builder;
+    flow::builder<"MiddleParallelFlow"> builder;
     actual = "";
 
     builder.add(a >> (b && c) >> d);

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -31,26 +31,26 @@ inline auto logging::config<> =
     logging::fmt::config{std::back_inserter(log_buffer)};
 
 TEST_CASE("callback matches message", "[handler]") {
-    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto callback = msg::callback<"cb", msg_defn>(match::always, [] {});
     auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
     CHECK(callback.is_match(msg_match));
 }
 
 TEST_CASE("callback matches message (alternative range)", "[handler]") {
-    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto callback = msg::callback<"cb", msg_defn>(match::always, [] {});
     auto const msg_match = std::array<std::uint8_t, 8>{0x11, 0xba, 0x00, 0x80,
                                                        0x0d, 0xd0, 0x42, 0x00};
     CHECK(callback.is_match(msg_match));
 }
 
 TEST_CASE("callback matches message (typed message)", "[handler]") {
-    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto callback = msg::callback<"cb", msg_defn>(match::always, [] {});
     auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
     CHECK(callback.is_match(msg_match));
 }
 
 TEST_CASE("callback logs mismatch (raw)", "[handler]") {
-    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto callback = msg::callback<"cb", msg_defn>(match::always, [] {});
     auto const msg_nomatch = std::array{0x8100ba11u, 0x0042d00du};
     CHECK(not callback.is_match(msg_nomatch));
 
@@ -61,7 +61,7 @@ TEST_CASE("callback logs mismatch (raw)", "[handler]") {
 }
 
 TEST_CASE("callback logs mismatch (typed)", "[handler]") {
-    auto callback = msg::callback<msg_defn>("cb"_sc, match::always, [] {});
+    auto callback = msg::callback<"cb", msg_defn>(match::always, [] {});
     auto const msg_nomatch = msg::owning<msg_defn>{"id"_field = 0x81};
     CHECK(not callback.is_match(msg_nomatch));
 
@@ -72,9 +72,8 @@ TEST_CASE("callback logs mismatch (typed)", "[handler]") {
 }
 
 TEST_CASE("callback handles message (raw)", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        ""_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
 
     dispatched = false;
@@ -83,9 +82,8 @@ TEST_CASE("callback handles message (raw)", "[handler]") {
 }
 
 TEST_CASE("callback handles message (typed)", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        ""_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
 
     dispatched = false;
@@ -94,9 +92,8 @@ TEST_CASE("callback handles message (typed)", "[handler]") {
 }
 
 TEST_CASE("callback logs match", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        "cb"_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg_match = std::array{0x8000ba11u, 0x0042d00du};
 
     log_buffer.clear();

--- a/test/msg/fail/impossible_match_callback.cpp
+++ b/test/msg/fail/impossible_match_callback.cpp
@@ -16,8 +16,7 @@ using test_id_field =
 using msg_defn = message<"test_msg", test_id_field>;
 using test_msg_t = owning<msg_defn>;
 
-constexpr auto test_callback = msg::indexed_callback(
-    "test_callback"_sc,
+constexpr auto test_callback = msg::indexed_callback<"test_callback">(
     test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
     [](test_msg_t const &) {});
 

--- a/test/msg/fail/impossible_match_field.cpp
+++ b/test/msg/fail/impossible_match_field.cpp
@@ -16,9 +16,8 @@ using test_id_field =
 using msg_defn = message<"test_msg", test_id_field::WithRequired<0x80>>;
 using test_msg_t = owning<msg_defn>;
 
-constexpr auto test_callback =
-    msg::indexed_callback("test_callback"_sc, test_id_field::equal_to<0x81>,
-                          [](test_msg_t const &) {});
+constexpr auto test_callback = msg::indexed_callback<"test_callback">(
+    test_id_field::equal_to<0x81>, [](test_msg_t const &) {});
 
 using index_spec = msg::index_spec<test_id_field>;
 struct test_service : msg::indexed_service<index_spec, test_msg_t> {};

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -37,9 +37,8 @@ inline auto logging::config<> =
     logging::fmt::config{std::back_inserter(log_buffer)};
 
 TEST_CASE("is_match is true for a match", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        "cb"_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg = std::array{0x8000ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
@@ -48,9 +47,8 @@ TEST_CASE("is_match is true for a match", "[handler]") {
 }
 
 TEST_CASE("dispatch single callback (match, raw data)", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        "cb"_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg = std::array{0x8000ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
@@ -61,9 +59,8 @@ TEST_CASE("dispatch single callback (match, raw data)", "[handler]") {
 }
 
 TEST_CASE("dispatch single callback (match, typed data)", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        "cb"_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg = msg::owning<msg_defn>{"id"_field = 0x80};
 
     auto callbacks = stdx::make_tuple(callback);
@@ -74,9 +71,8 @@ TEST_CASE("dispatch single callback (match, typed data)", "[handler]") {
 }
 
 TEST_CASE("dispatch single callback (no match)", "[handler]") {
-    auto callback = msg::callback<msg_defn>(
-        "cb"_sc, match::always,
-        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto callback = msg::callback<"cb", msg_defn>(
+        match::always, [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg = std::array{0x8100ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
@@ -98,11 +94,10 @@ TEST_CASE("log mismatch when no match", "[handler]") {
 }
 
 TEST_CASE("match and dispatch only one callback", "[handler]") {
-    auto callback1 = msg::callback<msg_defn>(
-        "cb1"_sc, match::always,
-        [&](msg::const_view<msg_defn>) { CHECK(false); });
-    auto callback2 = msg::callback<msg_defn_field_reqd>(
-        "TestCallback2"_sc, match::always,
+    auto callback1 = msg::callback<"cb1", msg_defn>(
+        match::always, [&](msg::const_view<msg_defn>) { CHECK(false); });
+    auto callback2 = msg::callback<"cb2", msg_defn_field_reqd>(
+        match::always,
         [](msg::const_view<msg_defn_field_reqd>) { dispatched = true; });
     auto const msg = std::array{0x4400ba11u, 0x0042d00du};
 
@@ -116,8 +111,8 @@ TEST_CASE("match and dispatch only one callback", "[handler]") {
 }
 
 TEST_CASE("dispatch with extra args", "[handler]") {
-    auto callback = msg::callback<msg_defn, int>(
-        "cb"_sc, match::always, [](msg::const_view<msg_defn>, int value) {
+    auto callback = msg::callback<"cb", msg_defn, int>(
+        match::always, [](msg::const_view<msg_defn>, int value) {
             dispatched = true;
             CHECK(value == 0xcafe);
         });

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -28,8 +28,8 @@ struct test_service : msg::service<msg_view_t> {};
 
 bool callback_success;
 
-constexpr auto test_callback = msg::callback<msg_defn>(
-    "cb"_sc, match::always, [](msg_view_t) { callback_success = true; });
+constexpr auto test_callback = msg::callback<"cb", msg_defn>(
+    match::always, [](msg_view_t) { callback_success = true; });
 
 struct test_project {
     constexpr static auto config = cib::config(

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -33,9 +33,9 @@ struct test_service : indexed_service<index_spec, test_msg_t> {};
 
 bool callback_success;
 
-constexpr auto test_callback =
-    indexed_callback("TestCallback"_sc, test_id_field::in<0x80>,
-                     [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback = indexed_callback<"TestCallback">(
+    test_id_field::in<0x80>,
+    [](test_msg_t const &) { callback_success = true; });
 
 struct test_project {
     constexpr static auto config = cib::config(
@@ -90,9 +90,9 @@ TEST_CASE("match output failure", "[handler_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_equals =
-    msg::indexed_callback("TestCallback"_sc, test_id_field::equal_to<0x80>,
-                          [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_equals = msg::indexed_callback<"TestCallback">(
+    test_id_field::equal_to<0x80>,
+    [](test_msg_t const &) { callback_success = true; });
 
 struct test_project_equals {
     constexpr static auto config =
@@ -117,16 +117,17 @@ TEST_CASE("build handler field equal_to", "[indexed_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_multi_field = msg::indexed_callback(
-    "test_callback_multi_field"_sc,
-    test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
-    [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_multi_field =
+    msg::indexed_callback<"test_callback_multi_field">(
+        test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        [](test_msg_t const &) { callback_success = true; });
 
 bool callback_success_single_field;
 
-constexpr auto test_callback_single_field = msg::indexed_callback(
-    "test_callback_single_field"_sc, test_id_field::equal_to<0x50>,
-    [](test_msg_t const &) { callback_success_single_field = true; });
+constexpr auto test_callback_single_field =
+    msg::indexed_callback<"test_callback_single_field">(
+        test_id_field::equal_to<0x50>,
+        [](test_msg_t const &) { callback_success_single_field = true; });
 
 struct test_project_multi_field {
     constexpr static auto config =
@@ -195,9 +196,10 @@ TEST_CASE("message matching partial index but not callback matcher",
 }
 
 namespace {
-constexpr auto test_callback_not_single_field = msg::indexed_callback(
-    "test_callback_not_single_field"_sc, not test_id_field::equal_to<0x50>,
-    [](test_msg_t const &) { callback_success_single_field = true; });
+constexpr auto test_callback_not_single_field =
+    msg::indexed_callback<"test_callback_not_single_field">(
+        not test_id_field::equal_to<0x50>,
+        [](test_msg_t const &) { callback_success_single_field = true; });
 
 struct test_project_not_single_field {
     constexpr static auto config =
@@ -225,10 +227,10 @@ TEST_CASE("build handler not single field", "[indexed_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_not_multi_field = msg::indexed_callback(
-    "test_callback_multi_field"_sc,
-    not test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
-    [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_not_multi_field =
+    msg::indexed_callback<"test_callback_multi_field">(
+        not test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        [](test_msg_t const &) { callback_success = true; });
 
 struct test_project_not_multi_field {
     constexpr static auto config =
@@ -275,10 +277,10 @@ TEST_CASE("build handler not multi fields", "[indexed_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_disjunction = msg::indexed_callback(
-    "test_callback_multi_field"_sc,
-    test_id_field::equal_to<0x80> or test_opcode_field::equal_to<1>,
-    [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_disjunction =
+    msg::indexed_callback<"test_callback_multi_field">(
+        test_id_field::equal_to<0x80> or test_opcode_field::equal_to<1>,
+        [](test_msg_t const &) { callback_success = true; });
 
 struct test_project_disjunction {
     constexpr static auto config =
@@ -315,9 +317,8 @@ using msg_match_index_spec = msg::index_spec<test_id_field>;
 struct test_msg_match_service
     : msg::indexed_service<msg_match_index_spec, test_msg_match_t> {};
 
-constexpr auto test_msg_match_callback = msg::indexed_callback(
-    "TestCallback"_sc, match::always,
-    [](test_msg_match_t const &) { callback_success = true; });
+constexpr auto test_msg_match_callback = msg::indexed_callback<"TestCallback">(
+    match::always, [](test_msg_match_t const &) { callback_success = true; });
 
 struct test_msg_match_project {
     constexpr static auto config = cib::config(
@@ -343,10 +344,10 @@ TEST_CASE("match output success (message matcher)", "[handler_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_impossible = msg::indexed_callback(
-    "test_callback_impossible"_sc,
-    test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
-    [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_impossible =
+    msg::indexed_callback<"test_callback_impossible">(
+        test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
+        [](test_msg_t const &) { callback_success = true; });
 
 struct test_project_impossible {
     constexpr static auto config =

--- a/test/msg/indexed_callback.cpp
+++ b/test/msg/indexed_callback.cpp
@@ -59,14 +59,13 @@ template <typename T, T Value> struct test_m {
 } // namespace
 
 TEST_CASE("callback matches trivially", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(""_sc, test_m<int, 0>{}, [] {});
+    constexpr auto cb = msg::indexed_callback<"">(test_m<int, 0>{}, [] {});
     CHECK(cb.matcher(msg_t{}));
     CHECK(not cb.matcher(msg_t{1, 'a'}));
 }
 
 TEST_CASE("callback with compound match", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
     CHECK(not cb.matcher(msg_t{}));
@@ -75,8 +74,7 @@ TEST_CASE("callback with compound match", "[indexed_callback]") {
 }
 
 TEST_CASE("callback is sum of products", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
     static_assert(
@@ -87,8 +85,7 @@ TEST_CASE("callback is sum of products", "[indexed_callback]") {
 }
 
 TEST_CASE("index a callback", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
 
@@ -113,8 +110,7 @@ TEST_CASE("index a callback", "[indexed_callback]") {
 }
 
 TEST_CASE("index not terms in a callback", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         not test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
 
@@ -137,8 +133,7 @@ TEST_CASE("index not terms in a callback", "[indexed_callback]") {
 }
 
 TEST_CASE("remove an indexed term from a callback", "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
 
@@ -150,8 +145,7 @@ TEST_CASE("remove an indexed term from a callback", "[indexed_callback]") {
 
 TEST_CASE("remove multiple indexed terms from a callback",
           "[indexed_callback]") {
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc,
+    constexpr auto cb = msg::indexed_callback<"">(
         test_m<int, 0>{} and (test_m<char, 'a'>{} or test_m<char, 'b'>{}),
         [] {});
 
@@ -165,8 +159,8 @@ int called{};
 
 TEST_CASE("separate sum terms in a callback", "[indexed_callback]") {
     called = 0;
-    constexpr auto cb = msg::indexed_callback(
-        ""_sc, test_m<int, 0>{} or test_m<int, 1>{}, [] { ++called; });
+    constexpr auto cb = msg::indexed_callback<"">(
+        test_m<int, 0>{} or test_m<int, 1>{}, [] { ++called; });
     CHECK(cb.matcher(msg_t{}));
 
     auto sut = msg::separate_sum_terms(cb);

--- a/test/msg/rle_indexed_builder.cpp
+++ b/test/msg/rle_indexed_builder.cpp
@@ -33,9 +33,9 @@ struct test_service : rle_indexed_service<index_spec, test_msg_t> {};
 
 bool callback_success;
 
-constexpr auto test_callback =
-    msg::indexed_callback("TestCallback"_sc, test_id_field::in<0x80>,
-                          [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback = msg::indexed_callback<"TestCallback">(
+    test_id_field::in<0x80>,
+    [](test_msg_t const &) { callback_success = true; });
 
 struct test_project {
     constexpr static auto config = cib::config(
@@ -90,9 +90,9 @@ TEST_CASE("match rle output failure", "[rle_handler_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_equals =
-    msg::indexed_callback("TestCallback"_sc, test_id_field::equal_to<0x80>,
-                          [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_equals = msg::indexed_callback<"TestCallback">(
+    test_id_field::equal_to<0x80>,
+    [](test_msg_t const &) { callback_success = true; });
 
 struct test_project_equals {
     constexpr static auto config =
@@ -117,16 +117,17 @@ TEST_CASE("build rle handler field equal_to", "[rle_indexed_builder]") {
 }
 
 namespace {
-constexpr auto test_callback_multi_field = msg::indexed_callback(
-    "test_callback_multi_field"_sc,
-    test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
-    [](test_msg_t const &) { callback_success = true; });
+constexpr auto test_callback_multi_field =
+    msg::indexed_callback<"test_callback_multi_field">(
+        test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        [](test_msg_t const &) { callback_success = true; });
 
 bool callback_success_single_field;
 
-constexpr auto test_callback_single_field = msg::indexed_callback(
-    "test_callback_single_field"_sc, test_id_field::equal_to<0x50>,
-    [](test_msg_t const &) { callback_success_single_field = true; });
+constexpr auto test_callback_single_field =
+    msg::indexed_callback<"test_callback_single_field">(
+        test_id_field::equal_to<0x50>,
+        [](test_msg_t const &) { callback_success_single_field = true; });
 
 struct test_project_multi_field {
     constexpr static auto config =


### PR DESCRIPTION
With C++20, we can pass strings as NTTPs directly and we don't need to say `decltype("hello"_sc)` everywhere.