### PR TITLE
add convenience msg matcher

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -338,6 +338,12 @@ template <stdx::ct_string Name, typename... Fields> struct message {
 
     using matcher_t = decltype(match::all(
         make_msg_matcher<message, typename Fields::matcher_t>()...));
+
+    template <typename M> constexpr static auto matcher(M) {
+        return match::all(
+            make_msg_matcher<message, M>(),
+            make_msg_matcher<message, typename Fields::matcher_t>()...);
+    }
 };
 
 template <typename T> using owning = typename T::template owner_t<>;

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -125,3 +125,26 @@ TEST_CASE("callback logs match", "[handler]") {
     CHECK(log_buffer.find("matched [cb], because [id == 0x80]") !=
           std::string::npos);
 }
+
+TEST_CASE("callback with convenience matcher", "[handler]") {
+    auto callback = msg::callback<"cb">(
+        msg_defn::matcher(id_field::equal_to<0x80>),
+        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
+
+    dispatched = false;
+    CHECK(callback.handle(msg_match));
+    CHECK(dispatched);
+}
+
+TEST_CASE("callback with compound convenience matcher", "[handler]") {
+    auto callback = msg::callback<"cb">(
+        msg_defn::matcher(id_field::equal_to<0x80> and field1::equal_to<11>),
+        [](msg::const_view<msg_defn>) { dispatched = true; });
+    auto const msg_match =
+        msg::owning<msg_defn>{"id"_field = 0x80, "f1"_field = 11};
+
+    dispatched = false;
+    CHECK(callback.handle(msg_match));
+    CHECK(dispatched);
+}


### PR DESCRIPTION
I'm finding the current API for msg callback matchers being too verbose. This PR provides a simpler option.