### PR TITLE
Fix matcher ordering

### DIFF
--- a/docs/match.adoc
+++ b/docs/match.adoc
@@ -362,3 +362,21 @@ In disjunctive normal form, all `not` applications are pushed down to act on
 single terms and not on the compound `and` and `or` terms. The transformation
 recursively applies distribution of _and_ over _or_ and
 https://en.wikipedia.org/wiki/De_Morgan%27s_laws[de Morgan's laws].
+
+=== Matcher ordering and equivalence
+
+Given a definition of implication, we can define a partial ordering of matchers:
+
+* Two matchers `A` and `B` are equivalent if `A => B` and `B => A`.
+* Otherwise, `A => B` means that `A < B` and vice versa.
+* If no implication relationship between `A` and `B` holds true, then `A` and
+  `B` are unorderable.
+
+Therefore, `operator<​=​>` is defined on matchers such that it returns a
+https://en.cppreference.com/w/cpp/utility/compare/partial_ordering[`std::partial_ordering`].
+
+An intuition for what "less than" means when applied to matchers: one matcher is
+less than another if it matches fewer values. This is consistent with theory:
+matchers form a
+https://en.wikipedia.org/wiki/Boolean_algebra_(structure)[Boolean algebra] with
+`never` and `always` as ⊥ and ⊤ respectively.

--- a/include/match/ops.hpp
+++ b/include/match/ops.hpp
@@ -39,5 +39,5 @@ template <match::matcher L, match::matcher R>
     if (not x and not y) {
         return std::partial_ordering::unordered;
     }
-    return x <=> y;
+    return y <=> x;
 }

--- a/test/match/equivalence.cpp
+++ b/test/match/equivalence.cpp
@@ -8,16 +8,16 @@
 #include <type_traits>
 
 TEST_CASE("less than", "[match equivalence]") {
-    using T = test_m<0>;
-    using U = match::and_t<T, test_m<1>>;
+    using T = match::and_t<test_m<0>, test_m<1>>;
+    using U = test_m<0>;
     constexpr auto result = T{} <=> U{};
     static_assert(result == std::partial_ordering::less);
     static_assert(T{} < U{});
 }
 
 TEST_CASE("greater than", "[match equivalence]") {
-    using T = test_m<0>;
-    using U = match::or_t<T, test_m<1>>;
+    using T = match::or_t<test_m<0>, test_m<1>>;
+    using U = test_m<0>;
     constexpr auto result = T{} <=> U{};
     static_assert(result == std::partial_ordering::greater);
     static_assert(T{} > U{});


### PR DESCRIPTION
Further research indicates that we had it the wrong way around.