### PR TITLE
:rotating_light: Remove some old lint directives

### DIFF
--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -43,7 +43,6 @@ template <int NumFuncs = 0, typename... ArgTypes> struct callback {
      * @see cib::nexus
      */
     template <std::convertible_to<func_ptr_t>... Fs>
-    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     [[nodiscard]] constexpr auto add(Fs &&...fs) const {
         callback<NumFuncs + sizeof...(Fs), ArgTypes...> cb;
         auto i = std::size_t{};

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -155,7 +155,6 @@ struct graph_builder {
         constexpr static auto run() { built()(); }
 
       public:
-        // NOLINTNEXTLINE(google-explicit-constructor)
         constexpr operator FunctionPtr() const { return run; }
         constexpr auto operator()() const -> void { run(); }
         constexpr static bool active = decltype(built())::active;

--- a/include/flow/graphviz_builder.hpp
+++ b/include/flow/graphviz_builder.hpp
@@ -61,7 +61,6 @@ struct graphviz_builder {
         static auto run() -> std::string { return built(); }
 
       public:
-        // NOLINTNEXTLINE(google-explicit-constructor)
         constexpr operator VizFunctionPtr() const { return run; }
         auto operator()() const -> std::string { return run(); }
         constexpr static bool active = true;

--- a/include/log/catalog/mipi_encoder.hpp
+++ b/include/log/catalog/mipi_encoder.hpp
@@ -163,7 +163,6 @@ template <typename TDestinations> struct log_handler {
 
   private:
     template <typename... MsgDataTypes>
-    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     NEVER_INLINE auto
     dispatch_pass_by_args(MsgDataTypes &&...msg_data) -> void {
         stdx::for_each(

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -369,8 +369,7 @@ template <stdx::ct_string Name, typename... Fields> struct message {
         using span_t = Span;
 
         template <detail::storage_like S>
-        // NOLINTNEXTLINE(google-explicit-constructor)
-        view_t(S const &s) : storage{s} {}
+        explicit(false) view_t(S const &s) : storage{s} {}
 
         template <detail::storage_like S, some_field_value... Vs>
         constexpr explicit view_t(S &s, Vs... vs) : storage{s} {
@@ -378,12 +377,11 @@ template <stdx::ct_string Name, typename... Fields> struct message {
         }
 
         template <typename S>
-        // NOLINTNEXTLINE(google-explicit-constructor)
-        constexpr view_t(owner_t<S> const &s LIFETIMEBOUND)
+        constexpr explicit(false) view_t(owner_t<S> const &s LIFETIMEBOUND)
             : storage{s.data()} {}
 
         template <typename S, some_field_value... Vs>
-        explicit constexpr view_t(owner_t<S> &s LIFETIMEBOUND, Vs... vs)
+        explicit(true) constexpr view_t(owner_t<S> &s LIFETIMEBOUND, Vs... vs)
             : storage{s.data()} {
             this->set(vs...);
         }
@@ -393,8 +391,8 @@ template <stdx::ct_string Name, typename... Fields> struct message {
                      std::same_as<std::add_const_t<typename S::element_type>,
                                   typename span_t::element_type> and
                      span_t::extent <= S::extent)
-        // NOLINTNEXTLINE(google-explicit-constructor)
-        constexpr view_t(view_t<S> const &s) : storage{s.data()} {}
+        constexpr explicit(false) view_t(view_t<S> const &s)
+            : storage{s.data()} {}
 
         [[nodiscard]] constexpr auto data() const { return storage; }
 

--- a/include/sc/lazy_string_format.hpp
+++ b/include/sc/lazy_string_format.hpp
@@ -14,7 +14,6 @@ struct lazy_string_format {
     constexpr lazy_string_format(StringConstant, ArgTuple newArgs)
         : args{newArgs} {}
 
-    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     template <typename F> constexpr auto apply(F &&f) const {
         return args.apply(
             [&](auto const &...as) { return std::forward<F>(f)(str, as...); });


### PR DESCRIPTION
Updates to clang-tidy mean that some old directives are no longer needed.