### PR TITLE
:bug: Fix accidental integer promotion in field type handling

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -86,7 +86,8 @@ CONSTEVAL auto bit_mask() -> T {
     if constexpr (BitSize == 0u) {
         return {};
     } else {
-        return std::numeric_limits<T>::max() >> (bit_size<T>() - BitSize);
+        return static_cast<T>(std::numeric_limits<T>::max() >>
+                              (bit_size<T>() - BitSize));
     }
 }
 
@@ -108,7 +109,7 @@ struct bits_locator_t {
         if constexpr (BitSize == bit_size<T>()) {
             return {};
         } else {
-            return value >> BitSize;
+            return static_cast<T>(value >> BitSize);
         }
     }
 
@@ -117,7 +118,7 @@ struct bits_locator_t {
         if constexpr (BitSize == bit_size<T>()) {
             return {};
         } else {
-            return value << BitSize;
+            return static_cast<T>(value << BitSize);
         }
     }
 
@@ -275,8 +276,9 @@ template <bits_locator... BLs> struct field_locator_t {
         using raw_t = integral_type_for<typename Spec::type>;
         auto raw = static_cast<raw_t>(value);
         auto const insert_bits = [&]<bits_locator B>() {
-            B::insert(std::forward<R>(r),
-                      raw & detail::bit_mask<raw_t, B::size>());
+            B::insert(
+                std::forward<R>(r),
+                static_cast<raw_t>(raw & detail::bit_mask<raw_t, B::size>()));
             raw = B::fold(raw);
         };
 

--- a/test/msg/field_extract.cpp
+++ b/test/msg/field_extract.cpp
@@ -80,7 +80,7 @@ TEST_CASE("max field size", "[field extract]") {
 }
 
 namespace {
-enum struct E { Value = 0b10101 };
+enum struct E : std::uint8_t { Value = 0b10101 };
 } // namespace
 
 TEST_CASE("enum field type ", "[field extract]") {

--- a/test/msg/field_insert.cpp
+++ b/test/msg/field_insert.cpp
@@ -96,10 +96,10 @@ TEST_CASE("max field size", "[field insert]") {
 }
 
 namespace {
-enum struct E { Value = 0b10101 };
+enum struct E : std::uint8_t { Value = 0b10101 };
 } // namespace
 
-TEST_CASE("enum field type ", "[field extract]") {
+TEST_CASE("enum field type ", "[field insert]") {
     using F = field<"", E>::located<at{0_dw, 5_msb, 1_lsb}>;
     std::array<std::uint8_t, 1> data{0b1100'0001};
     //                                   ^----^


### PR DESCRIPTION
When an argument to any binary operator is an integral type with width less than `int`, integer promotion rules mean that the result is an `int`. Even when the types involved are unsigned...