### PR TITLE
:arrow_up: Update to fmtlib 10.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(
 
 include(cmake/string_catalog.cmake)
 
-add_versioned_package("gh:fmtlib/fmt#f918289")
+add_versioned_package("gh:fmtlib/fmt#10.1.1")
 add_versioned_package("gh:intel/cpp-std-extensions#19b7932")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#8d49b6d")
 


### PR DESCRIPTION
We were previously on a between-release commit in order to support constexpr `formatted_size` calls.