### PR TITLE
:art: Optional generation of the string catalog library

### DIFF
--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -38,7 +38,8 @@ function(gen_str_catalog)
             --cpp_output ${SC_OUTPUT_CPP} --json_output ${SC_OUTPUT_JSON}
             --xml_output ${SC_OUTPUT_XML}
         DEPENDS ${UNDEFS} ${INPUT_JSON} ${SC_GEN_STR_CATALOG})
-
-    add_library(${SC_OUTPUT_LIB} STATIC ${SC_OUTPUT_CPP})
-    target_link_libraries(${SC_OUTPUT_LIB} PUBLIC cib)
+    if(SC_OUTPUT_LIB)
+        add_library(${SC_OUTPUT_LIB} STATIC ${SC_OUTPUT_CPP})
+        target_link_libraries(${SC_OUTPUT_LIB} PUBLIC cib)
+    endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,8 +89,6 @@ gen_str_catalog(
     ${CMAKE_CURRENT_BINARY_DIR}/strings.json
     OUTPUT_XML
     ${CMAKE_CURRENT_BINARY_DIR}/strings.xml
-    OUTPUT_LIB
-    catalog_strings
     INPUT_LIBS
     catalog1_lib
     catalog2_lib
@@ -99,6 +97,9 @@ gen_str_catalog(
     INPUT_HEADERS
     log/catalog_enums.hpp)
 
+add_library(catalog_strings STATIC ${CMAKE_CURRENT_BINARY_DIR}/strings.cpp)
+target_link_libraries(catalog_strings PUBLIC cib)
+
 add_unit_test(
     log_catalog_test
     CATCH2
@@ -106,6 +107,7 @@ add_unit_test(
     log/catalog_app.cpp
     LIBRARIES
     warnings
+    cib
     catalog1_lib
     catalog2_lib
     catalog_strings)


### PR DESCRIPTION
If the `OUTPUT_LIB` argument is omitted, a library target will not be generated. The caller can generate their own library that builds the cpp file they specified.

Closes #515 