### PR TITLE
:art: Rework field matchers/default values

### DIFF
--- a/docs/message.adoc
+++ b/docs/message.adoc
@@ -78,12 +78,12 @@ For example, a message type looks like this:
 ----
 using my_message_defn = msg::message<
     "my_message",                      // name
-    my_field::WithRequired<0x80>>;     // field(s)
+    my_field::with_required<0x80>>;     // field(s)
 
 using my_message = msg::owning<my_message_defn>;
 ----
 
-Here the message has only one field. `WithRequired<0x80>` is an alias
+Here the message has only one field. `with_required<0x80>` is an alias
 specialization that expresses `my_field` with a matcher that is
 `equal_to_t<0x80>`.
 
@@ -132,8 +132,8 @@ in this way can add matchers to existing fields:
 
 [source,cpp]
 ----
-using msg1_defn = extend<header_defn, "msg", type_f::WithRequired<1>, payload_f>;
-using msg2_defn = extend<header_defn, "msg", type_f::WithRequired<2>, payload_f>;
+using msg1_defn = extend<header_defn, "msg", type_f::with_required<1>, payload_f>;
+using msg2_defn = extend<header_defn, "msg", type_f::with_required<2>, payload_f>;
 ----
 
 ==== Owning vs view types

--- a/include/log/catalog/mipi_encoder.hpp
+++ b/include/log/catalog/mipi_encoder.hpp
@@ -75,22 +75,22 @@ using compact64_build_id_f = field<"build_id", std::uint64_t>::located<
     at{1_dw, 31_msb, 0_lsb}, at{0_dw, 31_msb, 30_lsb}, at{0_dw, 23_msb, 4_lsb}>;
 
 using normal_build_msg_t =
-    message<"normal_build", type_f::WithRequired<type::Build>,
-            opt_len_f::WithRequired<true>,
-            build_subtype_f::WithRequired<build_subtype::Long>, payload_len_f>;
+    message<"normal_build", type_f::with_required<type::Build>,
+            opt_len_f::with_required<true>,
+            build_subtype_f::with_required<build_subtype::Long>, payload_len_f>;
 using compact32_build_msg_t =
-    message<"compact32_build", type_f::WithRequired<type::Build>,
-            build_subtype_f::WithRequired<build_subtype::Compact32>,
+    message<"compact32_build", type_f::with_required<type::Build>,
+            build_subtype_f::with_required<build_subtype::Compact32>,
             compact32_build_id_f>;
 using compact64_build_msg_t =
-    message<"compact64_build", type_f::WithRequired<type::Build>,
-            build_subtype_f::WithRequired<build_subtype::Compact64>,
+    message<"compact64_build", type_f::with_required<type::Build>,
+            build_subtype_f::with_required<build_subtype::Compact64>,
             compact64_build_id_f>;
 
 using short32_payload_f =
     field<"payload", std::uint32_t>::located<at{0_dw, 31_msb, 4_lsb}>;
 using short32_msg_t =
-    message<"short32", type_f::WithRequired<type::Short32>, short32_payload_f>;
+    message<"short32", type_f::with_required<type::Short32>, short32_payload_f>;
 
 using catalog_subtype_f =
     field<"subtype", catalog_subtype>::located<at{0_dw, 29_msb, 24_lsb}>;
@@ -100,9 +100,9 @@ using module_id_f =
     field<"module_id", std::uint8_t>::located<at{0_dw, 22_msb, 16_lsb}>;
 
 using catalog_msg_t =
-    message<"catalog", type_f::WithRequired<type::Catalog>, severity_f,
+    message<"catalog", type_f::with_required<type::Catalog>, severity_f,
             module_id_f,
