### PR TITLE
:art: Put UDLs inside `literals` namespaces

### DIFF
--- a/include/interrupt/fwd.hpp
+++ b/include/interrupt/fwd.hpp
@@ -9,8 +9,10 @@ namespace interrupt {
 enum struct irq_num_t : std::uint32_t {};
 using priority_t = std::size_t;
 
+inline namespace literals {
 // NOLINTNEXTLINE(google-runtime-int)
 CONSTEVAL auto operator""_irq(unsigned long long int v) -> irq_num_t {
     return static_cast<irq_num_t>(v);
 }
+} // namespace literals
 } // namespace interrupt

--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -279,21 +279,20 @@ enum struct dword_index_t : std::uint32_t {};
 enum struct msb_t : std::uint32_t {};
 enum struct lsb_t : std::uint32_t {};
 
-namespace literals {
+inline namespace literals {
 // NOLINTNEXTLINE(google-runtime-int)
 CONSTEVAL auto operator""_dw(unsigned long long int v) -> dword_index_t {
     return static_cast<dword_index_t>(v);
 }
 // NOLINTNEXTLINE(google-runtime-int)
-CONSTEVAL auto operator""_msb(unsigned long long int v) -> msb_t {
-    return static_cast<msb_t>(v);
-}
-// NOLINTNEXTLINE(google-runtime-int)
 CONSTEVAL auto operator""_lsb(unsigned long long int v) -> lsb_t {
     return static_cast<lsb_t>(v);
 }
+// NOLINTNEXTLINE(google-runtime-int)
+CONSTEVAL auto operator""_msb(unsigned long long int v) -> msb_t {
+    return static_cast<msb_t>(v);
+}
 } // namespace literals
-using namespace literals;
 
 template <typename...> struct at;
 

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -145,9 +145,14 @@ template <typename Name> struct field_name {
 };
 } // namespace detail
 
+inline namespace literals {
 template <class T, T... chars> constexpr auto operator""_field() {
     return detail::field_name<sc::string_constant<T, chars...>>{};
 }
+template <class T, T... chars> constexpr auto operator""_f() {
+    return detail::field_name<sc::string_constant<T, chars...>>{};
+}
+} // namespace literals
 
 template <typename T>
 concept field_value = requires(T const &t) {

--- a/include/sc/fwd.hpp
+++ b/include/sc/fwd.hpp
@@ -28,9 +28,12 @@ template <typename T> struct type_name {
 template <typename T> constexpr static type_name<T> type_{};
 
 template <typename CharT, CharT... chars> struct string_constant;
-} // namespace sc
 
+inline namespace literals {
 template <class T, T... chars>
 constexpr auto operator""_sc() -> sc::string_constant<T, chars...> {
     return {};
 }
+} // namespace literals
+} // namespace sc
+using sc::literals::operator""_sc;


### PR DESCRIPTION
In particular `msg::literals` receives the `_field` and `_f` UDLs. Also `_sc::literals` gets the `_sc` UDL.

Note: `_sc` is currently exposed in the global namespace... it's a TODO to make that better and maybe use `_cts` from `stdx`.