### PR TITLE
:sparkles: Add `can_hold` to `field`

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -274,6 +274,8 @@ template <bits_locator... BLs> struct field_locator_t {
     template <typename T> constexpr static auto extent_in() -> std::size_t {
         return std::max({std::size_t{}, BLs::template extent_in<T>()...});
     }
+
+    constexpr static auto size = (std::size_t{} + ... + BLs::size);
 };
 } // namespace detail
 
@@ -449,6 +451,10 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
 
     [[nodiscard]] constexpr static auto describe(value_type v) {
         return format("{}: 0x{:x}"_sc, spec_t::name, v);
+    }
+
+    constexpr static auto can_hold(value_type v) -> bool {
+        return locator_t::size >= static_cast<std::size_t>(stdx::bit_width(v));
     }
 
     // ======================================================================

--- a/test/msg/field_insert.cpp
+++ b/test/msg/field_insert.cpp
@@ -121,3 +121,18 @@ TEST_CASE("trivially_copyable field type ", "[field insert]") {
     F::insert(data, custom_t{17});
     CHECK(17 == stdx::bit_cast<custom_t>(data[0]).v);
 }
+
+TEST_CASE("value fits in field", "[field insert]") {
+    using F = field<"", std::uint32_t>::located<at{0_dw, 3_msb, 0_lsb}>;
+    static_assert(F::can_hold(15));
+    CHECK(F::can_hold(15));
+    CHECK(not F::can_hold(16));
+}
+
+TEST_CASE("value fits in split field", "[field insert]") {
+    using F = field<"", std::uint32_t>::located<at{0_dw, 1_msb, 0_lsb},
+                                                at{0_dw, 7_msb, 6_lsb}>;
+    static_assert(F::can_hold(15));
+    CHECK(F::can_hold(15));
+    CHECK(not F::can_hold(16));
+}


### PR DESCRIPTION
A field's type can be larger than the bits used in the message. It is sometimes useful at runtime to determine whether or not a given value will fit in a field.