### PR TITLE
:art: Remove unnecessary type specifier for field matcher

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -424,26 +424,26 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
     using matcher_t = M;
 
     template <T expected_value>
-    constexpr static msg::equal_to_t<field_t, T, expected_value> equal_to{};
+    constexpr static msg::equal_to_t<field_t, expected_value> equal_to{};
 
-    constexpr static msg::equal_to_t<field_t, T, DefaultValue> match_default{};
+    constexpr static msg::equal_to_t<field_t, DefaultValue> match_default{};
 
     template <T... expected_values>
-    constexpr static msg::in_t<field_t, T, expected_values...> in{};
+    constexpr static msg::in_t<field_t, expected_values...> in{};
 
     template <T expected_value>
-    constexpr static msg::greater_than_t<field_t, T, expected_value>
+    constexpr static msg::greater_than_t<field_t, expected_value>
         greater_than{};
 
     template <T expected_value>
-    constexpr static msg::greater_than_or_equal_to_t<field_t, T, expected_value>
+    constexpr static msg::greater_than_or_equal_to_t<field_t, expected_value>
         greater_than_or_equal_to{};
 
     template <T expected_value>
-    constexpr static msg::less_than_t<field_t, T, expected_value> less_than{};
+    constexpr static msg::less_than_t<field_t, expected_value> less_than{};
 
     template <T expected_value>
-    constexpr static msg::less_than_or_equal_to_t<field_t, T, expected_value>
+    constexpr static msg::less_than_or_equal_to_t<field_t, expected_value>
         less_than_or_equal_to{};
 
     template <T NewDefaultValue>
@@ -455,34 +455,32 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
     template <T NewRequiredValue>
     using WithRequired =
         field_t<Name, T, NewRequiredValue,
-                msg::equal_to_t<field_t, T, NewRequiredValue>, Ats...>;
+                msg::equal_to_t<field_t, NewRequiredValue>, Ats...>;
 
     template <T... PotentialValues>
-    using WithIn = field_t<Name, T, T{},
-                           msg::in_t<field_t, T, PotentialValues...>, Ats...>;
+    using WithIn =
+        field_t<Name, T, T{}, msg::in_t<field_t, PotentialValues...>, Ats...>;
 
     template <T NewGreaterValue>
     using WithGreaterThan =
         field_t<Name, T, NewGreaterValue,
-                msg::greater_than_t<field_t, T, NewGreaterValue>, Ats...>;
+                msg::greater_than_t<field_t, NewGreaterValue>, Ats...>;
 
     template <T NewGreaterValue>
     using WithGreaterThanOrEqualTo =
         field_t<Name, T, NewGreaterValue,
-                msg::greater_than_or_equal_to_t<field_t, T, NewGreaterValue>,
+                msg::greater_than_or_equal_to_t<field_t, NewGreaterValue>,
                 Ats...>;
 
     template <T NewLesserValue>
     using WithLessThan =
         field_t<Name, T, NewLesserValue,
-                msg::less_than_or_equal_to_t<field_t, T, NewLesserValue>,
-                Ats...>;
+                msg::less_than_or_equal_to_t<field_t, NewLesserValue>, Ats...>;
 
     template <T NewLesserValue>
     using WithLessThanOrEqualTo =
         field_t<Name, T, NewLesserValue,
-                msg::less_than_or_equal_to_t<field_t, T, NewLesserValue>,
-                Ats...>;
+                msg::less_than_or_equal_to_t<field_t, NewLesserValue>, Ats...>;
 
     [[nodiscard]] constexpr static auto describe(value_type v) {
         return format("{}: 0x{:x}"_sc, spec_t::name, v);

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -24,8 +24,7 @@ using msg_defn =
     message<"msg", id_field::WithRequired<0x80>, field1, field2, field3>;
 
 constexpr auto id_match =
-    msg::msg_matcher<msg_defn,
-                     msg::equal_to_t<id_field, std::uint32_t, 0x80>>{};
+    msg::msg_matcher<msg_defn, msg::equal_to_t<id_field, 0x80>>{};
 
 std::string log_buffer{};
 } // namespace

