### PR TITLE
add runtime_conditional and flow unary operator*

### DIFF
--- a/docs/flows.adoc
+++ b/docs/flows.adoc
@@ -44,11 +44,11 @@ Actions are added to the flow inside a component's `cib::config`.
 struct morning {
   constexpr auto config = cib::config(
     cib::extend<MorningRoutine>(
-        WAKE_UP >>
-        selfcare::SHOWER >>
-        selfcare::GET_DRESSED >>
-        food::MAKE_COFFEE >>
-        food::DRINK_COFFEE));
+        *WAKE_UP >>
+        *selfcare::SHOWER >>
+        *selfcare::GET_DRESSED >>
+        *food::MAKE_COFFEE >>
+        *food::DRINK_COFFEE));
 };
 ----
 
@@ -57,6 +57,17 @@ example `WAKE_UP >> SHOWER` means you need to wake up first before you can take
 a shower. The flow library will order actions in a flow to respect these
 dependencies. The actions will be executed in an order that respects all given
 dependencies.
+
+The `*` operator is used to explicitly add an action to the
+flow. Without the `*` operator an action is just a reference.
+A compile-time error will be triggered if an action is referenced without ever
+being explicitly added to the flow. If an action is added under a compile-time
+or runtime conditional, and the conditional is false, then it is as if the
+action was never added at all.
+
+The behavior of the `*` operator ensures that merely referencing an 
+action to create an ordering dependency doesn't unintentionally add the action
+to the flow.
 
 If we only use the `morning` component in our project, the `MorningRoutine` flow
 graph would look like the following:
@@ -93,11 +104,11 @@ struct childcare {
   constexpr auto config = cib::config(
       cib::extend<MorningRoutine>(
           food::MAKE_COFFEE >>          // this step exists in the MorningRoutine flow
-          PACK_SCHOOL_LUNCHES >>        // new
+          *PACK_SCHOOL_LUNCHES >>       // new
           food::DRINK_COFFEE >>         // existing
-          food::MAKE_BREAKFAST >>       // new
-          food::EAT_BREAKFAST >>        // new
-          SEND_KIDS_TO_SCHOOL));        // new
+          *food::MAKE_BREAKFAST >>      // new
+          *food::EAT_BREAKFAST >>       // new
+          *SEND_KIDS_TO_SCHOOL));       // new
 };
 ----
 
@@ -140,7 +151,7 @@ struct exercise {
   constexpr auto config = cib::config(
       cib::extend<MorningRoutine>(
           morning::WAKE_UP >>
-          RIDE_STATIONARY_BIKE >>
+          *RIDE_STATIONARY_BIKE >>
           selfcare::SHOWER));
 };
 ----
@@ -321,7 +332,47 @@ namespace example_component {
   constexpr auto config = cib::config(
       cib::extend<MyFlow>(
           // no order requirement between these actions
-          SOME_ACTION && SOME_OTHER_ACTION));
+          *SOME_ACTION && *SOME_OTHER_ACTION));
+}
+----
+
+==== `operator*`
+
+Explicitly add an action to the flow. Actions used in flow extensions without
+the `*` will be treated as references only and will not be added to the
+flow at that location. It is a compilation error if an action is not added 
+with a `*` in exactly one location in the overall config.
+
+Actions can be added and ordered all at once:
+
+[source,cpp]
+----
+namespace example_component {
+  constexpr auto config = cib::config(
+      cib::extend<MyFlow>(
+          // Add both actions and create an ordering between them.
+          *SOME_ACTION >> *SOME_OTHER_ACTION));
+}
+----
+
+Actions can also be added and ordered seperately:
+
+[source,cpp]
+----
+namespace other_component {
+  constexpr auto INIT_SOMETHING = ...
+
+  constexpr auto config = cib::config(
+      cib::extend<MyFlow>(*INIT_SOMETHING));
+}
+
+namespace example_component {
+  constexpr auto DO_A_THING = ...
+
+  constexpr auto config = cib::config(
+      cib::extend<MyFlow>(
+          other_component::INIT_SOMETHING >> 
+          *DO_A_THING));
 }
 ----
 

--- a/examples/flow_daily_routine/main.cpp
+++ b/examples/flow_daily_routine/main.cpp
@@ -95,14 +95,10 @@ struct self_care_component_t {
     // Extend flow services
     constexpr static auto config = cib::config(
 
-        cib::extend<morning_routine_t>(self_care_component_t::WAKE_UP >>
-                                       self_care_component_t::EXERCISE >>
-                                       self_care_component_t::TAKE_BATH),
+        cib::extend<morning_routine_t>(*WAKE_UP >> *EXERCISE >> *TAKE_BATH),
 
-        cib::extend<evening_routine_t>(self_care_component_t::EXERCISE >>
-                                       self_care_component_t::TAKE_BATH >>
-                                       self_care_component_t::RELAX >>
-                                       self_care_component_t::GO_TO_BED));
+        cib::extend<evening_routine_t>(*EXERCISE >> *TAKE_BATH >> *RELAX >>
+                                       *GO_TO_BED));
 };
 
 struct food_component_t {
@@ -119,10 +115,10 @@ struct food_component_t {
     constexpr static auto config = cib::config(
 
         cib::extend<morning_routine_t>(self_care_component_t::TAKE_BATH >>
-                                       food_component_t::BREAKFAST),
+                                       *BREAKFAST),
 
         cib::extend<evening_routine_t>(self_care_component_t::RELAX >>
-                                       food_component_t::DINNER >>
+                                       *DINNER >>
                                        self_care_component_t::GO_TO_BED));
 };
 
