### PR TITLE
:zap: Improve compilation benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
-add_versioned_package("gh:intel/cpp-std-extensions#646bdbe")
+add_versioned_package("gh:intel/cpp-std-extensions#2fc35c7")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#fef18ca")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#113eeff")
 

--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -45,10 +45,14 @@ template <int NumFuncs = 0, typename... ArgTypes> struct callback {
     template <std::convertible_to<func_ptr_t>... Fs>
     // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     [[nodiscard]] constexpr auto add(Fs &&...fs) const {
-        return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-            return callback<NumFuncs + sizeof...(Fs), ArgTypes...>{
-                {funcs[Is]..., std::forward<Fs>(fs)...}};
-        }(std::make_index_sequence<NumFuncs>{});
+        callback<NumFuncs + sizeof...(Fs), ArgTypes...> cb;
+        auto i = std::size_t{};
+        while (i < NumFuncs) {
+            cb.funcs[i] = funcs[i];
+            ++i;
+        }
+        ((cb.funcs[i++] = std::forward<Fs>(fs)), ...);
+        return cb;
     }
 
     /**

--- a/include/cib/detail/config_details.hpp
+++ b/include/cib/detail/config_details.hpp
@@ -13,35 +13,33 @@ template <auto Value>
 constexpr static auto as_constant_v =
     std::integral_constant<std::remove_cvref_t<decltype(Value)>, Value>{};
 
-template <auto... Args> struct args {
-    constexpr static auto value = stdx::make_tuple(as_constant_v<Args>...);
-};
+template <auto... Args> struct args {};
 
-template <typename ConfigArgs, typename... ConfigTs>
-struct config : public detail::config_item {
+template <typename...> struct config;
+
+template <auto... ConfigArgs, typename... ConfigTs>
+struct config<args<ConfigArgs...>, ConfigTs...> : public detail::config_item {
     stdx::tuple<ConfigTs...> configs_tuple;
 
-    CONSTEVAL explicit config(ConfigArgs, ConfigTs const &...configs)
+    CONSTEVAL explicit config(args<ConfigArgs...>, ConfigTs const &...configs)
         : configs_tuple{configs...} {}
 
     template <typename... Args>
     [[nodiscard]] constexpr auto extends_tuple(Args const &...args) const {
-        return ConfigArgs::value.apply([&](auto const &...config_args) {
-            return configs_tuple.apply([&](auto const &...configs_pack) {
-                return stdx::tuple_cat(
-                    configs_pack.extends_tuple(args..., config_args...)...);
-            });
+        return configs_tuple.apply([&](auto const &...configs_pack) {
+            return stdx::tuple_cat(configs_pack.extends_tuple(
+                args..., as_constant_v<ConfigArgs>...)...);
         });
     }
 
     template <typename... Args>
     [[nodiscard]] constexpr auto exports_tuple(Args const &...args) const {
-        return ConfigArgs::value.apply([&](auto const &...config_args) {
-            return configs_tuple.apply([&](auto const &...configs_pack) {
-                return stdx::tuple_cat(
-                    configs_pack.exports_tuple(args..., config_args...)...);
-            });
+        return configs_tuple.apply([&](auto const &...configs_pack) {
+            return stdx::tuple_cat(configs_pack.exports_tuple(
+                args..., as_constant_v<ConfigArgs>...)...);
         });
     }
 };
+
+template <typename... Ts> config(Ts...) -> config<Ts...>;
 } // namespace cib::detail

--- a/include/cib/detail/config_item.hpp
+++ b/include/cib/detail/config_item.hpp
@@ -5,13 +5,15 @@
 namespace cib::detail {
 struct config_item {
     template <typename... Args>
-    [[nodiscard]] constexpr auto extends_tuple(Args const &...) const {
-        return stdx::make_tuple();
+    [[nodiscard]] constexpr auto
+    extends_tuple(Args const &...) const -> stdx::tuple<> {
+        return {};
     }
 
     template <typename... InitArgs>
-    [[nodiscard]] constexpr auto exports_tuple(InitArgs const &...) const {
-        return stdx::make_tuple();
+    [[nodiscard]] constexpr auto
+    exports_tuple(InitArgs const &...) const -> stdx::tuple<> {
+        return {};
     }
 };
 } // namespace cib::detail

--- a/include/cib/detail/exports.hpp
+++ b/include/cib/detail/exports.hpp
@@ -13,13 +13,15 @@ template <typename ServiceT, typename BuilderT> struct service_entry {
 
 template <typename... Services> struct exports : public detail::config_item {
     template <typename... InitArgs>
-    [[nodiscard]] constexpr auto extends_tuple(InitArgs const &...) const {
-        return stdx::make_tuple(extend<Services>{}...);
+    [[nodiscard]] constexpr auto extends_tuple(InitArgs const &...) const
+        -> stdx::tuple<extend<Services>...> {
+        return {extend<Services>{}...};
     }
 
     template <typename... InitArgs>
-    [[nodiscard]] constexpr auto exports_tuple(InitArgs const &...) const {
-        return stdx::make_tuple(Services{}...);
+    [[nodiscard]] constexpr auto
+    exports_tuple(InitArgs const &...) const -> stdx::tuple<Services...> {
+        return {};
     }
 };
 } // namespace cib::detail

--- a/include/cib/detail/extend.hpp
+++ b/include/cib/detail/extend.hpp
@@ -16,8 +16,9 @@ struct extend : public config_item {
     CONSTEVAL explicit extend(Args const &...args) : args_tuple{args...} {}
 
     template <typename... InitArgs>
-    [[nodiscard]] constexpr auto extends_tuple(InitArgs const &...) const {
-        return stdx::make_tuple(*this);
+    [[nodiscard]] constexpr auto
+    extends_tuple(InitArgs const &...) const -> stdx::tuple<extend> {
+        return {*this};
     }
 };
 } // namespace cib::detail

--- a/include/cib/detail/nexus_details.hpp
+++ b/include/cib/detail/nexus_details.hpp
@@ -36,7 +36,7 @@ constexpr static auto initialized_builders = transform<extract_service_tag>(
         return detail::service_entry<service, decltype(built_service)>{
             built_service};
     },
-    chunk_by<get_service>(sort<get_service>(Config::config.extends_tuple())));
+    stdx::gather_by<get_service>(Config::config.extends_tuple()));
 
 template <typename Config, typename Tag> struct initialized {
     constexpr static auto value =


### PR DESCRIPTION
The change to use `gather_by` provides a good speedup; a few other things provide small speedups.