### PR TITLE
:sparkles: Add module ID to logs

### DIFF
--- a/include/log/catalog/catalog.hpp
+++ b/include/log/catalog/catalog.hpp
@@ -7,14 +7,13 @@
 namespace sc {
 template <typename...> struct args;
 template <typename, typename T, T...> struct undefined;
+
+template <logging::level, typename> struct message {};
+template <typename> struct module_string {};
 } // namespace sc
 
-template <logging::level level, typename MessageString> struct message {};
-
 using string_id = std::uint32_t;
+using module_id = std::uint32_t;
 
-template <typename StringType> extern auto catalog() -> string_id;
-
-template <typename StringType> inline auto catalog(StringType) -> string_id {
-    return catalog<StringType>();
-}
+template <typename> extern auto catalog() -> string_id;
+template <typename> extern auto module() -> module_id;

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -25,7 +25,7 @@ namespace logging::fmt {
 template <typename TDestinations> struct log_handler {
     constexpr explicit log_handler(TDestinations &&ds) : dests{std::move(ds)} {}
 
-    template <logging::level L, typename FilenameStringType,
+    template <logging::level L, typename ModuleId, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
     auto log(FilenameStringType, LineNumberType, MsgType const &msg) -> void {
         auto const currentTime =
@@ -35,8 +35,8 @@ template <typename TDestinations> struct log_handler {
 
         stdx::for_each(
             [&](auto &out) {
-                ::fmt::format_to(out, "{:>8}us {}: ", currentTime,
-                                 level_constant<L>{});
+                ::fmt::format_to(out, "{:>8}us {} [{}]: ", currentTime,
+                                 level_constant<L>{}, ModuleId::value);
                 msg.apply(
                     [&]<typename StringType>(StringType, auto const &...args) {
                         ::fmt::format_to(out, StringType::value, args...);

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -12,7 +12,7 @@ namespace logging {
 namespace null {
 struct config {
     struct {
-        template <level L>
+        template <level, typename>
         constexpr auto log(auto &&...) const noexcept -> void {}
     } logger;
 };
@@ -25,16 +25,38 @@ concept loggable = requires(T const &t) {
     t.apply([]<typename StringType>(StringType, auto const &...) {});
 };
 
-template <level L, typename... Ts, typename... TArgs>
+template <level L, typename ModuleId, typename... Ts, typename... TArgs>
 static auto log(TArgs &&...args) -> void {
     auto &cfg = config<Ts...>;
-    cfg.logger.template log<L>(std::forward<TArgs>(args)...);
+    cfg.logger.template log<L, ModuleId>(std::forward<TArgs>(args)...);
 }
+
+template <stdx::ct_string S> struct module_id_t {
+    using type = decltype(stdx::ct_string_to_type<S, sc::string_constant>());
+};
 } // namespace logging
 
+using cib_log_module_id_t = typename logging::module_id_t<"default">::type;
+
+#define CIB_DO_PRAGMA(X) _Pragma(#X)
+#ifdef __clang__
+#define CIB_PRAGMA(X) CIB_DO_PRAGMA(clang X)
+#define CIB_PRAGMA_SEMI
+#else
+#define CIB_PRAGMA(X) CIB_DO_PRAGMA(GCC X)
+#define CIB_PRAGMA_SEMI ;
+#endif
+
+#define CIB_LOG_MODULE(S)                                                      \
+    CIB_PRAGMA(diagnostic push)                                                \
+    CIB_PRAGMA(diagnostic ignored "-Wshadow")                                  \
+    using cib_log_module_id_t [[maybe_unused]] =                               \
+        typename logging::module_id_t<S>::type CIB_PRAGMA_SEMI CIB_PRAGMA(     \
+            diagnostic pop)
+
 #define CIB_LOG(LEVEL, MSG, ...)                                               \
-    logging::log<LEVEL>(__FILE__, __LINE__,                                    \
-                        sc::formatter{MSG##_sc}(__VA_ARGS__))
+    logging::log<LEVEL, cib_log_module_id_t>(                                  \
+        __FILE__, __LINE__, sc::formatter{MSG##_sc}(__VA_ARGS__))
 
 #define CIB_TRACE(...) CIB_LOG(logging::level::TRACE, __VA_ARGS__)
 #define CIB_INFO(...) CIB_LOG(logging::level::INFO, __VA_ARGS__)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_tests(
     log/fmt_logger
     log/log
     log/mipi_encoder
+    log/module_id
     lookup/direct_array
     lookup/fast_hash
     lookup/input

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -21,18 +21,18 @@ auto log_one_rt_arg() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         "A string with no placeholders"_sc);
 }
 
 auto log_one_ct_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         format("B string with {} placeholder"_sc, "one"_sc));
 }
 
 auto log_one_rt_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         format("C string with {} placeholder"_sc, 1));
 }

--- a/test/log/catalog2_lib.cpp
+++ b/test/log/catalog2_lib.cpp
@@ -21,13 +21,13 @@ auto log_rt_enum_arg() -> void;
 
 auto log_two_rt_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         format("D string with {} and {} placeholder"_sc, 1, 2));
 }
 
 auto log_rt_enum_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
     using namespace ns;
-    cfg.logger.log_msg<logging::level::TRACE>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         format("E string with {} placeholder"_sc, E::value));
 }

--- a/test/log/mipi_encoder.cpp
+++ b/test/log/mipi_encoder.cpp
@@ -10,6 +10,19 @@
 #include <utility>
 
 namespace {
+constexpr string_id test_string_id = 42u;
+constexpr module_id test_module_id = 17u;
+} // namespace
+
+template <typename StringType> auto catalog() -> string_id {
+    return test_string_id;
+}
+
+template <typename StringType> auto module() -> module_id {
+    return test_module_id;
+}
+
+namespace {
 struct [[nodiscard]] test_critical_section {
     test_critical_section() { ++count; }
     ~test_critical_section() { ++count; }
@@ -30,20 +43,21 @@ struct test_conc_policy {
     }
 };
 
-constexpr string_id test_string_id = 42u;
-
 [[maybe_unused]] constexpr auto expected_short32_header() -> std::uint32_t {
     return (static_cast<std::uint32_t>(test_string_id) << 4u) | 0x1u;
 }
 
-[[maybe_unused]] constexpr auto expected_catalog32_header(logging::level level)
+[[maybe_unused]] constexpr auto expected_catalog32_header(logging::level level,
+                                                          module_id m)
     -> std::uint32_t {
-    return (0x1u << 24u) | (static_cast<std::uint32_t>(level) << 4u) | 0x3u;
+    return (0x1u << 24u) | (m << 16u) |
+           (static_cast<std::uint32_t>(level) << 4u) | 0x3u;
 }
 
-[[maybe_unused]] constexpr auto expected_header(logging::level level, size_t sz)
+[[maybe_unused]] constexpr auto expected_header(logging::level level,
+                                                module_id m, size_t sz)
     -> std::uint32_t {
-    return sz > 0 ? expected_catalog32_header(level)
+    return sz > 0 ? expected_catalog32_header(level, m)
                   : expected_short32_header();
 }
 
@@ -55,62 +69,57 @@ template <auto ExpectedId> struct test_log_id_destination {
 
 int num_log_args_calls{};
 
-template <logging::level Level, auto... ExpectedArgs>
+template <logging::level Level, typename ModuleId, auto... ExpectedArgs>
 struct test_log_args_destination {
     template <typename... Args>
     auto log_by_args(std::uint32_t header, Args... args) {
-        CHECK(header == expected_header(Level, sizeof...(Args)));
+        CHECK(header ==
+              expected_header(Level, module<ModuleId>(), sizeof...(Args)));
         CHECK(((ExpectedArgs == args) and ...));
         ++num_log_args_calls;
     }
 };
 
-template <logging::level Level, auto... ExpectedArgs>
+template <logging::level Level, typename ModuleId, auto... ExpectedArgs>
 struct test_log_buf_destination {
     template <typename... Args>
     auto log_by_buf(std::uint32_t *buf, std::uint32_t size) const {
         CHECK(size == 1 + sizeof...(ExpectedArgs));
-        CHECK(*buf++ == expected_header(Level, sizeof...(ExpectedArgs)));
+        CHECK(*buf++ == expected_header(Level, module<ModuleId>(),
+                                        sizeof...(ExpectedArgs)));
         CHECK(((ExpectedArgs == *buf++) and ...));
     }
 };
 } // namespace
 
-template <typename StringType> auto catalog() -> string_id {
-    return test_string_id;
-}
-
 template <> inline auto conc::injected_policy<> = test_conc_policy{};
-
-TEST_CASE("log id", "[mipi]") {
-    test_critical_section::count = 0;
-    constexpr string_id id{3u};
-    auto cfg = logging::mipi::config{test_log_id_destination<id>{}};
-    cfg.logger.log_id(id);
-    CHECK(test_critical_section::count == 2);
-}
 
 TEST_CASE("log zero arguments", "[mipi]") {
     test_critical_section::count = 0;
-    auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE>{}};
-    cfg.logger.log_msg<logging::level::TRACE>("Hello"_sc);
+    auto cfg =
+        logging::mipi::config{test_log_args_destination<logging::level::TRACE,
+                                                        cib_log_module_id_t>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>("Hello"_sc);
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log one argument", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, 42u, 17u>{}};
-    cfg.logger.log_msg<logging::level::TRACE>(format("{}"_sc, 17u));
+        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
+                                  42u, 17u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        format("{}"_sc, 17u));
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log two arguments", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE>(format("{} {}"_sc, 17u, 18u));
+        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
+                                  42u, 17u, 18u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 2);
 }
 
@@ -118,18 +127,18 @@ TEST_CASE("log more than two arguments", "[mipi]") {
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, 42u, 17u, 18u,
-                                     19u>{}};
-        cfg.logger.log_msg<logging::level::TRACE>(
+            test_log_buf_destination<logging::level::TRACE, cib_log_module_id_t,
+                                     42u, 17u, 18u, 19u>{}};
+        cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
             format("{} {} {}"_sc, 17u, 18u, 19u));
         CHECK(test_critical_section::count == 2);
     }
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, 42u, 17u, 18u, 19u,
-                                     20u>{}};
-        cfg.logger.log_msg<logging::level::TRACE>(
+            test_log_buf_destination<logging::level::TRACE, cib_log_module_id_t,
+                                     42u, 17u, 18u, 19u, 20u>{}};
+        cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
             format("{} {} {} {}"_sc, 17u, 18u, 19u, 20u));
         CHECK(test_critical_section::count == 2);
     }
