### PR TITLE
Decouple graph builder

### DIFF
--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -26,11 +26,7 @@ namespace flow {
 
 template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
-struct builder : graph_builder<node, Name, NodeCapacity, EdgeCapacity,
-                               builder<Name, NodeCapacity, EdgeCapacity>> {
-    template <stdx::ct_string N, std::size_t Capacity>
-    using impl_t = flow::impl<N, Capacity>;
-};
+using builder = graph_builder<node, impl, Name, NodeCapacity, EdgeCapacity>;
 
 /**
  * Extend this to create named flow services.

--- a/include/flow/detail/par.hpp
+++ b/include/flow/detail/par.hpp
@@ -22,17 +22,19 @@ template <node Lhs, node Rhs> struct par {
 
     using is_node = void;
 
-    constexpr auto walk(auto c) const -> void {
-        dsl::walk(c, lhs);
-        dsl::walk(c, rhs);
+  private:
+    template <typename F>
+    friend constexpr auto tag_invoke(walk_t, F &&f, par const &p) -> void {
+        walk(f, p.lhs);
+        walk(f, p.rhs);
     }
 
-    constexpr auto initials() const {
-        return concat(dsl::initials(lhs), dsl::initials(rhs));
+    friend constexpr auto tag_invoke(get_initials_t, par const &p) {
+        return concat(get_initials(p.lhs), get_initials(p.rhs));
     }
 
-    constexpr auto finals() const {
-        return concat(dsl::finals(lhs), dsl::finals(rhs));
+    friend constexpr auto tag_invoke(get_finals_t, par const &p) {
+        return concat(get_finals(p.lhs), get_finals(p.rhs));
     }
 };
 

--- a/include/flow/detail/seq.hpp
+++ b/include/flow/detail/seq.hpp
@@ -9,19 +9,26 @@ template <node Lhs, node Rhs> struct seq {
 
     using is_node = void;
 
-    constexpr auto walk(auto c) const -> void {
-        dsl::walk(c, lhs);
-        dsl::walk(c, rhs);
+  private:
+    template <typename F>
+    friend constexpr auto tag_invoke(walk_t, F &&f, seq const &s) -> void {
+        walk(f, s.lhs);
+        walk(f, s.rhs);
 
-        for (auto final : dsl::finals(lhs)) {
-            for (auto initial : dsl::initials(rhs)) {
-                c(final, initial);
+        for (auto final : get_finals(s.lhs)) {
+            for (auto initial : get_initials(s.rhs)) {
+                f(final, initial);
             }
         }
     }
 
-    constexpr auto initials() const { return dsl::initials(lhs); }
-    constexpr auto finals() const { return dsl::finals(rhs); }
+    friend constexpr auto tag_invoke(get_initials_t, seq const &s) {
+        return get_initials(s.lhs);
+    }
+
+    friend constexpr auto tag_invoke(get_finals_t, seq const &s) {
+        return get_finals(s.rhs);
+    }
 };
 
 template <node Lhs, node Rhs> seq(Lhs, Rhs) -> seq<Lhs, Rhs>;

--- a/include/flow/detail/walk.hpp
+++ b/include/flow/detail/walk.hpp
@@ -1,32 +1,57 @@
 #pragma once
 
+#include <stdx/concepts.hpp>
+
 #include <array>
+#include <utility>
 
 namespace flow::dsl {
 template <typename T>
 concept node = requires { typename T::is_node; };
 
-[[nodiscard]] constexpr auto initials(node auto const &n) {
-    if constexpr (requires { n.initials(); }) {
-        return n.initials();
-    } else {
+constexpr inline class walk_t {
+    template <node N, stdx::invocable<N> F>
+    friend constexpr auto tag_invoke(walk_t, F &&f, N const &n) {
+        return std::forward<F>(f)(n);
+    }
+
+  public:
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<walk_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} walk{};
+
+constexpr inline class get_initials_t {
+    friend constexpr auto tag_invoke(get_initials_t, node auto const &n) {
         return std::array{n};
     }
-}
 
-[[nodiscard]] constexpr auto finals(node auto const &n) {
-    if constexpr (requires { n.finals(); }) {
-        return n.finals();
-    } else {
+  public:
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<get_initials_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} get_initials{};
+
+constexpr inline class get_finals_t {
+    friend constexpr auto tag_invoke(get_finals_t, node auto const &n) {
         return std::array{n};
     }
-}
 
-constexpr auto walk(auto c, node auto const &n) -> void {
-    if constexpr (requires { n.walk(c); }) {
-        n.walk(c);
-    } else {
-        c(n, {});
+  public:
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<get_finals_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
     }
-}
+} get_finals{};
 } // namespace flow::dsl

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -30,10 +30,10 @@ namespace flow {
  * @tparam NodeCapacity The maximum number of nodes that can be added.
  * @tparam EdgeCapacity The maximum number of edges between one node and
  *         another.
- * @tparam Derived The class that uses graph_builder with CRTP.
  */
-template <flow::dsl::node Node, stdx::ct_string Name, std::size_t NodeCapacity,
-          std::size_t EdgeCapacity, typename Derived>
+template <
+    flow::dsl::node Node, template <stdx::ct_string, std::size_t> typename Impl,
+    stdx::ct_string Name, std::size_t NodeCapacity, std::size_t EdgeCapacity>
 class graph_builder {
     using graph_t = stdx::cx_multimap<Node, Node, NodeCapacity, EdgeCapacity>;
     graph_t graph{};
@@ -105,9 +105,9 @@ class graph_builder {
      * "c".
      */
     template <typename... Ts>
-    constexpr auto add(Ts const &...descriptions) -> Derived & {
+    constexpr auto add(Ts const &...descriptions) -> auto & {
         (insert(descriptions), ...);
-        return static_cast<Derived &>(*this);
+        return *this;
     }
 
     /**
@@ -171,7 +171,7 @@ class graph_builder {
 
     template <typename BuilderValue>
     [[nodiscard]] constexpr static auto build() -> FunctionPtr {
-        return run_impl<BuilderValue, Derived::template impl_t>;
+        return run_impl<BuilderValue, Impl>;
     }
 };
 } // namespace flow

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <flow/common.hpp>
+#include <flow/detail/walk.hpp>
 
 #include <stdx/ct_string.hpp>
 #include <stdx/cx_multimap.hpp>
 #include <stdx/cx_vector.hpp>
+#include <stdx/utility.hpp>
 
 #include <algorithm>
 #include <array>
@@ -14,12 +16,6 @@
 #include <span>
 
 namespace flow {
-namespace detail {
-template <typename T, typename Node>
-concept walkable = std::same_as<T, Node> or
-                   requires(T const &t) { t.walk([](Node, Node) {}); };
-}
-
 /**
  * flow::graph_builder allows a compile-time graph to be built, and then used to
  * output a topologically sorted flow.
@@ -36,7 +32,7 @@ concept walkable = std::same_as<T, Node> or
  *         another.
  * @tparam Derived The class that uses graph_builder with CRTP.
  */
-template <typename Node, stdx::ct_string Name, std::size_t NodeCapacity,
+template <flow::dsl::node Node, stdx::ct_string Name, std::size_t NodeCapacity,
           std::size_t EdgeCapacity, typename Derived>
 class graph_builder {
     using graph_t = stdx::cx_multimap<Node, Node, NodeCapacity, EdgeCapacity>;
@@ -63,17 +59,11 @@ class graph_builder {
         return s;
     }
 
-    constexpr auto insert(Node const &node) -> void { graph.put(node); }
-
-    template <detail::walkable<Node> T>
-    constexpr auto insert(T const &t) -> void {
-        t.walk([&](Node lhs, Node rhs) {
-            if (rhs == Node{}) {
-                graph.put(lhs);
-            } else {
-                graph.put(lhs, rhs);
-            }
-        });
+    constexpr auto insert(flow::dsl::node auto const &t) -> void {
+        dsl::walk(
+            stdx::overload{[&](Node n) { graph.put(n); },
+                           [&](Node lhs, Node rhs) { graph.put(lhs, rhs); }},
+            t);
     }
 
     template <typename BuilderValue,
@@ -114,7 +104,7 @@ class graph_builder {
      * Note that it does not specify an ordering requirement between "b" and
      * "c".
      */
-    template <detail::walkable<Node>... Ts>
+    template <typename... Ts>
     constexpr auto add(Ts const &...descriptions) -> Derived & {
         (insert(descriptions), ...);
         return static_cast<Derived &>(*this);

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -26,12 +26,8 @@ namespace seq {
 
 template <stdx::ct_string Name = "", std::size_t NodeCapacity = 64,
           std::size_t EdgeCapacity = 16>
-struct builder
-    : flow::graph_builder<step_base, Name, NodeCapacity, EdgeCapacity,
-                          builder<Name, NodeCapacity, EdgeCapacity>> {
-    template <stdx::ct_string N, std::size_t Capacity>
-    using impl_t = seq::impl<N, Capacity>;
-};
+using builder =
+    flow::graph_builder<step_base, impl, Name, NodeCapacity, EdgeCapacity>;
 
 /**
  * Extend this to create named seq services.

--- a/test/seq/sequencer.cpp
+++ b/test/seq/sequencer.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 int attempt_count;
-std::string result;
+std::string result{};
 } // namespace
 
 TEST_CASE("build and run empty seq", "[seq]") {
@@ -19,8 +19,7 @@ TEST_CASE("build and run empty seq", "[seq]") {
 }
 
 TEST_CASE("build seq with one step and run forwards and backwards", "[seq]") {
-    result = "";
-    seq::builder<> builder;
+    result.clear();
 
     auto s = seq::step(
         "S"_sc,
@@ -33,8 +32,7 @@ TEST_CASE("build seq with one step and run forwards and backwards", "[seq]") {
             return seq::status::DONE;
         });
 
-    builder.add(s);
-
+    auto builder = seq::builder<>{}.add(s);
     auto seq_impl = builder.topo_sort<seq::impl, 1>();
 
     CHECK(seq_impl->forward() == seq::status::DONE);
@@ -46,9 +44,8 @@ TEST_CASE("build seq with one step and run forwards and backwards", "[seq]") {
 
 TEST_CASE("build seq with a forward step that takes a while to finish",
           "[seq]") {
-    result = "";
+    result.clear();
     attempt_count = 0;
-    seq::builder<> builder;
 
     auto s = seq::step(
         "S"_sc,
@@ -65,8 +62,7 @@ TEST_CASE("build seq with a forward step that takes a while to finish",
             return seq::status::DONE;
         });
 
-    builder.add(s);
-
+    auto builder = seq::builder<>{}.add(s);
     auto seq_impl = builder.topo_sort<seq::impl, 1>();
 
     SECTION("forward can be called") {
@@ -94,9 +90,8 @@ TEST_CASE("build seq with a forward step that takes a while to finish",
 
 TEST_CASE("build seq with a backward step that takes a while to finish",
           "[seq]") {
-    result = "";
+    result.clear();
     attempt_count = 0;
-    seq::builder<> builder;
 
     auto s = seq::step(
         "S"_sc,
@@ -113,8 +108,7 @@ TEST_CASE("build seq with a backward step that takes a while to finish",
             }
         });
 
-    builder.add(s);
-
+    auto builder = seq::builder<>{}.add(s);
     auto seq_impl = builder.topo_sort<seq::impl, 1>();
 
     SECTION("backward can be called") {
@@ -146,8 +140,7 @@ TEST_CASE("build seq with a backward step that takes a while to finish",
 
 TEST_CASE("build seq with three steps and run forwards and backwards",
           "[seq]") {
-    result = "";
-    seq::builder<> builder;
+    result.clear();
 
     auto s1 = seq::step(
         "S1"_sc,
@@ -182,8 +175,7 @@ TEST_CASE("build seq with three steps and run forwards and backwards",
             return seq::status::DONE;
         });
 
-    builder.add(s1 >> s2 >> s3);
-
+    auto builder = seq::builder<>{}.add(s1 >> s2 >> s3);
     auto seq_impl = builder.topo_sort<seq::impl, 3>();
 
     CHECK(seq_impl->forward() == seq::status::DONE);


### PR DESCRIPTION
- use `tag_invoke` to walk the flow node tree; this will enable using other types in the flow tree if needed (thinking of #278)
- remove CRTP from graph_builder; it's not needed
- convert flow tests to use the "builder pattern" - in general, `add` functions that can return different types should be marked `[[nodiscard]]`? (Not yet true for `graph_builder`, but moving that way.)