### PR TITLE
:art: Clean up interrupt lib

### DIFF
--- a/include/interrupt/builder/irq_builder.hpp
+++ b/include/interrupt/builder/irq_builder.hpp
@@ -19,12 +19,12 @@ namespace interrupt {
  * @tparam IrqPriorityT
  *      Hardware IRQ priority.
  */
-template <typename ConfigT> struct irq_builder {
-    using IrqCallbackType = typename ConfigT::IrqCallbackType;
-    constexpr static auto irq_number = ConfigT::irq_number;
+template <typename Config> struct irq_builder {
+    using irq_callback_t = typename Config::irq_callback_t;
+    constexpr static auto irq_number = Config::irq_number;
 
   private:
-    IrqCallbackType interrupt_service_routine;
+    irq_callback_t interrupt_service_routine;
 
   public:
     /**
@@ -36,9 +36,8 @@ template <typename ConfigT> struct irq_builder {
      * @param flow_description
      *      See flow::Builder<>.add()
      */
-    template <typename IrqType, typename T>
-    constexpr void add(T const &flow_description) {
-        if constexpr (std::is_same_v<IrqCallbackType, IrqType>) {
+    template <typename Irq> constexpr void add(auto const &flow_description) {
+        if constexpr (std::is_same_v<irq_callback_t, Irq>) {
             interrupt_service_routine.add(flow_description);
         }
     }
@@ -61,7 +60,7 @@ template <typename ConfigT> struct irq_builder {
             BuilderValue::value.interrupt_service_routine;
         constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
-            irq_impl<ConfigT, flow::impl<IrqCallbackType::name, flow_size>>(
+            irq_impl<Config, flow::impl<irq_callback_t::name, flow_size>>(
                 run_flow);
 
         return optimized_irq_impl;

--- a/include/interrupt/builder/shared_irq_builder.hpp
+++ b/include/interrupt/builder/shared_irq_builder.hpp
@@ -22,7 +22,7 @@ namespace interrupt {
  * specialization should be declared by the user while the interrupt::Manager
  * creates and manages instances of shared_irq.
  */
-template <typename ConfigT> class shared_irq_builder {
+template <typename Config> class shared_irq_builder {
     template <typename BuilderValue, std::size_t Index> struct sub_value {
         constexpr static auto const &value =
             get<Index>(BuilderValue::value.irqs);
@@ -36,7 +36,7 @@ template <typename ConfigT> class shared_irq_builder {
     }
 
   public:
-    constexpr static auto children = ConfigT::children;
+    constexpr static auto children = Config::children;
 
     constexpr static auto irqs_type = stdx::transform(
         [](auto child) {
@@ -46,7 +46,7 @@ template <typename ConfigT> class shared_irq_builder {
                 return sub_irq_builder<decltype(child)>{};
             }
         },
-        ConfigT::children);
+        Config::children);
 
     std::remove_cv_t<decltype(irqs_type)> irqs;
 
@@ -67,7 +67,7 @@ template <typename ConfigT> class shared_irq_builder {
             std::make_index_sequence<irqs_t::size()>{});
 
         return sub_irq_impls.apply([](auto... sub_irq_impl_args) {
-            return shared_irq_impl<ConfigT, decltype(sub_irq_impl_args)...>(
+            return shared_irq_impl<Config, decltype(sub_irq_impl_args)...>(
                 sub_irq_impl_args...);
         });
     }

--- a/include/interrupt/builder/shared_sub_irq_builder.hpp
+++ b/include/interrupt/builder/shared_sub_irq_builder.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 
 namespace interrupt {
-template <typename ConfigT> class shared_sub_irq_builder {
+template <typename Config> class shared_sub_irq_builder {
     template <typename BuilderValue, std::size_t Index> struct sub_value {
         constexpr static auto const &value =
             get<Index>(BuilderValue::value.irqs);
@@ -24,9 +24,9 @@ template <typename ConfigT> class shared_sub_irq_builder {
     }
 
   public:
-    constexpr static auto resources = ConfigT::resources;
-    using IrqCallbackType = typename ConfigT::IrqCallbackType;
-    constexpr static auto children = ConfigT::children;
+    constexpr static auto resources = Config::resources;
+    using irq_callback_t = typename Config::irq_callback_t;
+    constexpr static auto children = Config::children;
 
     constexpr static auto irqs_type = stdx::transform(
         [](auto child) {
@@ -36,7 +36,7 @@ template <typename ConfigT> class shared_sub_irq_builder {
                 return sub_irq_builder<decltype(child)>{};
             }
         },
-        ConfigT::children);
+        Config::children);
 
     std::remove_cv_t<decltype(irqs_type)> irqs;
 
@@ -57,7 +57,7 @@ template <typename ConfigT> class shared_sub_irq_builder {
             std::make_index_sequence<sub_irqs_t::size()>{});
 
         return sub_irq_impls.apply([](auto... sub_irq_impl_args) {
-            return shared_sub_irq_impl<ConfigT, decltype(sub_irq_impl_args)...>(
+            return shared_sub_irq_impl<Config, decltype(sub_irq_impl_args)...>(
                 sub_irq_impl_args...);
         });
     }

--- a/include/interrupt/builder/sub_irq_builder.hpp
+++ b/include/interrupt/builder/sub_irq_builder.hpp
@@ -13,11 +13,11 @@ namespace interrupt {
  * specialization should be declared by the user while the interrupt::Manager
  * creates and manages instances of shared_irq.
  */
-template <typename ConfigT> struct sub_irq_builder {
-    using IrqCallbackType = typename ConfigT::IrqCallbackType;
+template <typename Config> struct sub_irq_builder {
+    using irq_callback_t = typename Config::irq_callback_t;
 
   private:
-    IrqCallbackType interrupt_service_routine;
+    irq_callback_t interrupt_service_routine;
 
   public:
     /**
@@ -29,9 +29,9 @@ template <typename ConfigT> struct sub_irq_builder {
      * @param flow_description
      *      See flow::Builder<>.add()
      */
-    template <typename IrqType, typename T>
-    constexpr void add(T const &flow_description) {
-        if constexpr (std::is_same_v<IrqCallbackType, IrqType>) {
+    template <typename IrqType>
+    constexpr void add(auto const &flow_description) {
+        if constexpr (std::is_same_v<irq_callback_t, IrqType>) {
             interrupt_service_routine.add(flow_description);
         }
     }
@@ -54,7 +54,7 @@ template <typename ConfigT> struct sub_irq_builder {
             BuilderValue::value.interrupt_service_routine;
         constexpr auto flow_size = flow_builder.size();
         auto const optimized_irq_impl =
-            sub_irq_impl<ConfigT, flow::impl<IrqCallbackType::name, flow_size>>(
+            sub_irq_impl<Config, flow::impl<irq_callback_t::name, flow_size>>(
                 run_flow);
 
         return optimized_irq_impl;

--- a/include/interrupt/config/irq.hpp
+++ b/include/interrupt/config/irq.hpp
@@ -16,27 +16,28 @@ namespace interrupt {
  * specialization should be declared by the user while the interrupt::Manager
  * creates and manages instances of irq.
  *
- * @tparam IrqNumberT
+ * @tparam IrqNumber
  *      Hardware IRQ number.
  *
- * @tparam IrqPriorityT
+ * @tparam IrqPriority
  *      Hardware IRQ priority.
  */
-template <std::size_t IrqNumberT, std::size_t IrqPriorityT,
-          typename IrqCallbackT, typename PoliciesT>
+template <irq_num_t IrqNumber, std::size_t IrqPriority, typename IrqCallback,
+          typename Policies>
 struct irq {
-    template <bool en>
+    template <bool Enable>
     constexpr static FunctionPtr enable_action =
-        hal::irq_init<en, IrqNumberT, IrqPriorityT>;
-    using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
-                                                           clear_status_first>;
+        hal::irq_init<Enable, IrqNumber, IrqPriority>;
+    using status_policy_t =
+        typename Policies::template type<status_clear_policy,
+                                         clear_status_first>;
     constexpr static auto resources =
-        PoliciesT::template get<required_resources_policy,
-                                required_resources<>>()
+        Policies::template get<required_resources_policy,
+                               required_resources<>>()
             .resources;
-    using IrqCallbackType = IrqCallbackT;
-    constexpr static stdx::tuple<> children{};
+    using irq_callback_t = IrqCallback;
 
-    constexpr static auto irq_number = IrqNumberT;
+    constexpr static auto children = stdx::tuple{};
+    constexpr static auto irq_number = IrqNumber;
 };
 } // namespace interrupt

--- a/include/interrupt/config/root.hpp
+++ b/include/interrupt/config/root.hpp
@@ -7,16 +7,13 @@
 #include <stdx/tuple_algorithms.hpp>
 
 namespace interrupt {
-template <typename... IrqsT> struct root {
-    template <typename T, bool en>
-    constexpr static FunctionPtr enable_action = [] {};
-    using StatusPolicy = clear_status_first;
-    constexpr static auto resources = stdx::make_tuple();
-    using IrqCallbackType = void;
-    constexpr static stdx::tuple<IrqsT...> children{};
+template <typename... Irqs> struct root {
+    using status_policy_t = clear_status_first;
+    constexpr static auto resources = stdx::tuple{};
+    constexpr static auto children = stdx::tuple<Irqs...>{};
 
   private:
-    template <typename IrqType> constexpr static auto getAllIrqs(IrqType irq) {
+    template <typename Irq> constexpr static auto getAllIrqs(Irq irq) {
         return irq.children.apply([&](auto... irqChildren) {
             return stdx::tuple_cat(getAllIrqs(irqChildren)...,
                                    stdx::make_tuple(irq));

--- a/include/interrupt/config/shared_irq.hpp
+++ b/include/interrupt/config/shared_irq.hpp
@@ -18,31 +18,32 @@ namespace interrupt {
  * specialization should be declared by the user while the interrupt::Manager
  * creates and manages instances of shared_irq.
  *
- * @tparam IrqNumberT
+ * @tparam IrqNumber
  *      Hardware IRQ number.
  *
- * @tparam IrqPriorityT
+ * @tparam IrqPriority
  *      Hardware IRQ priority.
  *
  * @tparam SubIrqs
  *      One or more sub_irq types in this shared_irq.
  */
-template <std::size_t IrqNumberT, std::size_t IrqPriorityT, typename PoliciesT,
+template <irq_num_t IrqNumber, std::size_t IrqPriority, typename Policies,
           typename... SubIrqs>
 struct shared_irq {
   public:
-    template <bool en>
+    template <bool Enable>
     constexpr static FunctionPtr enable_action =
-        hal::irq_init<en, IrqNumberT, IrqPriorityT>;
-    using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
-                                                           clear_status_first>;
+        hal::irq_init<Enable, IrqNumber, IrqPriority>;
+    using status_policy_t =
+        typename Policies::template type<status_clear_policy,
+                                         clear_status_first>;
     constexpr static auto resources =
-        PoliciesT::template get<required_resources_policy,
-                                required_resources<>>()
+        Policies::template get<required_resources_policy,
+                               required_resources<>>()
             .resources;
-    using IrqCallbackType = void;
-    constexpr static stdx::tuple<SubIrqs...> children{};
 
-    constexpr static auto irq_number = IrqNumberT;
+    using irq_callback_t = void;
+    constexpr static auto children = stdx::tuple<SubIrqs...>{};
+    constexpr static auto irq_number = IrqNumber;
 };
 } // namespace interrupt

--- a/include/interrupt/config/shared_sub_irq.hpp
+++ b/include/interrupt/config/shared_sub_irq.hpp
@@ -6,19 +6,20 @@
 #include <stdx/tuple.hpp>
 
 namespace interrupt {
-template <typename EnableField, typename StatusField, typename PoliciesT,
+template <typename EnableField, typename StatusField, typename Policies,
           typename... SubIrqs>
 struct shared_sub_irq {
-    template <bool en> constexpr static FunctionPtr enable_action = [] {};
+    template <bool> constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
-    using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
-                                                           clear_status_first>;
+    using status_policy_t =
+        typename Policies::template type<status_clear_policy,
+                                         clear_status_first>;
     constexpr static auto resources =
-        PoliciesT::template get<required_resources_policy,
-                                required_resources<>>()
+        Policies::template get<required_resources_policy,
+                               required_resources<>>()
             .resources;
-    using IrqCallbackType = void;
-    constexpr static stdx::tuple<SubIrqs...> children{};
+    using irq_callback_t = void;
+    constexpr static auto children = stdx::tuple<SubIrqs...>{};
 };
 } // namespace interrupt

--- a/include/interrupt/config/sub_irq.hpp
+++ b/include/interrupt/config/sub_irq.hpp
@@ -20,19 +20,20 @@ namespace interrupt {
  *      The croo register field that indicates if this interrupt is pending or
  * not.
  */
-template <typename EnableField, typename StatusField, typename IrqCallbackT,
-          typename PoliciesT>
+template <typename EnableField, typename StatusField, typename IrqCallback,
+          typename Policies>
 struct sub_irq {
-    template <bool en> constexpr static FunctionPtr enable_action = [] {};
+    template <bool> constexpr static FunctionPtr enable_action = [] {};
     constexpr static auto enable_field = EnableField{};
     constexpr static auto status_field = StatusField{};
-    using StatusPolicy = typename PoliciesT::template type<status_clear_policy,
-                                                           clear_status_first>;
+    using status_policy_t =
+        typename Policies::template type<status_clear_policy,
+                                         clear_status_first>;
     constexpr static auto resources =
-        PoliciesT::template get<required_resources_policy,
-                                required_resources<>>()
+        Policies::template get<required_resources_policy,
+                               required_resources<>>()
             .resources;
-    using IrqCallbackType = IrqCallbackT;
-    constexpr static stdx::tuple<> children{};
+    using irq_callback_t = IrqCallback;
+    constexpr static auto children = stdx::tuple{};
 };
 } // namespace interrupt

--- a/include/interrupt/fwd.hpp
+++ b/include/interrupt/fwd.hpp
@@ -1,5 +1,16 @@
 #pragma once
 
+#include <stdx/compiler.hpp>
+
+#include <cstdint>
+
 namespace interrupt {
 using FunctionPtr = auto (*)() -> void;
+
+enum struct irq_num_t : std::uint32_t {};
+
+// NOLINTNEXTLINE(google-runtime-int)
+CONSTEVAL auto operator""_irq(unsigned long long int v) -> irq_num_t {
+    return static_cast<irq_num_t>(v);
+}
 } // namespace interrupt

--- a/include/interrupt/hal.hpp
+++ b/include/interrupt/hal.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <interrupt/fwd.hpp>
 #include <interrupt/policies.hpp>
 
 #include <stdx/concepts.hpp>
@@ -10,23 +11,23 @@ template <typename T>
 concept hal_interface = requires(T const &t, void (*isr)()) {
     { t.init() } -> stdx::same_as<void>;
     {
-        t.template irq_init<true, std::size_t{}, std::size_t{}>()
+        t.template irq_init<true, irq_num_t{}, std::size_t{}>()
     } -> stdx::same_as<void>;
     {
-        t.template run<dont_clear_status>(std::size_t{}, isr)
+        t.template run<dont_clear_status>(irq_num_t{}, isr)
     } -> stdx::same_as<void>;
 };
 
 template <typename...> struct null_hal {
     static auto init() -> void { undefined(); }
 
-    template <bool Enable, int IrqNumber, int PriorityLevel>
+    template <bool Enable, irq_num_t IrqNumber, std::size_t PriorityLevel>
     static auto irq_init() -> void {
         undefined();
     }
 
     template <status_policy>
-    static auto run(std::size_t, stdx::invocable auto const &) -> void {
+    static auto run(irq_num_t, stdx::invocable auto const &) -> void {
         undefined();
     }
 
@@ -47,7 +48,7 @@ struct hal {
         injected_hal<Ts...>.init();
     }
 
-    template <bool Enable, int IrqNumber, int Priority, typename... Ts>
+    template <bool Enable, irq_num_t IrqNumber, int Priority, typename... Ts>
         requires(sizeof...(Ts) == 0)
     static auto irq_init() -> void {
         injected_hal<Ts...>.template irq_init<Enable, IrqNumber, Priority>();
@@ -55,7 +56,7 @@ struct hal {
 
     template <status_policy P, typename... Ts>
         requires(sizeof...(Ts) == 0)
-    static auto run(std::size_t irq, stdx::invocable auto const &isr) -> void {
+    static auto run(irq_num_t irq, stdx::invocable auto const &isr) -> void {
         injected_hal<Ts...>.template run<P>(irq, isr);
     }
 };

--- a/include/interrupt/impl/irq_impl.hpp
+++ b/include/interrupt/impl/irq_impl.hpp
@@ -9,20 +9,20 @@ namespace interrupt {
 /**
  * Runtime implementation of the irq.
  *
- * @tparam FlowTypeT
+ * @tparam Flow
  *      The actual flow::impl<Size> type that can contain all of the interrupt
  * service routines from the irq's flow::Builder<>. This needs to be accurately
  * sized to ensure it can indicate whether any interrupt service routines are
  * registered.
  */
-template <typename ConfigT, typename FlowTypeT> struct irq_impl {
+template <typename Config, typename Flow> struct irq_impl {
   public:
-    template <bool en>
+    template <bool Enable>
     constexpr static FunctionPtr enable_action =
-        ConfigT::template enable_action<en>;
-    using StatusPolicy = typename ConfigT::StatusPolicy;
+        Config::template enable_action<Enable>;
+    using status_policy_t = typename Config::status_policy_t;
 
-    constexpr static auto irq_number = ConfigT::irq_number;
+    constexpr static auto irq_number = Config::irq_number;
 
     /**
      * True if this irq::impl has any interrupt service routines to execute,
@@ -31,7 +31,7 @@ template <typename ConfigT, typename FlowTypeT> struct irq_impl {
      * This is used to optimize compiled size and runtime performance. Unused
      * Irqs should not consume any resources.
      */
-    constexpr static bool active = FlowTypeT::active;
+    constexpr static bool active = Flow::active;
 
   private:
     FunctionPtr interrupt_service_routine;
@@ -60,8 +60,8 @@ template <typename ConfigT, typename FlowTypeT> struct irq_impl {
      */
     inline void run() const {
         if constexpr (active) {
-            hal::run<StatusPolicy>(irq_number,
-                                   [&]() { interrupt_service_routine(); });
+            hal::run<status_policy_t>(irq_number,
+                                      [&]() { interrupt_service_routine(); });
         }
     }
 };

--- a/include/interrupt/impl/shared_irq_impl.hpp
+++ b/include/interrupt/impl/shared_irq_impl.hpp
@@ -9,14 +9,14 @@
 #include <type_traits>
 
 namespace interrupt {
-template <typename ConfigT, typename... SubIrqImpls> struct shared_irq_impl {
+template <typename Config, typename... SubIrqImpls> struct shared_irq_impl {
   public:
-    template <bool en>
+    template <bool Enable>
     constexpr static FunctionPtr enable_action =
-        ConfigT::template enable_action<en>;
-    using StatusPolicy = typename ConfigT::StatusPolicy;
+        Config::template enable_action<Enable>;
+    using status_policy_t = typename Config::status_policy_t;
 
-    constexpr static auto irq_number = ConfigT::irq_number;
+    constexpr static auto irq_number = Config::irq_number;
 
     /**
      * True if this shared_irq::impl has any active sub_irq::Impls, otherwise
@@ -58,7 +58,7 @@ template <typename ConfigT, typename... SubIrqImpls> struct shared_irq_impl {
                 return stdx::tuple_cat(irqs.get_interrupt_enables()...);
             });
         } else {
-            return stdx::make_tuple();
+            return stdx::tuple{};
         }
     }
 
@@ -72,7 +72,7 @@ template <typename ConfigT, typename... SubIrqImpls> struct shared_irq_impl {
      */
     inline void run() const {
         if constexpr (active) {
-            hal::run<StatusPolicy>(irq_number, [&] {
+            hal::run<status_policy_t>(irq_number, [&] {
                 stdx::for_each([](auto irq) { irq.run(); }, sub_irq_impls);
             });
         }

--- a/test/interrupt/common.hpp
+++ b/test/interrupt/common.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdx/ct_string.hpp>
+
+#include <cstdint>
+
+template <typename Field> struct field_value_t {
+    constexpr static auto id = Field::id;
+    std::uint32_t value;
+};
+
+template <int Id, typename Reg, stdx::ct_string Name, std::uint32_t Msb,
+          std::uint32_t Lsb>
+struct mock_field_t {
+    constexpr static auto id = Id;
+    using RegisterType = Reg;
+    using DataType = std::uint32_t;
+
+    constexpr static auto get_register() -> Reg { return {}; }
+
+    constexpr static auto get_mask() -> DataType {
+        return ((1u << (Msb + 1u)) - 1u) - ((1u << Lsb) - 1u);
+    }
+
+    constexpr auto operator()(std::uint32_t value) const {
+        return field_value_t<mock_field_t>{value};
+    }
+};
+
+template <int Id, typename Reg, stdx::ct_string Name> struct mock_register_t {
+    constexpr static auto id = Id;
+    using RegisterType = Reg;
+    using DataType = std::uint32_t;
+
+    constexpr static auto get_register() -> Reg { return {}; }
+
+    constexpr static mock_field_t<Id, Reg, "raw", 31, 0> raw{};
+};
+
+template <typename... Ops> constexpr auto apply(Ops... ops) {
+    return (ops(), ...);
+}

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -1,4 +1,9 @@
+#include "common.hpp"
+
 #include <interrupt/dynamic_controller.hpp>
+#include <interrupt/fwd.hpp>
+#include <interrupt/manager.hpp>
+#include <interrupt/policies.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -9,7 +14,94 @@ struct with_enable_field {
 struct without_enable_field {};
 } // namespace
 
-TEST_CASE("detect enable_field", "[dynamic_controller]") {
+TEST_CASE("detect enable_field", "[dynamic controller]") {
     static_assert(interrupt::has_enable_field<with_enable_field>);
     static_assert(not interrupt::has_enable_field<without_enable_field>);
+}
+
+namespace {
+using namespace interrupt;
+
+std::uint32_t register_value{};
+constexpr auto write(auto v) {
+    return [=] { register_value = v.value; };
+}
+
+using test_flow_1_t = irq_flow<"1">;
+using test_flow_2_t = irq_flow<"2">;
+
+struct reg_t : mock_register_t<0, reg_t, ""> {};
+using en_field_1_t = mock_field_t<1, reg_t, "", 0, 0>;
+using sts_field_t = mock_field_t<2, reg_t, "", 1, 1>;
+using en_field_2_t = mock_field_t<3, reg_t, "", 2, 2>;
+
+struct test_resource_1 {};
+struct test_resource_2 {};
+
+using config_t = root<shared_irq<
+    0_irq, 0, policies<>,
+    sub_irq<en_field_1_t, sts_field_t, test_flow_1_t,
+            policies<required_resources<test_resource_1>>>,
+    sub_irq<en_field_2_t, sts_field_t, test_flow_2_t,
+            policies<required_resources<test_resource_1, test_resource_2>>>>>;
+
+using dynamic_t = dynamic_controller<config_t>;
+
+auto reset_dynamic_state() {
+    register_value = 0;
+    dynamic_t::disable<test_flow_1_t, test_flow_2_t>();
+    dynamic_t::turn_on_resource<test_resource_1>();
+    dynamic_t::turn_on_resource<test_resource_2>();
+}
+} // namespace
+
+TEST_CASE("enable one irq", "[dynamic controller]") {
+    reset_dynamic_state();
+    dynamic_t::enable<test_flow_1_t>();
+    CHECK(register_value == 0b1);
+}
+
+TEST_CASE("enable multiple irqs", "[dynamic controller]") {
+    reset_dynamic_state();
+    dynamic_t::enable<test_flow_1_t, test_flow_2_t>();
+    CHECK(register_value == 0b101);
+}
+
+TEST_CASE("disabling resource disables irq that requires it",
+          "[dynamic controller]") {
+    reset_dynamic_state();
+
+    dynamic_t::enable<test_flow_2_t>();
+    CHECK(register_value == 0b100);
+
+    dynamic_t::turn_off_resource<test_resource_2>();
+    CHECK(register_value == 0);
+    dynamic_t::turn_on_resource<test_resource_2>();
+    CHECK(register_value == 0b100);
+}
+
+TEST_CASE("disabling resource disables only irqs that require it",
+          "[dynamic controller]") {
+    reset_dynamic_state();
+
+    dynamic_t::enable<test_flow_1_t, test_flow_2_t>();
+    CHECK(register_value == 0b101);
+
+    dynamic_t::turn_off_resource<test_resource_2>();
+    CHECK(register_value == 0b1);
+    dynamic_t::turn_on_resource<test_resource_2>();
+    CHECK(register_value == 0b101);
+}
+
+TEST_CASE("disable resource that multiple irqs require",
+          "[dynamic controller]") {
+    reset_dynamic_state();
+
+    dynamic_t::enable<test_flow_1_t, test_flow_2_t>();
+    CHECK(register_value == 0b101);
+
+    dynamic_t::turn_off_resource<test_resource_1>();
+    CHECK(register_value == 0);
+    dynamic_t::turn_on_resource<test_resource_1>();
+    CHECK(register_value == 0b101);
 }


### PR DESCRIPTION
 - separate dynamic tests from manager tests
 - add strong type for irq number so as not to mix up with priority
 - conventional names for types