### PR TITLE
:sparkles: Add message equivalence

### DIFF
--- a/docs/message.adoc
+++ b/docs/message.adoc
@@ -192,6 +192,22 @@ auto data = msg.data();
 
 This always returns a (const-observing) `stdx::span` over the underlying data.
 
+=== Message equivalence
+
+Equality (`operator==`) is not defined on messages. A general definition of
+equality is problematic, but that doesn't mean we can't have a useful notion of
+equivalence that is spelled differently:
+
+[source,cpp]
+----
+auto m1 = my_message{"my_field"_field = 42};
+auto m2 = my_message{"my_field"_field = 0x2a};
+assert(equivalent(m1.as_const_view(), m2.as_mutable_view()));
+----
+
+Equivalence means that all fields hold the same values. It is defined for all
+combinations of owning messages, const views and mutable views.
+
 === Handling messages with callbacks
 
 _cib_ contains an implementation of a basic message handler which can be used in

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -131,6 +131,8 @@ add_compile_fail_test(msg/fail/owning_msg_incompatible_storage.cpp LIBRARIES
                       warnings cib)
 add_compile_fail_test(msg/fail/owning_msg_incompatible_view.cpp LIBRARIES
                       warnings cib)
+add_compile_fail_test(msg/fail/message_cmp_owner.cpp LIBRARIES warnings cib)
+add_compile_fail_test(msg/fail/message_cmp_view.cpp LIBRARIES warnings cib)
 add_compile_fail_test(msg/fail/message_const_field_write.cpp LIBRARIES warnings
                       cib)
 add_compile_fail_test(msg/fail/message_dangling_view.cpp LIBRARIES warnings cib)

--- a/test/msg/fail/message_cmp_owner.cpp
+++ b/test/msg/fail/message_cmp_owner.cpp
@@ -1,0 +1,19 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: consider using equivalent
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"f1", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using test_field2 = field<"f2", std::uint32_t>::located<at{1_dw, 7_msb, 0_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1, test_field2>;
+} // namespace
+
+auto main() -> int {
+    owning<msg_defn> m1{};
+    auto m2 = m1;
+    [[maybe_unused]] auto b = m1 == m2;
+}

--- a/test/msg/fail/message_cmp_view.cpp
+++ b/test/msg/fail/message_cmp_view.cpp
@@ -1,0 +1,20 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: consider using equivalent
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"f1", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using test_field2 = field<"f2", std::uint32_t>::located<at{1_dw, 7_msb, 0_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1, test_field2>;
+} // namespace
+
+auto main() -> int {
+    owning<msg_defn> m{};
+    auto mv1 = m.as_mutable_view();
+    auto mv2 = m.as_mutable_view();
+    [[maybe_unused]] auto b = mv1 == mv2;
+}


### PR DESCRIPTION
Problem:
- equality is not defined for span, so it is also not defined for messages.

Solution:
- add `msg::equivalent` to determine whether two message instances are
  equivalent (all fields have the same values).
- equivalence is defined for all combinations of owning, const and mutable view
  types.