-            catalog_subtype_f::WithRequired<catalog_subtype::Id32_Pack32>>;
+            catalog_subtype_f::with_required<catalog_subtype::Id32_Pack32>>;
 } // namespace defn
 
 template <typename TDestinations> struct log_handler {
@@ -185,8 +185,7 @@ template <typename TDestinations> struct log_handler {
                                         MsgDataTypes... msg_data) -> void {
         using namespace msg;
         if constexpr (sizeof...(msg_data) == 0u) {
-            owning<defn::short32_msg_t> message{"type"_field = 1,
-                                                "payload"_field = id};
+            owning<defn::short32_msg_t> message{"payload"_field = id};
             dispatch_pass_by_args(message.data()[0]);
         } else if constexpr (sizeof...(MsgDataTypes) <= 2u) {
             owning<defn::catalog_msg_t> message{"severity"_field = Level,

--- a/include/msg/field_matchers.hpp
+++ b/include/msg/field_matchers.hpp
@@ -178,13 +178,26 @@ struct rel_matcher_t {
 template <typename Field, auto ExpectedValue>
 using less_than_t = rel_matcher_t<std::less<>, Field, ExpectedValue>;
 template <typename Field, auto ExpectedValue>
+constexpr auto less_than = less_than_t<Field, ExpectedValue>{};
+
+template <typename Field, auto ExpectedValue>
 using less_than_or_equal_to_t =
     rel_matcher_t<std::less_equal<>, Field, ExpectedValue>;
 template <typename Field, auto ExpectedValue>
+constexpr auto less_than_or_equal_to =
+    less_than_or_equal_to_t<Field, ExpectedValue>{};
+
+template <typename Field, auto ExpectedValue>
 using greater_than_t = rel_matcher_t<std::greater<>, Field, ExpectedValue>;
+template <typename Field, auto ExpectedValue>
+constexpr auto greater_than = greater_than_t<Field, ExpectedValue>{};
+
 template <typename Field, auto ExpectedValue>
 using greater_than_or_equal_to_t =
     rel_matcher_t<std::greater_equal<>, Field, ExpectedValue>;
+template <typename Field, auto ExpectedValue>
+constexpr auto greater_than_or_equal_to =
+    greater_than_or_equal_to_t<Field, ExpectedValue>{};
 
 template <typename Field, auto X, decltype(X) Y>
 [[nodiscard]] constexpr auto
@@ -218,6 +231,8 @@ tag_invoke(match::implies_t, greater_than_t<Field, X> const &,
 
 template <typename Field, auto ExpectedValue>
 using equal_to_t = rel_matcher_t<std::equal_to<>, Field, ExpectedValue>;
+template <typename Field, auto ExpectedValue>
+constexpr auto equal_to = equal_to_t<Field, ExpectedValue>{};
 
 template <typename Field, auto X, typename RelOp, decltype(X) Y>
 [[nodiscard]] constexpr auto
@@ -235,6 +250,8 @@ constexpr auto tag_invoke(index_terms_t, equal_to_t<Field, X> const &,
 
 template <typename Field, auto ExpectedValue>
 using not_equal_to_t = rel_matcher_t<std::not_equal_to<>, Field, ExpectedValue>;
+template <typename Field, auto ExpectedValue>
+constexpr auto not_equal_to = not_equal_to_t<Field, ExpectedValue>{};
 
 template <typename Field, auto X>
 constexpr auto tag_invoke(index_not_terms_t, not_equal_to_t<Field, X> const &,
@@ -296,4 +313,11 @@ tag_invoke(match::implies_t, greater_than_or_equal_to_t<Field, X> const &,
 template <typename Field, auto... ExpectedValues>
 using in_t =
     decltype((equal_to_t<Field, ExpectedValues>{} or ... or match::never));
+template <typename Field, auto... ExpectedValues>
+constexpr auto in = in_t<Field, ExpectedValues...>{};
+
+template <typename Field>
+using equal_default_t = equal_to_t<Field, Field::default_value>;
+template <typename Field>
+constexpr auto equal_default = equal_default_t<Field>{};
 } // namespace msg

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,6 +135,12 @@ add_compile_fail_test(msg/fail/owning_msg_incompatible_storage.cpp LIBRARIES
                       warnings cib)
 add_compile_fail_test(msg/fail/owning_msg_incompatible_view.cpp LIBRARIES
                       warnings cib)
+add_compile_fail_test(msg/fail/message_const_field_write.cpp LIBRARIES warnings
+                      cib)
 add_compile_fail_test(msg/fail/message_dup_fieldnames.cpp LIBRARIES warnings
                       cib)
+add_compile_fail_test(msg/fail/message_incompatible_matcher.cpp LIBRARIES
+                      warnings cib)
+add_compile_fail_test(msg/fail/message_uninitialized_field.cpp LIBRARIES
+                      warnings cib)
 add_compile_fail_test(msg/fail/view_upsize.cpp LIBRARIES warnings cib)

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -22,7 +22,7 @@ using field3 = field<"f3", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
 
 using msg_defn = message<"msg", id_field, field1, field2, field3>;
 
-constexpr auto id_match = id_field::equal_to<0x80>;
+constexpr auto id_match = msg::equal_to<id_field, 0x80>;
 
 std::string log_buffer{};
 } // namespace
@@ -126,7 +126,7 @@ TEST_CASE("callback logs match", "[callback]") {
 
 TEST_CASE("callback with convenience matcher", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
-        id_field::equal_to<0x80>,
+        msg::equal_to<id_field, 0x80>,
         [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg_match = msg::owning<msg_defn>{"id"_field = 0x80};
 
@@ -137,7 +137,7 @@ TEST_CASE("callback with convenience matcher", "[callback]") {
 
 TEST_CASE("callback with compound convenience matcher", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
-        id_field::equal_to<0x80> and field1::equal_to<11>,
+        msg::equal_to<id_field, 0x80> and msg::equal_to<field1, 11>,
         [](msg::const_view<msg_defn>) { dispatched = true; });
     auto const msg_match =
         msg::owning<msg_defn>{"id"_field = 0x80, "f1"_field = 11};

--- a/test/msg/fail/impossible_match_callback.cpp
+++ b/test/msg/fail/impossible_match_callback.cpp
@@ -16,7 +16,7 @@ using msg_defn = message<"test_msg", test_id_field>;
 using test_msg_t = owning<msg_defn>;
 
 constexpr auto test_callback = msg::callback<"test_callback", msg_defn>(
-    test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
+    msg::equal_to<test_id_field, 0x80> and msg::equal_to<test_id_field, 0x81>,
     [](auto) {});
 
 using index_spec = msg::index_spec<test_id_field>;

--- a/test/msg/fail/impossible_match_field.cpp
+++ b/test/msg/fail/impossible_match_field.cpp
@@ -12,11 +12,11 @@ using test_id_field =
     msg::field<"test_id_field",
                std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
 
-using msg_defn = message<"test_msg", test_id_field::WithRequired<0x80>>;
+using msg_defn = message<"test_msg", test_id_field::with_required<0x80>>;
 using test_msg_t = owning<msg_defn>;
 
 constexpr auto test_callback = msg::callback<"test_callback", msg_defn>(
-    test_id_field::equal_to<0x81>, [](auto) {});
+    msg::equal_to<test_id_field, 0x81>, [](auto) {});
 
 using index_spec = msg::index_spec<test_id_field>;
 struct test_service : msg::indexed_service<index_spec, test_msg_t> {};

--- a/test/msg/fail/message_const_field_write.cpp
+++ b/test/msg/fail/message_const_field_write.cpp
@@ -1,0 +1,13 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: change a field with a required value
+namespace {
+using namespace msg;
+
+using f = field<"f", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn = message<"test_msg", f::with_required<1>>;
+} // namespace
+
+auto main() -> int { [[maybe_unused]] msg::owning<msg_defn> m{"f"_field = 2}; }

--- a/test/msg/fail/message_incompatible_matcher.cpp
+++ b/test/msg/fail/message_incompatible_matcher.cpp
@@ -1,0 +1,14 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: (constraints not satisfied for)|(template constraint failure for)
+namespace {
+using namespace msg;
+
+using f = field<"f", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn =
+    message<"test_msg", f::with_const_default<1>::with_equal_to<2>>;
+} // namespace
+
+auto main() -> int {}

--- a/test/msg/fail/message_uninitialized_field.cpp
+++ b/test/msg/fail/message_uninitialized_field.cpp
@@ -1,0 +1,13 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: All fields must be initialized or defaulted
+namespace {
+using namespace msg;
+
+using f = field<"f", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn = message<"test_msg", f::without_default>;
+} // namespace
+
+auto main() -> int { [[maybe_unused]] msg::owning<msg_defn> m{}; }

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -25,7 +25,7 @@ using field3 = field<"f3", std::uint32_t>::located<at{1_dw, 15_msb, 0_lsb}>;
 
 using msg_defn = message<"msg", id_field, field1, field2, field3>;
 
-template <auto V> constexpr auto id_match = id_field::equal_to<V>;
+template <auto V> constexpr auto id_match = msg::equal_to_t<id_field, V>{};
 
 std::string log_buffer{};
 } // namespace

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -23,7 +23,7 @@ using msg_defn = message<"msg", id_field, field1, field2, field3>;
 using test_msg_t = msg::owning<msg_defn>;
 using msg_view_t = msg::const_view<msg_defn>;
 
-constexpr auto id_match = id_field::equal_to<0x80>;
+constexpr auto id_match = msg::equal_to<id_field, 0x80>;
 
 bool callback_success;
 

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -34,7 +34,7 @@ struct test_service : indexed_service<index_spec, test_msg_t> {};
 bool callback_success;
 
 constexpr auto test_callback = callback<"TestCallback", msg_defn>(
-    test_id_field::in<0x80>, [](auto) { callback_success = true; });
+    msg::in<test_id_field, 0x80>, [](auto) { callback_success = true; });
 
 struct test_project {
     constexpr static auto config = cib::config(
@@ -90,7 +90,7 @@ TEST_CASE("match output failure", "[handler_builder]") {
 
 namespace {
 constexpr auto test_callback_equals = msg::callback<"TestCallback", msg_defn>(
-    test_id_field::equal_to<0x80>, [](auto) { callback_success = true; });
+    msg::equal_to<test_id_field, 0x80>, [](auto) { callback_success = true; });
 
 struct test_project_equals {
     constexpr static auto config =
@@ -117,14 +117,15 @@ TEST_CASE("build handler field equal_to", "[indexed_builder]") {
 namespace {
 constexpr auto test_callback_multi_field =
     msg::callback<"test_callback_multi_field", msg_defn>(
-        test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        msg::in<test_id_field, 0x80, 0x42> and
+            msg::equal_to<test_opcode_field, 1>,
         [](auto) { callback_success = true; });
 
 bool callback_success_single_field;
 
 constexpr auto test_callback_single_field =
     msg::callback<"test_callback_single_field", msg_defn>(
-        test_id_field::equal_to<0x50>,
+        msg::equal_to<test_id_field, 0x50>,
         [](auto) { callback_success_single_field = true; });
 
 struct test_project_multi_field {
@@ -196,7 +197,7 @@ TEST_CASE("message matching partial index but not callback matcher",
 namespace {
 constexpr auto test_callback_not_single_field =
     msg::callback<"test_callback_not_single_field", msg_defn>(
-        not test_id_field::equal_to<0x50>,
+        not msg::equal_to<test_id_field, 0x50>,
         [](auto) { callback_success_single_field = true; });
 
 struct test_project_not_single_field {
@@ -227,7 +228,8 @@ TEST_CASE("build handler not single field", "[indexed_builder]") {
 namespace {
 constexpr auto test_callback_not_multi_field =
     msg::callback<"test_callback_multi_field", msg_defn>(
-        not test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        not msg::in<test_id_field, 0x80, 0x42> and
+            msg::equal_to<test_opcode_field, 1>,
         [](auto) { callback_success = true; });
 
 struct test_project_not_multi_field {
@@ -277,7 +279,8 @@ TEST_CASE("build handler not multi fields", "[indexed_builder]") {
 namespace {
 constexpr auto test_callback_disjunction =
     msg::callback<"test_callback_multi_field", msg_defn>(
-        test_id_field::equal_to<0x80> or test_opcode_field::equal_to<1>,
+        msg::equal_to<test_id_field, 0x80> or
+            msg::equal_to<test_opcode_field, 1>,
         [](auto) { callback_success = true; });
 
 struct test_project_disjunction {
@@ -308,7 +311,7 @@ TEST_CASE("build handler disjunction", "[indexed_builder]") {
 }
 
 namespace {
-using msg_match_defn = message<"test_msg", test_id_field::WithRequired<0x80>>;
+using msg_match_defn = message<"test_msg", test_id_field::with_default<0x80>>;
 using test_msg_match_t = owning<msg_match_defn>;
 
 using msg_match_index_spec = msg::index_spec<test_id_field>;
@@ -317,7 +320,8 @@ struct test_msg_match_service
 
 constexpr auto test_msg_match_callback =
     msg::callback<"TestCallback", msg_match_defn>(
-        test_id_field::equal_to<0x80>, [](auto) { callback_success = true; });
+        msg::equal_to<test_id_field, 0x80>,
+        [](auto) { callback_success = true; });
 
 struct test_msg_match_project {
     constexpr static auto config = cib::config(
@@ -332,8 +336,7 @@ TEST_CASE("match output success (message matcher)", "[handler_builder]") {
     test_nexus.init();
 
     callback_success = false;
-    cib::service<test_msg_match_service>->handle(
-        test_msg_match_t{"test_id_field"_field = 0x80});
+    cib::service<test_msg_match_service>->handle(test_msg_match_t{});
     CHECK(callback_success);
 
     callback_success = false;
@@ -345,7 +348,8 @@ TEST_CASE("match output success (message matcher)", "[handler_builder]") {
 namespace {
 constexpr auto test_callback_impossible =
     msg::callback<"test_callback_impossible", msg_defn>(
-        test_id_field::equal_to<0x80> and test_id_field::equal_to<0x81>,
+        msg::equal_to<test_id_field, 0x80> and
+            msg::equal_to<test_id_field, 0x81>,
         [](auto) { callback_success = true; });
 
 struct test_project_impossible {
@@ -366,7 +370,7 @@ int callback_extra_arg{};
 
 constexpr auto test_callback_extra_args =
     msg::callback<"test_callback_extra_args", msg_defn, int>(
-        test_id_field::equal_to<0x80>, [](auto, int i) {
+        msg::equal_to<test_id_field, 0x80>, [](auto, int i) {
             callback_success = true;
             callback_extra_arg = i;
         });

--- a/test/msg/rle_indexed_builder.cpp
+++ b/test/msg/rle_indexed_builder.cpp
@@ -34,7 +34,7 @@ struct test_service : rle_indexed_service<index_spec, test_msg_t> {};
 bool callback_success;
 
 constexpr auto test_callback = msg::callback<"TestCallback", msg_defn>(
-    test_id_field::in<0x80>, [](auto) { callback_success = true; });
+    msg::in<test_id_field, 0x80>, [](auto) { callback_success = true; });
 
 struct test_project {
     constexpr static auto config = cib::config(
@@ -90,7 +90,7 @@ TEST_CASE("match rle output failure", "[rle_handler_builder]") {
 
 namespace {
 constexpr auto test_callback_equals = msg::callback<"TestCallback", msg_defn>(
-    test_id_field::equal_to<0x80>, [](auto) { callback_success = true; });
+    msg::equal_to<test_id_field, 0x80>, [](auto) { callback_success = true; });
 
 struct test_project_equals {
     constexpr static auto config =
@@ -117,14 +117,15 @@ TEST_CASE("build rle handler field equal_to", "[rle_indexed_builder]") {
 namespace {
 constexpr auto test_callback_multi_field =
     msg::callback<"test_callback_multi_field", msg_defn>(
-        test_id_field::in<0x80, 0x42> and test_opcode_field::equal_to<1>,
+        msg::in_t<test_id_field, 0x80, 0x42>{} and
+            msg::equal_to_t<test_opcode_field, 1>{},
         [](auto) { callback_success = true; });
 
 bool callback_success_single_field;
 
 constexpr auto test_callback_single_field =
     msg::callback<"test_callback_single_field", msg_defn>(
-        test_id_field::equal_to<0x50>,
+        msg::equal_to_t<test_id_field, 0x50>{},
         [](auto) { callback_success_single_field = true; });
 
 struct test_project_multi_field {


### PR DESCRIPTION
- Make field matcher aliases snake_case
- Preserve legacy field matcher aliases for now
- Add field default aliases
- Compile-time error when messages are constructed with uninitialized fields

Closes #551 