@@ -139,9 +148,12 @@ TEST_CASE("log to multiple destinations", "[mipi]") {
     test_critical_section::count = 0;
     num_log_args_calls = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{},
-        test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE>(format("{} {}"_sc, 17u, 18u));
+        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
+                                  42u, 17u, 18u>{},
+        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
+                                  42u, 17u, 18u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 4);
     CHECK(num_log_args_calls == 2);
 }

--- a/test/log/module_id.cpp
+++ b/test/log/module_id.cpp
@@ -1,0 +1,51 @@
+#include <log/log.hpp>
+#include <sc/string_constant.hpp>
+
+#include <stdx/ct_string.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <type_traits>
+
+TEST_CASE("default log module id", "[module_id]") {
+    static_assert(std::is_same_v<cib_log_module_id_t, decltype("default"_sc)>);
+}
+
+namespace ns {
+CIB_LOG_MODULE("ns");
+
+TEST_CASE("log module id overridden at namespace scope", "[module_id]") {
+    static_assert(std::is_same_v<cib_log_module_id_t, decltype("ns"_sc)>);
+}
+} // namespace ns
+
+struct S {
+    CIB_LOG_MODULE("S");
+
+    template <typename = void> constexpr static auto test() {
+        static_assert(std::is_same_v<cib_log_module_id_t, decltype("S"_sc)>);
+    }
+};
+
+TEST_CASE("log module id overridden at class scope", "[module_id]") {
+    S::test();
+}
+
+template <typename = void> constexpr static auto func_test() {
+    CIB_LOG_MODULE("fn");
+    static_assert(std::is_same_v<cib_log_module_id_t, decltype("fn"_sc)>);
+}
+
+TEST_CASE("log module id overridden at function scope", "[module_id]") {
+    func_test();
+}
+
+TEST_CASE("log module id overridden at statement scope", "[module_id]") {
+    CIB_LOG_MODULE("wrong");
+
+    {
+        CIB_LOG_MODULE("statement");
+        static_assert(
+            std::is_same_v<cib_log_module_id_t, decltype("statement"_sc)>);
+    }
+}


### PR DESCRIPTION
A module ID is a compile-time string. Module ID is overridden in the current scope with the `CIB_LOG_MODULE` macro. Module IDs are mapped in the same way as string catalog IDs, with a link-time dependency.