### PR TITLE
:bug: Fix constexpr glvalue usage

### DIFF
--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -111,12 +111,14 @@ struct indexed_builder_base {
                                           ExtraCallbackArgsT... args) {
         // FIXME: incomplete message callback invocation...
         //        1) bit_cast message argument
-        constexpr auto &orig_cb = BuilderValue::value.callbacks[stdx::index<I>];
         constexpr auto cb = IndexSpec{}.apply([&]<typename... Indices>(
                                                   Indices...) {
+            constexpr auto orig_cb =
+                BuilderValue::value.callbacks[stdx::index<I>];
             return remove_match_terms<typename Indices::field_type...>(orig_cb);
         });
 
+        auto const &orig_cb = BuilderValue::value.callbacks[stdx::index<I>];
         using CB = std::remove_cvref_t<decltype(cb)>;
         if constexpr (not validate_matcher<typename CB::matcher_t>()) {
             static_assert(


### PR DESCRIPTION
GCC 13.2 complains about using a glvalue in a constant expression.