### PR TITLE
docs(README.md): fix typo in CPM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The recommended way to use *cib* is with CMake and [CPM](https://github.com/cpm-
 With this method,add the following to your CMakeLists.txt:
 
 ```cmake
-CPMAddPackage("gh:intel/compile-time-init-build#047aab6)
+CPMAddPackage("gh:intel/compile-time-init-build#047aab6")
 target_link_libraries(your_target PRIVATE cib)
 ```
 


### PR DESCRIPTION
'"' was missing in the markdown

Looked weird

![image](https://github.com/intel/compile-time-init-build/assets/28534575/f6ef6d50-9fb3-4b56-863d-5a6dcbca1841)
