### PR TITLE
:bug: Fix return value of `indexed_handler::handle`

### DIFF
--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -141,12 +141,12 @@ struct indexed_builder_base {
                        ExtraCallbackArgsT...>{new_callbacks};
     }
 
-    using callback_func_t = void (*)(BaseMsgT const &,
-                                     ExtraCallbackArgsT... args);
+    using callback_func_t = auto (*)(BaseMsgT const &,
+                                     ExtraCallbackArgsT... args) -> bool;
 
     template <typename BuilderValue, std::size_t I>
     constexpr static auto invoke_callback(BaseMsgT const &data,
-                                          ExtraCallbackArgsT... args) {
+                                          ExtraCallbackArgsT... args) -> bool {
         // FIXME: incomplete message callback invocation...
         //        1) bit_cast message argument
         constexpr auto cb = IndexSpec{}.apply([&]<typename... Indices>(
@@ -173,7 +173,9 @@ struct indexed_builder_base {
                 stdx::ct_string_to_type<cb.name, sc::string_constant>(),
                 orig_cb.matcher.describe(), cb.matcher.describe());
             cb.callable(view, args...);
+            return true;
         }
+        return false;
     }
 
     template <typename BuilderValue, std::size_t... Is>

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -68,8 +68,8 @@ TEST_CASE("match output success", "[handler_builder]") {
     cib::nexus<test_project> test_nexus{};
     test_nexus.init();
 
-    cib::service<test_service>->handle(
-        test_msg_t{"test_id_field"_field = 0x80});
+    CHECK(cib::service<test_service>->handle(
+        test_msg_t{"test_id_field"_field = 0x80}));
     CAPTURE(log_buffer);
     CHECK(log_buffer.find("Incoming message matched") != std::string::npos);
     CHECK(log_buffer.find("[TestCallback]") != std::string::npos);
@@ -81,8 +81,8 @@ TEST_CASE("match output failure", "[handler_builder]") {
     cib::nexus<test_project> test_nexus{};
     test_nexus.init();
 
-    cib::service<test_service>->handle(
-        test_msg_t{"test_id_field"_field = 0x81});
+    CHECK(not cib::service<test_service>->handle(
+        test_msg_t{"test_id_field"_field = 0x81}));
     CHECK(log_buffer.find(
               "None of the registered callbacks claimed this message") !=
           std::string::npos);
@@ -189,8 +189,8 @@ TEST_CASE("message matching partial index but not callback matcher",
 
     log_buffer.clear();
     callback_success = false;
-    cib::service<partially_indexed_test_service>->handle(test_msg_t{
-        "test_id_field"_field = 0x80, "test_opcode_field"_field = 2});
+    CHECK(not cib::service<partially_indexed_test_service>->handle(test_msg_t{
+        "test_id_field"_field = 0x80, "test_opcode_field"_field = 2}));
     CHECK(not callback_success);
 }
 


### PR DESCRIPTION
An indexed handler may have indexed callbacks to call, but those callbacks may not handle the message, because they have extra matchers that weren't part of the index.