### PR TITLE
:bug: Fix handler short-circuiting

### DIFF
--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -21,8 +21,10 @@ struct handler : handler_interface<BaseMsg, ExtraCallbackArgs...> {
 
     auto handle(BaseMsg const &msg,
                 ExtraCallbackArgs... args) const -> bool final {
-        bool const found_valid_callback = stdx::any_of(
-            [&](auto &callback) { return callback.handle(msg, args...); },
+        auto const found_valid_callback = stdx::apply(
+            [&](auto &...cbs) -> bool {
+                return (0u | ... | cbs.handle(msg, args...));
+            },
             callbacks);
         if (!found_valid_callback) {
             CIB_ERROR("None of the registered callbacks claimed this message:");


### PR DESCRIPTION
The handler should call all the callbacks that match a message, not just the first that matches.

This is consistent with the indexed_handler behaviour.

NOTE: The order of calling the callbacks is not defined.