@@ -141,16 +137,13 @@ struct dress_up_component_t {
     constexpr static auto config = cib::config(
 
         cib::extend<morning_routine_t>(
-            self_care_component_t::WAKE_UP >>
-            dress_up_component_t::GET_READY_FOR_EXERCISE >>
+            self_care_component_t::WAKE_UP >> *GET_READY_FOR_EXERCISE >>
             self_care_component_t::EXERCISE >>
-            self_care_component_t::TAKE_BATH >>
-            dress_up_component_t::GET_READY_TO_WORK >>
+            self_care_component_t::TAKE_BATH >> *GET_READY_TO_WORK >>
             food_component_t::BREAKFAST),
 
-        cib::extend<evening_routine_t>(
-            dress_up_component_t::GET_READY_FOR_EXERCISE >>
-            self_care_component_t::EXERCISE));
+        cib::extend<evening_routine_t>(*GET_READY_FOR_EXERCISE >>
+                                       self_care_component_t::EXERCISE));
 };
 
 struct commute_component_t {
@@ -167,11 +160,10 @@ struct commute_component_t {
     constexpr static auto config = cib::config(
 
         cib::extend<morning_routine_t>(food_component_t::BREAKFAST >>
-                                       commute_component_t::GO_TO_OFFICE),
+                                       *GO_TO_OFFICE),
 
         cib::extend<evening_routine_t>(
-            commute_component_t::RETURN_HOME >>
-            dress_up_component_t::GET_READY_FOR_EXERCISE));
+            *RETURN_HOME >> dress_up_component_t::GET_READY_FOR_EXERCISE));
 };
 
 struct daily_routine_component_t {
@@ -206,7 +198,7 @@ struct daily_routine_component_t {
 
         // we need to extend the MainLoop as cib::top implements
         // MainLoop service
-        cib::extend<cib::MainLoop>(DAILY_ROUTINES));
+        cib::extend<cib::MainLoop>(*DAILY_ROUTINES));
 };
 
 struct person_routine_proj {

--- a/include/cib/config.hpp
+++ b/include/cib/config.hpp
@@ -7,6 +7,7 @@
 #include <cib/detail/config_item.hpp>
 #include <cib/detail/exports.hpp>
 #include <cib/detail/extend.hpp>
+#include <cib/detail/runtime_conditional.hpp>
 
 #include <stdx/compiler.hpp>
 
@@ -22,6 +23,7 @@ namespace cib {
  * @see cib::extend
  * @see cib::exports
  * @see cib::conditional
+ * @see cib::runtime_conditional
  */
 template <typename... Configs>
 [[nodiscard]] CONSTEVAL auto config(Configs const &...configs) {
@@ -72,4 +74,10 @@ template <typename Predicate, typename... Configs>
                                          Configs const &...configs) {
     return detail::conditional<Predicate, Configs...>{configs...};
 }
+
+template <stdx::ct_string Name>
+constexpr auto runtime_condition = []<typename P>(P) {
+    static_assert(std::is_default_constructible_v<P>);
+    return detail::runtime_condition<Name, P>{};
+};
 } // namespace cib

--- a/include/cib/detail/runtime_conditional.hpp
+++ b/include/cib/detail/runtime_conditional.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cib/detail/config_details.hpp>
+#include <cib/detail/config_item.hpp>
+#include <cib/detail/extend.hpp>
+
+#include <stdx/compiler.hpp>
+#include <stdx/ct_format.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+
+namespace cib::detail {
+namespace poison {
+template <typename... Ts>
+constexpr auto make_runtime_conditional(Ts &&...) = delete;
+}
+
+template <typename Cond, typename... Configs>
+struct runtime_conditional : config_item {
+    detail::config<Configs...> body;
+
+    CONSTEVAL explicit runtime_conditional(Configs const &...configs)
+        : body{configs...} {}
+
+    [[nodiscard]] constexpr auto extends_tuple() const {
+        return stdx::transform(
+            []<typename E>(E e) {
+                auto args_tuple = stdx::transform(
+                    []<typename Arg>(Arg) {
+                        using poison::make_runtime_conditional;
+                        return make_runtime_conditional(Cond{}, Arg{});
+                    },
+                    e.args_tuple);
+
+                return stdx::apply(
+                    []<typename... Args>(Args...) {
+                        return extend<typename E::service_type, Args...>{
+                            Args{}...};
+                    },
+                    args_tuple);
+            },
+            body.extends_tuple());
+    }
+
+    [[nodiscard]] constexpr auto exports_tuple() const {
+        return body.exports_tuple();
+    }
+};
+
+template <stdx::ct_string Name, typename... Ps> // FIXME: concept for Ps
+struct runtime_condition {
+    constexpr static auto predicates = stdx::make_tuple(Ps{}...);
+
+    constexpr static auto ct_name = Name;
+
+    template <typename... Configs>
+    [[nodiscard]] CONSTEVAL auto operator()(Configs const &...configs) const {
+        return detail::runtime_conditional<runtime_condition<Name, Ps...>,
+                                           Configs...>{configs...};
+    }
+
+    explicit operator bool() const { return (Ps{}() and ...); }
+};
+
+template <stdx::ct_string LhsName, typename... LhsPs, stdx::ct_string RhsName,
+          typename... RhsPs>
+[[nodiscard]] constexpr auto
+operator and(runtime_condition<LhsName, LhsPs...> const &lhs,
+             runtime_condition<RhsName, RhsPs...> const &rhs) {
+    if constexpr ((sizeof...(LhsPs) + sizeof...(RhsPs)) == 0) {
+        return runtime_condition<"always">{};
+
+    } else if constexpr (sizeof...(LhsPs) == 0) {
+        return rhs;
+
+    } else if constexpr (sizeof...(RhsPs) == 0) {
+        return lhs;
+
+    } else {
+        constexpr auto name =
+            stdx::ct_format<"{} and {}">(CX_VALUE(LhsName), CX_VALUE(RhsName));
+
+        return runtime_condition<name, LhsPs..., RhsPs...>{};
+    }
+}
+
+using always_condition_t = runtime_condition<"always">;
+constexpr auto always_condition = always_condition_t{};
+} // namespace cib::detail

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -9,7 +9,7 @@
 
 namespace flow {
 template <stdx::ct_string Name = "">
-using builder = graph<Name, graph_builder<impl>>;
+using builder = graph<Name, graph_builder<Name, impl>>;
 
 template <stdx::ct_string Name = "">
 struct service : cib::builder_meta<builder<Name>, FunctionPtr> {};

--- a/include/flow/detail/par.hpp
+++ b/include/flow/detail/par.hpp
@@ -1,15 +1,22 @@
 #pragma once
 
 #include <flow/detail/walk.hpp>
+#include <flow/subgraph_identity.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
 
 namespace flow::dsl {
-template <node Lhs, node Rhs> struct par {
+template <subgraph Lhs, subgraph Rhs,
+          subgraph_identity Identity = subgraph_identity::REFERENCE>
+struct par {
     Lhs lhs;
     Rhs rhs;
 
-    using is_node = void;
+    using is_subgraph = void;
+
+    constexpr auto operator*() const {
+        return par<Lhs, Rhs, subgraph_identity::VALUE>{Lhs{}, Rhs{}};
+    }
 
   private:
     friend constexpr auto tag_invoke(get_initials_t, par const &p) {
@@ -21,7 +28,21 @@ template <node Lhs, node Rhs> struct par {
     }
 
     friend constexpr auto tag_invoke(get_nodes_t, par const &p) {
-        return stdx::tuple_cat(get_nodes(p.lhs), get_nodes(p.rhs));
+        if constexpr (Identity == subgraph_identity::VALUE) {
+            auto all_nodes = stdx::to_unsorted_set(
+                stdx::tuple_cat(get_all_mentioned_nodes(p.lhs),
+                                get_all_mentioned_nodes(p.rhs)));
+
+            return stdx::transform([](auto const &n) { return *n; }, all_nodes);
+
+        } else {
+            return stdx::tuple_cat(get_nodes(p.lhs), get_nodes(p.rhs));
+        }
+    }
+
+    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, par const &p) {
+        return stdx::tuple_cat(get_all_mentioned_nodes(p.lhs),
+                               get_all_mentioned_nodes(p.rhs));
     }
 
     friend constexpr auto tag_invoke(get_edges_t, par const &p) {
@@ -29,10 +50,23 @@ template <node Lhs, node Rhs> struct par {
     }
 };
 
-template <node Lhs, node Rhs> par(Lhs, Rhs) -> par<Lhs, Rhs>;
+template <subgraph Lhs, subgraph Rhs> par(Lhs, Rhs) -> par<Lhs, Rhs>;
 } // namespace flow::dsl
 
-template <flow::dsl::node Lhs, flow::dsl::node Rhs>
+template <flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs>
 [[nodiscard]] constexpr auto operator&&(Lhs const &lhs, Rhs const &rhs) {
     return flow::dsl::par{lhs, rhs};
+}
+
+template <typename Cond, flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs,
+          flow::subgraph_identity Identity>
+constexpr auto make_runtime_conditional(Cond,
+                                        flow::dsl::par<Lhs, Rhs, Identity>) {
+    auto lhs = make_runtime_conditional(Cond{}, Lhs{});
+    auto rhs = make_runtime_conditional(Cond{}, Rhs{});
+
+    using lhs_t = decltype(lhs);
+    using rhs_t = decltype(rhs);
+
+    return flow::dsl::par<lhs_t, rhs_t, Identity>{lhs, rhs};
 }

--- a/include/flow/detail/seq.hpp
+++ b/include/flow/detail/seq.hpp
@@ -1,15 +1,24 @@
 #pragma once
 
+#include <cib/detail/runtime_conditional.hpp>
 #include <flow/detail/walk.hpp>
+#include <flow/subgraph_identity.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
 
 namespace flow::dsl {
-template <node Lhs, node Rhs> struct seq {
+template <subgraph Lhs, subgraph Rhs,
+          subgraph_identity Identity = subgraph_identity::REFERENCE,
+          typename Cond = cib::detail::always_condition_t>
+struct seq {
     Lhs lhs;
     Rhs rhs;
 
-    using is_node = void;
+    using is_subgraph = void;
+
+    constexpr auto operator*() const {
+        return seq<Lhs, Rhs, subgraph_identity::VALUE, Cond>{Lhs{}, Rhs{}};
+    }
 
   private:
     friend constexpr auto tag_invoke(get_initials_t, seq const &s) {
@@ -21,7 +30,21 @@ template <node Lhs, node Rhs> struct seq {
     }
 
     friend constexpr auto tag_invoke(get_nodes_t, seq const &s) {
-        return stdx::tuple_cat(get_nodes(s.lhs), get_nodes(s.rhs));
+        if constexpr (Identity == subgraph_identity::VALUE) {
+            auto all_nodes = stdx::to_unsorted_set(
+                stdx::tuple_cat(get_all_mentioned_nodes(s.lhs),
+                                get_all_mentioned_nodes(s.rhs)));
+
+            return stdx::transform([](auto const &n) { return *n; }, all_nodes);
+
+        } else {
+            return stdx::tuple_cat(get_nodes(s.lhs), get_nodes(s.rhs));
+        }
+    }
+
+    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, seq const &s) {
+        return stdx::tuple_cat(get_all_mentioned_nodes(s.lhs),
+                               get_all_mentioned_nodes(s.rhs));
     }
 
     friend constexpr auto tag_invoke(get_edges_t, seq const &s) {
@@ -33,16 +56,31 @@ template <node Lhs, node Rhs> struct seq {
             transform(
                 []<typename P>(P const &) {
                     return edge<stdx::tuple_element_t<0, P>,
-                                stdx::tuple_element_t<1, P>>{};
+                                stdx::tuple_element_t<1, P>, Cond>{};
                 },
                 cartesian_product_copy(fs, is)));
     }
 };
 
-template <node Lhs, node Rhs> seq(Lhs, Rhs) -> seq<Lhs, Rhs>;
+template <subgraph Lhs, subgraph Rhs> seq(Lhs, Rhs) -> seq<Lhs, Rhs>;
+
 } // namespace flow::dsl
 
-template <flow::dsl::node Lhs, flow::dsl::node Rhs>
+template <flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs>
 [[nodiscard]] constexpr auto operator>>(Lhs const &lhs, Rhs const &rhs) {
     return flow::dsl::seq{lhs, rhs};
+}
+
+template <typename Cond, flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs,
+          flow::subgraph_identity Identity, typename EdgeCond>
+constexpr auto
+make_runtime_conditional(Cond, flow::dsl::seq<Lhs, Rhs, Identity, EdgeCond>) {
+    auto lhs = make_runtime_conditional(Cond{}, Lhs{});
+    auto rhs = make_runtime_conditional(Cond{}, Rhs{});
+
+    using lhs_t = decltype(lhs);
+    using rhs_t = decltype(rhs);
+    using cond_t = decltype(EdgeCond{} and Cond{});
+
+    return flow::dsl::seq<lhs_t, rhs_t, Identity, cond_t>{lhs, rhs};
 }

--- a/include/flow/detail/walk.hpp
+++ b/include/flow/detail/walk.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <flow/subgraph_identity.hpp>
+
 #include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/type_traits.hpp>
@@ -8,15 +10,17 @@
 
 namespace flow::dsl {
 template <typename T>
-concept node = requires { typename stdx::remove_cvref_t<T>::is_node; };
+concept subgraph = requires { typename stdx::remove_cvref_t<T>::is_subgraph; };
 
-template <typename Source, typename Dest> struct edge {
+template <typename Source, typename Dest, typename Cond> struct edge {
     using source_t = Source;
     using dest_t = Dest;
+    using cond_t = Cond;
 };
 
 constexpr inline class get_initials_t {
-    template <node N> friend constexpr auto tag_invoke(get_initials_t, N &&n) {
+    template <subgraph N>
+    friend constexpr auto tag_invoke(get_initials_t, N &&n) {
         return stdx::make_tuple(std::forward<N>(n));
     }
 
@@ -31,7 +35,8 @@ constexpr inline class get_initials_t {
 } get_initials{};
 
 constexpr inline class get_finals_t {
-    template <node N> friend constexpr auto tag_invoke(get_finals_t, N &&n) {
+    template <subgraph N>
+    friend constexpr auto tag_invoke(get_finals_t, N &&n) {
         return stdx::make_tuple(std::forward<N>(n));
     }
 
@@ -46,8 +51,13 @@ constexpr inline class get_finals_t {
 } get_finals{};
 
 constexpr inline class get_nodes_t {
-    template <node N> friend constexpr auto tag_invoke(get_nodes_t, N &&n) {
-        return stdx::make_tuple(std::forward<N>(n));
+    template <subgraph N> friend constexpr auto tag_invoke(get_nodes_t, N &&n) {
+        if constexpr (std::remove_cvref_t<N>::identity ==
+                      subgraph_identity::REFERENCE) {
+            return stdx::tuple{};
+        } else {
+            return stdx::make_tuple(std::forward<N>(n));
+        }
     }
 
   public:
@@ -60,8 +70,24 @@ constexpr inline class get_nodes_t {
     }
 } get_nodes{};
 
+constexpr inline class get_all_mentioned_nodes_t {
+    template <subgraph N>
+    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, N &&n) {
+        return stdx::make_tuple(std::forward<N>(n));
+    }
+
+  public:
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<get_all_mentioned_nodes_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} get_all_mentioned_nodes{};
+
 constexpr inline class get_edges_t {
-    friend constexpr auto tag_invoke(get_edges_t, node auto const &) {
+    friend constexpr auto tag_invoke(get_edges_t, subgraph auto const &) {
         return stdx::tuple{};
     }
 

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -4,12 +4,16 @@
 #include <flow/detail/walk.hpp>
 #include <flow/impl.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/cx_multimap.hpp>
 #include <stdx/cx_set.hpp>
 #include <stdx/cx_vector.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
+#include <stdx/utility.hpp>
+
+#include <boost/mp11/set.hpp>
 
 #include <algorithm>
 #include <array>
@@ -20,14 +24,21 @@
 #include <utility>
 
 namespace flow {
+namespace detail {
+template <typename T> using is_duplicated = std::bool_constant<(T::size() > 1)>;
+}
+template <typename T> using name_for = typename T::name_t;
+
 [[nodiscard]] constexpr auto edge_size(auto const &nodes,
                                        auto const &edges) -> std::size_t {
     auto const edge_capacities = transform(
         [&]<typename N>(N const &) {
             return edges.fold_left(
                 std::size_t{}, []<typename E>(auto acc, E const &) {
-                    if constexpr (std::is_same_v<typename E::source_t, N> or
-                                  std::is_same_v<typename E::dest_t, N>) {
+                    if constexpr (std::is_same_v<name_for<typename E::source_t>,
+                                                 name_for<N>> or
+                                  std::is_same_v<name_for<typename E::dest_t>,
+                                                 name_for<N>>) {
                         return ++acc;
                     } else {
                         return acc;
@@ -41,10 +52,31 @@ namespace flow {
     });
 }
 
-template <template <stdx::ct_string, std::size_t> typename Impl>
-struct graph_builder {
-    template <typename T> using name_for = typename T::name_t;
+template <typename Cond> struct sequence_conditions;
 
+template <auto...> struct INFO_flow_name_;
+
+template <auto...> struct INFO_step_a_name_;
+
+template <auto...> struct INFO_step_a_condition_;
+
+template <auto...> struct INFO_step_b_name_;
+
+template <auto...> struct INFO_step_b_condition_;
+
+template <auto...> struct INFO_sequence_condition_;
+
+template <typename...> struct INFO_sequence_missing_predicate_;
+
+template <typename...> constexpr bool ERROR_DETAILS_ = false;
+
+template <auto...> struct INFO_missing_steps_;
+
+template <auto...> struct INFO_duplicated_steps_;
+
+template <stdx::ct_string Name,
+          template <stdx::ct_string, std::size_t> typename Impl>
+struct graph_builder {
     template <typename Node, std::size_t N, std::size_t E>
     [[nodiscard]] constexpr static auto make_graph(auto const &nodes,
                                                    auto const &edges) {
@@ -54,9 +86,49 @@ struct graph_builder {
 
         auto const named_nodes = stdx::apply_indices<name_for>(nodes);
         for_each(
-            [&]<typename Edge>(Edge const &) {
-                g.put(get<name_for<typename Edge::source_t>>(named_nodes),
-                      get<name_for<typename Edge::dest_t>>(named_nodes));
+            [&]<typename Lhs, typename Rhs, typename Cond>(
+                dsl::edge<Lhs, Rhs, Cond> const &) {
+                auto lhs = get<name_for<Lhs>>(named_nodes);
+                auto rhs = get<name_for<Rhs>>(named_nodes);
+
+                using lhs_t = std::remove_cvref_t<decltype(lhs)>;
+                using rhs_t = std::remove_cvref_t<decltype(rhs)>;
+
+                using edge_ps_t = decltype(Cond::predicates);
+                auto node_ps = stdx::to_unsorted_set(stdx::tuple_cat(
+                    lhs_t::condition.predicates, rhs_t::condition.predicates));
+
+                stdx::for_each(
+                    [&]<typename P>(P const &) {
+                        if constexpr (not stdx::contains_type<edge_ps_t, P>) {
+                            static_assert(
+                                ERROR_DETAILS_<
+                                    INFO_flow_name_<Name>,
+                                    INFO_step_a_name_<lhs_t::ct_name>,
+                                    INFO_step_a_condition_<
+                                        lhs_t::condition.ct_name>,
+                                    INFO_step_b_name_<rhs_t::ct_name>,
+                                    INFO_step_b_condition_<
+                                        rhs_t::condition.ct_name>,
+                                    INFO_sequence_condition_<Cond::ct_name>,
+                                    INFO_sequence_missing_predicate_<P>>,
+
+                                "The conditions on this sequence "
+                                "(step_a >> step_b) are weaker than those on "
+                                "step_a and/or step_b. The sequence could be "
+                                "enabled while step_a and/or step_b is not. "
+                                "Specifically, the sequence is missing the "
+                                "predicate identified in "
+                                "`INFO_sequence_missing_predicate_`. TIP: "
+                                "Look for 'ERROR_DETAILS_` and `INFO_` in "
+                                "the compiler error message for details on "
+                                "the sequence, the step names, and the "
+                                "conditions.");
+                        }
+                    },
+                    node_ps);
+
+                g.put(lhs, rhs);
             },
             edges);
         return g;
@@ -119,13 +191,76 @@ struct graph_builder {
             std::span{std::cbegin(ordered_list), std::size(ordered_list)}};
     }
 
+    constexpr static void check_for_missing_nodes(auto nodes,
+                                                  auto mentioned_nodes) {
+        constexpr auto get_name = []<typename N>(N) ->
+            typename N::name_t { return {}; };
+        auto node_names = stdx::transform(get_name, nodes);
+        auto mentioned_node_names = stdx::transform(get_name, mentioned_nodes);
+
+        using node_names_t = decltype(stdx::to_sorted_set(node_names));
+        using mentioned_node_names_t =
+            decltype(stdx::to_sorted_set(mentioned_node_names));
+
+        if constexpr (not std::is_same_v<node_names_t,
+                                         mentioned_node_names_t>) {
+            using missing_nodes_t =
+                boost::mp11::mp_set_difference<mentioned_node_names_t,
+                                               node_names_t>;
+
+            constexpr auto missing_nodes = missing_nodes_t{};
+            constexpr auto missing_nodes_ct_strings = stdx::transform(
+                []<typename N>(N) { return stdx::ct_string_from_type(N{}); },
+                missing_nodes);
+
+            [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                using error_details_t = INFO_missing_steps_<stdx::get<Is>(
+                    missing_nodes_ct_strings)...>;
+
+                static_assert(
+                    ERROR_DETAILS_<INFO_flow_name_<Name>, error_details_t>,
+                    "One or more steps are referenced in the flow but not "
+                    "explicitly added with the * operator. The "
+                    "beginning of this error shows you which steps are "
+                    "missing.");
+            }(std::make_index_sequence<
+                stdx::tuple_size_v<decltype(missing_nodes)>>{});
+        }
+
+        if constexpr (stdx::tuple_size_v<node_names_t> !=
+                      stdx::tuple_size_v<decltype(node_names)>) {
+            constexpr auto duplicates = stdx::transform(
+                [](auto e) {
+                    return stdx::ct_string_from_type(stdx::get<0>(e));
+                },
+                stdx::filter<detail::is_duplicated>(stdx::gather(node_names)));
+
+            [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                using error_details_t =
+                    INFO_duplicated_steps_<stdx::get<Is>(duplicates)...>;
+
+                static_assert(
+                    ERROR_DETAILS_<INFO_flow_name_<Name>, error_details_t>,
+                    "One or more steps are explicitly added more than once "
+                    "using the * operator. The beginning of this "
+                    "error shows you which steps are duplicated.");
+            }(std::make_index_sequence<
+                stdx::tuple_size_v<decltype(duplicates)>>{});
+        }
+    }
+
     template <typename Graph>
     [[nodiscard]] constexpr static auto build(Graph const &input) {
         auto nodes = flow::dsl::get_nodes(input);
-        auto edges = flow::dsl::get_edges(input);
+        auto mentioned_nodes = flow::dsl::get_all_mentioned_nodes(input);
 
-        constexpr auto node_capacity = stdx::tuple_size_v<decltype(nodes)>;
-        constexpr auto edge_capacity = edge_size(nodes, edges);
+        check_for_missing_nodes(nodes, mentioned_nodes);
+
+        auto node_set = stdx::to_unsorted_set(nodes);
+        auto edges = stdx::to_unsorted_set(flow::dsl::get_edges(input));
+
+        constexpr auto node_capacity = stdx::tuple_size_v<decltype(node_set)>;
+        constexpr auto edge_capacity = edge_size(node_set, edges);
 
         using output_t = Impl<Graph::name, node_capacity>;
         using rt_node_t = typename output_t::node_t;
@@ -135,11 +270,11 @@ struct graph_builder {
                 []<typename N>(N const &) {
                     return std::is_convertible_v<N, rt_node_t>;
                 },
-                nodes),
+                node_set),
             "Output node type is not compatible with given input nodes");
 
-        auto g =
-            make_graph<rt_node_t, node_capacity, edge_capacity>(nodes, edges);
+        auto g = make_graph<rt_node_t, node_capacity, edge_capacity>(node_set,
+                                                                     edges);
         return topo_sort<output_t>(g);
     }
 
@@ -173,25 +308,19 @@ struct graph_builder {
     }
 };
 
-template <stdx::ct_string Name = "", typename Renderer = graph_builder<impl>,
-          flow::dsl::node... Fragments>
+template <stdx::ct_string Name = "",
+          typename Renderer = graph_builder<Name, impl>,
+          flow::dsl::subgraph... Fragments>
 class graph {
-    friend constexpr auto tag_invoke(flow::dsl::get_nodes_t, graph const &g) {
-        auto t = g.fragments.apply([](auto const &...frags) {
-            return stdx::tuple_cat(flow::dsl::get_nodes(frags)...);
+    template <typename Tag>
+    friend constexpr auto tag_invoke(Tag, graph const &g) {
+        return g.fragments.apply([](auto const &...frags) {
+            return stdx::tuple_cat(Tag{}(frags)...);
         });
-        return stdx::to_unsorted_set(t);
-    }
-
-    friend constexpr auto tag_invoke(flow::dsl::get_edges_t, graph const &g) {
-        auto t = g.fragments.apply([](auto const &...frags) {
-            return stdx::tuple_cat(flow::dsl::get_edges(frags)...);
-        });
-        return stdx::to_unsorted_set(t);
     }
 
   public:
-    template <flow::dsl::node... Ns>
+    template <flow::dsl::subgraph... Ns>
     [[nodiscard]] constexpr auto add(Ns &&...ns) {
         return fragments.apply([&](auto &...frags) {
             return graph<Name, Renderer, Fragments...,

--- a/include/flow/subgraph_identity.hpp
+++ b/include/flow/subgraph_identity.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace flow {
+enum class subgraph_identity { VALUE, REFERENCE };
+}

--- a/include/match/predicate.hpp
+++ b/include/match/predicate.hpp
@@ -12,7 +12,12 @@
 namespace match {
 template <stdx::ct_string Name, stdx::callable P> struct predicate_t {
     using is_matcher = void;
-    [[no_unique_address]] P pred;
+
+    constexpr static P pred{};
+
+    constexpr predicate_t(P) {}
+
+    constexpr predicate_t() {}
 
     [[nodiscard]] constexpr auto
     operator()(auto const &event) const -> decltype(pred(event)) {

--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -2,6 +2,7 @@
 
 #include <log/log.hpp>
 #include <match/ops.hpp>
+#include <match/predicate.hpp>
 #include <msg/message.hpp>
 
 #include <stdx/concepts.hpp>
@@ -84,6 +85,24 @@ template <stdx::ct_string Name, typename Msg> struct callback_construct_t {
         using fn = std::is_same<N, typename Field::name_t>;
     };
 };
+
+template <typename Cond, stdx::ct_string Name, typename Msg, match::matcher M,
+          stdx::callable F>
+constexpr auto make_runtime_conditional(Cond, callback<Name, Msg, M, F> cb) {
+    using ::operator and;
+
+    auto predicate = match::predicate<Cond::ct_name>(
+        [](auto...) -> bool { return static_cast<bool>(Cond{}); });
+    using predicate_t = decltype(predicate);
+
+    auto new_matcher = match::sum_of_products(M{} and predicate_t{});
+    using new_matcher_t = decltype(new_matcher);
+
+    using new_cb_t = callback<Name, Msg, new_matcher_t, F>;
+
+    return new_cb_t{new_matcher, cb.callable};
+}
+
 } // namespace detail
 
 template <stdx::ct_string Name, typename Msg>

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -9,7 +9,7 @@
 
 namespace seq {
 template <stdx::ct_string Name = "">
-using builder = flow::graph<Name, flow::graph_builder<impl>>;
+using builder = flow::graph<Name, flow::graph_builder<Name, impl>>;
 
 template <stdx::ct_string Name = "">
 struct service : cib::builder_meta<builder<Name>, flow::FunctionPtr> {};

--- a/test/flow/fail/CMakeLists.txt
+++ b/test/flow/fail/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_compile_fail_test(cyclic_flow.cpp LIBRARIES warnings cib)
+add_compile_fail_test(only_reference_added.cpp LIBRARIES warnings cib)
+add_compile_fail_test(mismatched_flow_runtime_conditional.cpp LIBRARIES
+                      warnings cib)
+add_compile_fail_test(node_explicitly_added_twice.cpp LIBRARIES warnings cib)

--- a/test/flow/fail/mismatched_flow_runtime_conditional.cpp
+++ b/test/flow/fail/mismatched_flow_runtime_conditional.cpp
@@ -1,0 +1,28 @@
+#include <cib/cib.hpp>
+#include <flow/flow.hpp>
+
+// EXPECT: The conditions on this sequence
+
+namespace {
+using namespace flow::literals;
+
+constexpr auto a = flow::milestone<"a">();
+constexpr auto b = flow::milestone<"b">();
+
+struct TestFlowAlpha : public flow::service<> {};
+
+constexpr auto when_feature_a_enabled =
+    cib::runtime_condition<"feature_a_enabled">([] { return true; });
+
+struct FlowConfig {
+    constexpr static auto config =
+        cib::config(cib::exports<TestFlowAlpha>,
+                    when_feature_a_enabled(cib::extend<TestFlowAlpha>(*a)),
+                    cib::extend<TestFlowAlpha>(a >> *b));
+};
+} // namespace
+
+auto main() -> int {
+    cib::nexus<FlowConfig> nexus{};
+    nexus.service<TestFlowAlpha>();
+}

--- a/test/flow/fail/node_explicitly_added_twice.cpp
+++ b/test/flow/fail/node_explicitly_added_twice.cpp
@@ -1,23 +1,22 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
 
-// EXPECT: Topological sort failed: cycle in flow
+// EXPECT: One or more steps are explicitly added more than once
 
 namespace {
 using namespace flow::literals;
 
 constexpr auto a = flow::milestone<"a">();
-constexpr auto b = flow::milestone<"b">();
 
 struct TestFlowAlpha : public flow::service<> {};
 
-struct CyclicFlowConfig {
+struct FlowConfig {
     constexpr static auto config = cib::config(
-        cib::exports<TestFlowAlpha>, cib::extend<TestFlowAlpha>(*a >> *b >> a));
+        cib::exports<TestFlowAlpha>, cib::extend<TestFlowAlpha>(*a, *a));
 };
 } // namespace
 
 auto main() -> int {
-    cib::nexus<CyclicFlowConfig> nexus{};
+    cib::nexus<FlowConfig> nexus{};
     nexus.service<TestFlowAlpha>();
 }

--- a/test/flow/fail/only_reference_added.cpp
+++ b/test/flow/fail/only_reference_added.cpp
@@ -1,0 +1,22 @@
+#include <cib/cib.hpp>
+#include <flow/flow.hpp>
+
+// EXPECT: One or more steps are referenced in the flow but not explicitly
+
+namespace {
+using namespace flow::literals;
+
+constexpr auto a = flow::milestone<"a">();
+
+struct TestFlowAlpha : public flow::service<> {};
+
+struct FlowConfig {
+    constexpr static auto config =
+        cib::config(cib::exports<TestFlowAlpha>, cib::extend<TestFlowAlpha>(a));
+};
+} // namespace
+
+auto main() -> int {
+    cib::nexus<FlowConfig> nexus{};
+    nexus.service<TestFlowAlpha>();
+}

--- a/test/flow/graph.cpp
+++ b/test/flow/graph.cpp
@@ -26,12 +26,12 @@ TEST_CASE("node size (empty graph)", "[graph]") {
 }
 
 TEST_CASE("node size (single action)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(a >> b);
+    constexpr auto g = flow::graph<>{}.add(*a >> *b);
     static_assert(node_size(g) == 2);
 }
 
 TEST_CASE("node size (overlapping actions)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(a >> b).add(b >> c);
+    constexpr auto g = flow::graph<>{}.add(*a >> *b).add(b >> *c);
     static_assert(node_size(g) == 3);
 }
 
@@ -41,11 +41,11 @@ TEST_CASE("edge size (empty flow)", "[graph]") {
 }
 
 TEST_CASE("edge size (single action)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(a >> b);
+    constexpr auto g = flow::graph<>{}.add(*a >> *b);
     static_assert(edge_size(g) == 1);
 }
 
 TEST_CASE("edge size (overlapping actions)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(a >> b).add(b >> c);
+    constexpr auto g = flow::graph<>{}.add(*a >> *b).add(*b >> *c);
     static_assert(edge_size(g) == 2);
 }

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -36,6 +36,16 @@ struct test_project {
         cib::exports<test_service>, cib::extend<test_service>(test_callback));
 };
 
+template <bool V>
+constexpr auto when_feature_enabled =
+    cib::runtime_condition<"feature_a_enabled">([] { return V; });
+
+template <bool V> struct runtime_condition_project {
+    constexpr static auto config = cib::config(
+        cib::exports<test_service>,
+        when_feature_enabled<V>(cib::extend<test_service>(test_callback)));
+};
+
 std::string log_buffer{};
 } // namespace
 
@@ -50,6 +60,33 @@ TEST_CASE("build handler", "[handler_builder]") {
     callback_success = false;
     cib::service<test_service>->handle(test_msg_t{"id"_field = 0x80});
     CHECK(callback_success);
+}
+
+TEST_CASE("build handler (no match)", "[handler_builder]") {
+    cib::nexus<test_project> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{"id"_field = 0x70});
+    CHECK(not callback_success);
+}
+
+TEST_CASE("true runtime condition", "[handler_builder]") {
+    cib::nexus<runtime_condition_project<true>> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{"id"_field = 0x80});
+    CHECK(callback_success);
+}
+
+TEST_CASE("false runtime condition", "[handler_builder]") {
+    cib::nexus<runtime_condition_project<false>> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(test_msg_t{"id"_field = 0x80});
+    CHECK(not callback_success);
 }
 
 TEST_CASE("match output success", "[handler_builder]") {

--- a/test/seq/sequencer.cpp
+++ b/test/seq/sequencer.cpp
@@ -10,7 +10,7 @@ namespace {
 int attempt_count;
 std::string result{};
 
-using builder = flow::graph_builder<seq::impl>;
+using builder = flow::graph_builder<"test_seq", seq::impl>;
 } // namespace
 
 TEST_CASE("build and run empty seq", "[seq]") {
@@ -34,7 +34,7 @@ TEST_CASE("build seq with one step and run forwards and backwards", "[seq]") {
             return seq::status::DONE;
         });
 
-    auto g = seq::builder<>{}.add(s);
+    auto g = seq::builder<>{}.add(*s);
     auto seq_impl = builder::build(g);
     REQUIRE(seq_impl.has_value());
 
@@ -64,7 +64,7 @@ TEST_CASE("build seq with a forward step that takes a while to finish",
             return seq::status::DONE;
         });
 
-    auto g = seq::builder<>{}.add(s);
+    auto g = seq::builder<>{}.add(*s);
     auto seq_impl = builder::build(g);
     REQUIRE(seq_impl.has_value());
 
@@ -110,7 +110,7 @@ TEST_CASE("build seq with a backward step that takes a while to finish",
             }
         });
 
-    auto g = seq::builder<>{}.add(s);
+    auto g = seq::builder<>{}.add(*s);
     auto seq_impl = builder::build(g);
     REQUIRE(seq_impl.has_value());
 
@@ -175,7 +175,7 @@ TEST_CASE("build seq with three steps and run forwards and backwards",
             return seq::status::DONE;
         });
 
-    auto g = seq::builder<>{}.add(s1 >> s2 >> s3);
+    auto g = seq::builder<>{}.add(*s1 >> *s2 >> *s3);
     auto seq_impl = builder::build(g);
     REQUIRE(seq_impl.has_value());
 


### PR DESCRIPTION
TODO:
- ✅Better way to ensure predicates for the same condition are unique
- ✅operator&& for predicates
- ✅Better error message for edge/node predicate requirements
- ✅Documentation
- ✅More unit tests for edge/node predicate requirements
- ✅unary operator* for seq/par objects 
- ~~unary operator- for explicit references (can't be made into non-reference by unary +)~~
- ✅Message handler support
- ✅Indexed message handler tests
- ~~runtime_condition support for cib::callback~~ (do in follow-on PR)