### PR TITLE
:art: Refactor field to use stdx::bit_mask

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_versioned_package(
     OPTIONS
     "FMT_INSTALL OFF"
     "FMT_OS OFF")
-add_versioned_package("gh:intel/cpp-std-extensions#9a49ddd")
+add_versioned_package("gh:intel/cpp-std-extensions#cff7a15")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#8d49b6d")
 
 add_library(cib INTERFACE)


### PR DESCRIPTION
Simplified `bits_locator_t::insert` a little: two compile-time cases can be collapsed into one.