### PR TITLE
use `to_string` function to convert field values into string_constants

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -371,6 +371,21 @@ template <typename R> constexpr auto capacity() -> std::size_t {
     }
 }
 
+[[nodiscard]] constexpr static auto to_string(std::integral auto v) {
+    constexpr auto hex_digits = sizeof(v) * 2;
+
+    if constexpr (hex_digits <= 8) {
+        constexpr auto hex_digits_sc = format("{}"_sc, sc::uint_<hex_digits>);
+        constexpr auto fmt_sc = "0x{:0"_sc + hex_digits_sc + "x}"_sc;
+        return format(fmt_sc, v);
+
+    } else {
+        return format("0x{:08x}{:08x}"_sc,
+                      static_cast<std::uint32_t>(v >> 32ull),
+                      static_cast<std::uint32_t>(v & 0xffffffff));
+    }
+}
+
 template <typename Name, typename T = std::uint32_t, T DefaultValue = T{},
           match::matcher M = match::always_t, auto... Ats>
     requires std::is_trivially_copyable_v<T> and
@@ -477,7 +492,7 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
                 msg::less_than_or_equal_to_t<field_t, NewLesserValue>, Ats...>;
 
     [[nodiscard]] constexpr static auto describe(value_type v) {
-        return format("{}: 0x{:x}"_sc, spec_t::name, v);
+        return format("{}: {}"_sc, spec_t::name, to_string(v));
     }
 };
 } // namespace detail

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -6,10 +6,10 @@
 namespace {
 using namespace msg;
 
-using id_field = field<"id", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
-using field1 = field<"f1", std::uint32_t>::located<at{0_dw, 15_msb, 0_lsb}>;
-using field2 = field<"f2", std::uint32_t>::located<at{1_dw, 23_msb, 16_lsb}>;
-using field3 = field<"f3", std::uint32_t>::located<at{1_dw, 15_msb, 8_lsb},
+using id_field = field<"id", std::uint8_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using field1 = field<"f1", std::uint16_t>::located<at{0_dw, 15_msb, 0_lsb}>;
+using field2 = field<"f2", std::uint8_t>::located<at{1_dw, 23_msb, 16_lsb}>;
+using field3 = field<"f3", std::uint16_t>::located<at{1_dw, 15_msb, 8_lsb},
                                                    at{1_dw, 7_msb, 0_lsb}>;
 
 using msg_defn =


### PR DESCRIPTION
`msg::field::describe` will now call `to_string(value_type)` to convert the field's value into a string_constant. This allows for values to be described even though they can not be directly converted into `std::uint32_t`. With this new extension point, the ability to correctly print 64-bit unsigned values is added.