### PR TITLE
Revert ":construction_worker: Temporarily remove clang-17 libc++ from…

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,6 +39,11 @@ jobs:
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17
             toolchain_root: "/usr/lib/llvm-17"
+          - version: 17
+            compiler: clang
+            stdlib: libc++
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo apt install -y libc++-17-dev libc++abi-17-dev
+            cxx_flags: "-stdlib=libc++"
           - version: 16
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
@@ -92,9 +97,6 @@ jobs:
           - compiler: clang
             version: 14
             stdlib: libstdc++
-          - compiler: clang
-            version: 17
-            stdlib: libc++
           - compiler: clang
             version: 13
           - compiler: clang


### PR DESCRIPTION
… build"

This reverts commit 95a07091b147eefbdbcd304def500c831eda2168.