### PR TITLE
:sparkles: Allow string catalog generation to use stable module IDs

### DIFF
--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -23,6 +23,7 @@ auto log_zero_args() -> void;
 auto log_one_ct_arg() -> void;
 auto log_one_rt_arg() -> void;
 auto log_with_non_default_module_id() -> void;
+auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
@@ -47,4 +48,11 @@ auto log_with_non_default_module_id() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
     cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
         format("ModuleID string with {} placeholder"_sc, 1));
+}
+
+auto log_with_fixed_module_id() -> void {
+    CIB_LOG_MODULE("fixed");
+    auto cfg = logging::mipi::config{test_log_args_destination{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        format("Fixed ModuleID string with {} placeholder"_sc, 1));
 }

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -16,6 +16,7 @@ extern auto log_one_rt_arg() -> void;
 extern auto log_two_rt_args() -> void;
 extern auto log_rt_enum_arg() -> void;
 extern auto log_with_non_default_module_id() -> void;
+extern auto log_with_fixed_module_id() -> void;
 
 TEST_CASE("log zero arguments", "[catalog]") {
     test_critical_section::count = 0;
@@ -69,4 +70,12 @@ TEST_CASE("log module ids change", "[catalog]") {
     log_with_non_default_module_id();
     CHECK((last_header & expected_static) == expected_static);
     CHECK((last_header ^ default_header) == (1u << 16u));
+}
+
+TEST_CASE("log with fixed module id", "[catalog]") {
+    std::uint32_t expected_static = (1u << 24u) | (7u << 4u) | 3u;
+
+    log_with_fixed_module_id();
+    CHECK((last_header & expected_static) == expected_static);
+    CHECK((last_header & ~expected_static) == (17u << 16u));
 }

--- a/test/log/stable_strings.json
+++ b/test/log/stable_strings.json
@@ -9,5 +9,11 @@
             "id": 42
         }
     ],
+    "modules": [
+        {
+            "string": "fixed",
+            "id": 17
+        }
+    ],
     "extra_key": "extra_value"
 }


### PR DESCRIPTION
Closes #547 