### PR TITLE
:art: Don't use nonstandard UDL extension

### DIFF
--- a/include/flow/step.hpp
+++ b/include/flow/step.hpp
@@ -58,19 +58,16 @@ template <stdx::ct_string Name> [[nodiscard]] constexpr auto milestone() {
 }
 
 inline namespace literals {
-template <class T, T... Cs> [[nodiscard]] constexpr auto operator""_action() {
-    constexpr auto S = stdx::ct_string<sizeof...(Cs) + 1U>{{Cs..., 0}};
+template <stdx::ct_string S> [[nodiscard]] constexpr auto operator""_action() {
     return action<S>();
 }
 
-template <class T, T... Cs> [[nodiscard]] constexpr auto operator""_step() {
-    constexpr auto S = stdx::ct_string<sizeof...(Cs) + 1U>{{Cs..., 0}};
+template <stdx::ct_string S> [[nodiscard]] constexpr auto operator""_step() {
     return action<S>();
 }
 
-template <class T, T... Cs>
+template <stdx::ct_string S>
 [[nodiscard]] constexpr auto operator""_milestone() {
-    constexpr auto S = stdx::ct_string<sizeof...(Cs) + 1U>{{Cs..., 0}};
     return milestone<S>();
 }
 } // namespace literals

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -171,11 +171,13 @@ template <typename Name> struct field_name {
 } // namespace detail
 
 inline namespace literals {
-template <class T, T... chars> constexpr auto operator""_field() {
-    return detail::field_name<sc::string_constant<T, chars...>>{};
+template <stdx::ct_string S> constexpr auto operator""_field() {
+    using Name = decltype(stdx::ct_string_to_type<S, sc::string_constant>());
+    return detail::field_name<Name>{};
 }
-template <class T, T... chars> constexpr auto operator""_f() {
-    return detail::field_name<sc::string_constant<T, chars...>>{};
+template <stdx::ct_string S> constexpr auto operator""_f() {
+    using Name = decltype(stdx::ct_string_to_type<S, sc::string_constant>());
+    return detail::field_name<Name>{};
 }
 } // namespace literals
 


### PR DESCRIPTION
GCC and clang allow a user-defined literal operator template with the signature:
```cpp
template <typename T, T...> auto operator""_udl();
```

This is a non-standard extension and for our purposes at least it is replaced in C++20 by using an operator template with a structural NTTP:
```cpp
template <ct_string S> auto operator""_udl();
```