--- a/test/msg/field_matchers.cpp
+++ b/test/msg/field_matchers.cpp
@@ -11,197 +11,180 @@ using test_field =
 } // namespace
 
 TEST_CASE("negate less_than", "[field matchers]") {
-    constexpr auto m = msg::less_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
     static_assert(
-        std::is_same_v<decltype(n), msg::greater_than_or_equal_to_t<
-                                        test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(n),
+                       msg::greater_than_or_equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate greater_than", "[field matchers]") {
-    constexpr auto m = msg::greater_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
     static_assert(
-        std::is_same_v<decltype(n), msg::less_than_or_equal_to_t<
-                                        test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(n),
+                       msg::less_than_or_equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate less_than_or_equal_to", "[field matchers]") {
-    constexpr auto m =
-        msg::less_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(std::is_same_v<
-                  decltype(n),
-                  msg::greater_than_t<test_field, std::uint32_t, 5> const>);
+    static_assert(
+        std::is_same_v<decltype(n), msg::greater_than_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate greater_than_or_equal_to", "[field matchers]") {
-    constexpr auto m =
-        msg::greater_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
     static_assert(
-        std::is_same_v<decltype(n),
-                       msg::less_than_t<test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(n), msg::less_than_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate equal_to", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(std::is_same_v<
-                  decltype(n),
-                  msg::not_equal_to_t<test_field, std::uint32_t, 5> const>);
+    static_assert(
+        std::is_same_v<decltype(n), msg::not_equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate not_equal_to", "[field matchers]") {
-    constexpr auto m = msg::not_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::not_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
     static_assert(
-        std::is_same_v<decltype(n),
-                       msg::equal_to_t<test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(n), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("less_than X implies less_than Y (X <= Y)", "[field matchers]") {
-    constexpr auto m = msg::less_than_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::less_than_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::less_than_t<test_field, 5>{};
+    constexpr auto n = msg::less_than_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies greater_than Y (X >= Y)",
           "[field matchers]") {
-    constexpr auto m = msg::greater_than_t<test_field, std::uint32_t, 6>{};
-    constexpr auto n = msg::greater_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_t<test_field, 6>{};
+    constexpr auto n = msg::greater_than_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("less_than_or_equal_to X implies less_than Y (X < Y)",
           "[field matchers]") {
-    constexpr auto m =
-        msg::less_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::less_than_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
+    constexpr auto n = msg::less_than_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("less_than X implies less_than_or_equal_to Y (X <= Y + 1)",
           "[field matchers]") {
-    constexpr auto m = msg::less_than_t<test_field, std::uint32_t, 6>{};
-    constexpr auto n =
-        msg::less_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::less_than_t<test_field, 6>{};
+    constexpr auto n = msg::less_than_or_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("greater_than_or_equal_to X implies greater_than Y (X > Y)",
           "[field matchers]") {
-    constexpr auto m =
-        msg::greater_than_or_equal_to_t<test_field, std::uint32_t, 6>{};
-    constexpr auto n = msg::greater_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 6>{};
+    constexpr auto n = msg::greater_than_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies greater_than_or_equal_to Y (X + 1 >= Y)",
           "[field matchers]") {
-    constexpr auto m = msg::greater_than_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n =
-        msg::greater_than_or_equal_to_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::greater_than_t<test_field, 5>{};
+    constexpr auto n = msg::greater_than_or_equal_to_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies less_than Y (X < Y)", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::less_than_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{};
+    constexpr auto n = msg::less_than_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies less_than_or_equal_to Y (X <= Y)",
           "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n =
-        msg::less_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{};
+    constexpr auto n = msg::less_than_or_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies greater_than Y (X > Y)", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 6>{};
-    constexpr auto n = msg::greater_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::equal_to_t<test_field, 6>{};
+    constexpr auto n = msg::greater_than_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies greater_than_or_equal_to Y (X >= Y)",
           "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n =
-        msg::greater_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{};
+    constexpr auto n = msg::greater_than_or_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies not equal_to Y (X != Y)", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = not msg::equal_to_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{};
+    constexpr auto n = not msg::equal_to_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X and equal_to Y is false (X != Y)", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{} and
-                       msg::equal_to_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m =
+        msg::equal_to_t<test_field, 5>{} and msg::equal_to_t<test_field, 6>{};
     static_assert(std::is_same_v<decltype(m), match::never_t const>);
 }
 
 TEST_CASE("equal_to X and not equal_to Y is equal_to X (X != Y)",
           "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{} and
-                       not msg::equal_to_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::equal_to_t<test_field, 5>{} and
+                       not msg::equal_to_t<test_field, 6>{};
     static_assert(
-        std::is_same_v<decltype(m),
-                       msg::equal_to_t<test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(m), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("equal_to X and less_than X is false (X != Y)", "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{} and
-                       msg::less_than_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m =
+        msg::equal_to_t<test_field, 5>{} and msg::less_than_t<test_field, 5>{};
     static_assert(std::is_same_v<decltype(m), match::never_t const>);
 }
 
 TEST_CASE("equal_to X and less_than Y is equal_to X (X < Y)",
           "[field matchers]") {
-    constexpr auto m = msg::equal_to_t<test_field, std::uint32_t, 5>{} and
-                       msg::less_than_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m =
+        msg::equal_to_t<test_field, 5>{} and msg::less_than_t<test_field, 6>{};
     static_assert(
-        std::is_same_v<decltype(m),
-                       msg::equal_to_t<test_field, std::uint32_t, 5> const>);
+        std::is_same_v<decltype(m), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("less_than X implies not_equal_to X", "[field matchers]") {
-    constexpr auto m = msg::less_than_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::not_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::less_than_t<test_field, 5>{};
+    constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies not_equal_to X", "[field matchers]") {
-    constexpr auto m = msg::greater_than_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::not_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_t<test_field, 5>{};
+    constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("less_than_or_equal_to X implies not_equal_to X",
           "[field matchers]") {
-    constexpr auto m =
-        msg::less_than_or_equal_to_t<test_field, std::uint32_t, 5>{};
-    constexpr auto n = msg::not_equal_to_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
+    constexpr auto n = msg::not_equal_to_t<test_field, 6>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("greater_than_or_equal_to X implies not_equal_to X",
           "[field matchers]") {
-    constexpr auto m =
-        msg::greater_than_or_equal_to_t<test_field, std::uint32_t, 6>{};
-    constexpr auto n = msg::not_equal_to_t<test_field, std::uint32_t, 5>{};
+    constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 6>{};
+    constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
     static_assert(match::implies(m, n));
 }
 
 TEST_CASE("not_equal_to X and less_than Y is less_than Y (X >= Y)",
           "[field matchers]") {
-    constexpr auto m = msg::not_equal_to_t<test_field, std::uint32_t, 6>{} and
-                       msg::less_than_t<test_field, std::uint32_t, 6>{};
+    constexpr auto m = msg::not_equal_to_t<test_field, 6>{} and
+                       msg::less_than_t<test_field, 6>{};
     static_assert(
-        std::is_same_v<decltype(m),
-                       msg::less_than_t<test_field, std::uint32_t, 6> const>);
+        std::is_same_v<decltype(m), msg::less_than_t<test_field, 6> const>);
 }

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -27,7 +27,7 @@ using msg_defn = message<"msg", id_field, field1, field2, field3>;
 
 template <auto V>
 constexpr auto id_match =
-    msg::msg_matcher<msg_defn, msg::equal_to_t<id_field, std::uint32_t, V>>{};
+    msg::msg_matcher<msg_defn, msg::equal_to_t<id_field, V>>{};
 
 std::string log_buffer{};
 } // namespace

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -24,8 +24,7 @@ using test_msg_t = msg::owning<msg_defn>;
 using msg_view_t = msg::const_view<msg_defn>;
 
 constexpr auto id_match =
-    msg::msg_matcher<msg_defn,
-                     msg::equal_to_t<id_field, std::uint32_t, 0x80>>{};
+    msg::msg_matcher<msg_defn, msg::equal_to_t<id_field, 0x80>>{};
 
 bool callback_success;
 


### PR DESCRIPTION
The field spec already knows its type, so a matcher doesn't need to be told both the field spec and the type.