### PR TITLE
:children_crossing: Improve error message for cyclic flows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,7 +86,7 @@ jobs:
             cxx_flags: ""
           - version: 13
             compiler: gcc
-            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt-get install -y gcc-13 g++-13
+            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt install -y gcc-13 g++-13
             cc: "gcc-13"
             cxx: "g++-13"
           - version: 12
@@ -232,7 +232,7 @@ jobs:
           - compiler: gcc
             cc: "gcc-13"
             cxx: "g++-13"
-            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt-get install -y gcc-13 g++-13
+            install: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt install -y gcc-13 g++-13
             toolchain_root: "/usr"
 
     steps:
@@ -288,7 +288,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt update && sudo apt-get install -y gcc-${{env.DEFAULT_GCC_VERSION}} g++-${{env.DEFAULT_GCC_VERSION}} ninja-build valgrind
+          sudo apt update && sudo apt install -y gcc-${{env.DEFAULT_GCC_VERSION}} g++-${{env.DEFAULT_GCC_VERSION}} ninja-build valgrind
 
       - name: Restore CPM cache
         env:

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -147,7 +147,8 @@ struct graph_builder {
         constexpr static auto built() {
             constexpr auto v = Initialized::value;
             constexpr auto built = build(v);
-            static_assert(built.has_value());
+            static_assert(built.has_value(),
+                          "Topological sort failed: cycle in flow");
             return *built;
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,6 +119,7 @@ add_unit_test(
     catalog2_lib
     catalog_strings)
 
+add_compile_fail_test(flow/fail/cyclic_flow.cpp LIBRARIES warnings cib)
 add_compile_fail_test(msg/fail/callback_bad_field_name.cpp LIBRARIES warnings
                       cib)
 add_compile_fail_test(msg/fail/field_location.cpp LIBRARIES warnings cib)

--- a/test/flow/fail/cyclic_flow.cpp
+++ b/test/flow/fail/cyclic_flow.cpp
@@ -1,0 +1,23 @@
+#include <cib/cib.hpp>
+#include <flow/flow.hpp>
+
+// EXPECT: Topological sort failed: cycle in flow
+
+namespace {
+using namespace flow::literals;
+
+constexpr auto a = flow::milestone<"a">();
+constexpr auto b = flow::milestone<"b">();
+
+struct TestFlowAlpha : public flow::service<> {};
+
+struct CyclicFlowConfig {
+    constexpr static auto config = cib::config(
+        cib::exports<TestFlowAlpha>, cib::extend<TestFlowAlpha>(a >> b >> a));
+};
+} // namespace
+
+auto main() -> int {
+    cib::nexus<CyclicFlowConfig> nexus{};
+    nexus.service<TestFlowAlpha>();
+}


### PR DESCRIPTION
The error trace given is something like:
```
/.../include/flow/graph_builder.hpp:150:27: fatal error: static assertion failed due to requirement 'built.has_value()': Topological so
rt failed: cycle in flow
  150 |             static_assert(built.has_value(),
      |                           ^~~~~~~~~~~~~~~~~
/.../include/flow/graph_builder.hpp:155:39: note: in instantiation of member function 'flow::graph_builder<flow::impl>::built_flow<cib:
:initialized<(anonymous namespace)::CyclicFlowConfig, (anonymous namespace)::TestFlowAlpha>>::built' requested here
  155 |         constexpr static auto run() { built()(); }
      |                                       ^
/.../include/flow/graph_builder.hpp:160:53: note: in instantiation of member function 'flow::graph_builder<flow::impl>::built_flow<cib:
:initialized<(anonymous namespace)::CyclicFlowConfig, (anonymous namespace)::TestFlowAlpha>>::run' requested here
  160 |         constexpr auto operator()() const -> void { run(); }
      |                                                     ^
/.../test/flow/fail/cyclic_flow.cpp:22:33: note: in instantiation of member function 'flow::graph_builder<flow::impl>::built_flow<cib::
initialized<(anonymous namespace)::CyclicFlowConfig, (anonymous namespace)::TestFlowAlpha>>::operator()' requested here
   22 |     nexus.service<TestFlowAlpha>();
      |                                 ^
```

So the flow that fails (`TestFlowAlpha`) is in the output just after the `static_assert` message.