### PR TITLE
:art: Allow indexed handler to handle messages by value

### DIFF
--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -7,19 +7,19 @@
 
 namespace msg {
 
-template <typename Callbacks, typename BaseMsg, typename... ExtraCallbackArgs>
-struct handler : handler_interface<BaseMsg, ExtraCallbackArgs...> {
+template <typename Callbacks, typename MsgBase, typename... ExtraCallbackArgs>
+struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
     Callbacks callbacks{};
 
     constexpr explicit handler(Callbacks new_callbacks)
         : callbacks{new_callbacks} {}
 
-    auto is_match(BaseMsg const &msg) const -> bool final {
+    auto is_match(MsgBase const &msg) const -> bool final {
         return stdx::any_of(
             [&](auto &callback) { return callback.is_match(msg); }, callbacks);
     }
 
-    auto handle(BaseMsg const &msg,
+    auto handle(MsgBase const &msg,
                 ExtraCallbackArgs... args) const -> bool final {
         auto const found_valid_callback = stdx::apply(
             [&](auto &...cbs) -> bool {

--- a/include/msg/handler_builder.hpp
+++ b/include/msg/handler_builder.hpp
@@ -6,21 +6,20 @@
 #include <stdx/tuple_algorithms.hpp>
 
 namespace msg {
-template <typename CallbacksT, typename BaseMsgT,
-          typename... ExtraCallbackArgsT>
+template <typename Callbacks, typename MsgBase, typename... ExtraCallbackArgs>
 struct handler_builder {
-    CallbacksT callbacks;
+    Callbacks callbacks;
 
     template <typename... Ts> [[nodiscard]] constexpr auto add(Ts... ts) {
         auto new_callbacks =
             stdx::tuple_cat(callbacks, stdx::make_tuple(ts...));
         using new_callbacks_t = decltype(new_callbacks);
-        return handler_builder<new_callbacks_t, BaseMsgT,
-                               ExtraCallbackArgsT...>{new_callbacks};
+        return handler_builder<new_callbacks_t, MsgBase, ExtraCallbackArgs...>{
+            new_callbacks};
     }
 
     template <typename BuilderValue> constexpr static auto build() {
-        return handler<CallbacksT, BaseMsgT, ExtraCallbackArgsT...>{
+        return handler<Callbacks, MsgBase, ExtraCallbackArgs...>{
             BuilderValue::value.callbacks};
     }
 };

--- a/include/msg/handler_interface.hpp
+++ b/include/msg/handler_interface.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 namespace msg {
-template <typename MsgBaseT, typename... ExtraCallbackArgsT>
+template <typename MsgBase, typename... ExtraCallbackArgs>
 struct handler_interface {
-    virtual auto is_match(MsgBaseT const &msg) const -> bool = 0;
+    virtual auto is_match(MsgBase const &msg) const -> bool = 0;
 
-    virtual auto handle(MsgBaseT const &msg,
-                        ExtraCallbackArgsT... extra_args) const -> bool = 0;
+    virtual auto handle(MsgBase const &msg,
+                        ExtraCallbackArgs... extra_args) const -> bool = 0;
 };
 } // namespace msg

--- a/include/msg/indexed_builder.hpp
+++ b/include/msg/indexed_builder.hpp
@@ -17,13 +17,13 @@
 
 namespace msg {
 // TODO: needs index configuration
-template <typename IndexSpec, typename CallbacksT, typename BaseMsgT,
-          typename... ExtraCallbackArgsT>
+template <typename IndexSpec, typename Callbacks, typename MsgBase,
+          typename... ExtraCallbackArgs>
 struct indexed_builder
-    : indexed_builder_base<indexed_builder, IndexSpec, CallbacksT, BaseMsgT,
-                           ExtraCallbackArgsT...> {
-    using base_t = indexed_builder_base<indexed_builder, IndexSpec, CallbacksT,
-                                        BaseMsgT, ExtraCallbackArgsT...>;
+    : indexed_builder_base<indexed_builder, IndexSpec, Callbacks, MsgBase,
+                           ExtraCallbackArgs...> {
+    using base_t = indexed_builder_base<indexed_builder, IndexSpec, Callbacks,
+                                        MsgBase, ExtraCallbackArgs...>;
 
     template <typename I, auto E>
     static CONSTEVAL auto get_entry(auto const &indices) {
@@ -73,14 +73,12 @@ struct indexed_builder
             });
 
         constexpr auto num_callbacks = BuilderValue::value.callbacks.size();
-        constexpr std::array<typename base_t::callback_func_t, num_callbacks>
-            callback_array =
-                base_t::template create_callback_array<BuilderValue>(
-                    std::make_index_sequence<num_callbacks>{});
+        constexpr auto callback_array =
+            base_t::template create_callback_array<BuilderValue>(
+                std::make_index_sequence<num_callbacks>{});
 
-        return indexed_handler{
-            callback_args_t<BaseMsgT, ExtraCallbackArgsT...>{}, baked_indices,
-            callback_array};
+        return make_indexed_handler<MsgBase, ExtraCallbackArgs...>(
+            baked_indices, callback_array);
     }
 };
 

--- a/include/msg/indexed_handler.hpp
+++ b/include/msg/indexed_handler.hpp
@@ -6,12 +6,12 @@
 
 namespace msg {
 
-template <typename... IndicesT> struct indices : IndicesT... {
-    CONSTEVAL explicit indices(IndicesT... index_args)
-        : IndicesT{index_args}... {}
+template <typename... Indices> struct indices : Indices... {
+    CONSTEVAL explicit indices(Indices... index_args)
+        : Indices{index_args}... {}
 
     constexpr auto operator()(auto const &data) const {
-        return (this->IndicesT::operator()(data) & ...);
+        return (this->Indices::operator()(data) & ...);
     }
 };
 

--- a/include/msg/indexed_service.hpp
+++ b/include/msg/indexed_service.hpp
@@ -7,10 +7,10 @@
 #include <stdx/tuple.hpp>
 
 namespace msg {
-template <typename IndexSpec, typename MsgBaseT, typename... ExtraCallbackArgsT>
+template <typename IndexSpec, typename MsgBase, typename... ExtraCallbackArgs>
 struct indexed_service
     : cib::builder_meta<
-          indexed_builder<IndexSpec, stdx::tuple<>, MsgBaseT,
-                          ExtraCallbackArgsT...>,
-          handler_interface<MsgBaseT, ExtraCallbackArgsT...> const *> {};
+          indexed_builder<IndexSpec, stdx::tuple<>, MsgBase,
+                          ExtraCallbackArgs...>,
+          handler_interface<MsgBase, ExtraCallbackArgs...> const *> {};
 } // namespace msg

--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -629,8 +629,8 @@ constexpr auto equivalent(O1 const &lhs, O2 const &rhs) {
 }
 
 template <typename Msg, typename F, typename S, typename... Args>
-constexpr auto call_with_message(F &&f, S &&s,
-                                 Args &&...args) -> decltype(auto) {
+__attribute__((flatten, always_inline)) constexpr auto
+call_with_message(F &&f, S &&s, Args &&...args) -> decltype(auto) {
     if constexpr (requires {
                       std::forward<F>(f)(std::forward<S>(s),
                                          std::forward<Args>(args)...);

--- a/include/msg/service.hpp
+++ b/include/msg/service.hpp
@@ -7,9 +7,9 @@
 #include <stdx/tuple.hpp>
 
 namespace msg {
-template <typename MsgBaseT, typename... ExtraCallbackArgsT>
+template <typename MsgBase, typename... ExtraCallbackArgs>
 struct service
     : cib::builder_meta<
-          handler_builder<stdx::tuple<>, MsgBaseT, ExtraCallbackArgsT...>,
-          handler_interface<MsgBaseT, ExtraCallbackArgsT...> const *> {};
+          handler_builder<stdx::tuple<>, MsgBase, ExtraCallbackArgs...>,
+          handler_interface<MsgBase, ExtraCallbackArgs...> const *> {};
 } // namespace msg


### PR DESCRIPTION
- remove the `T` suffix from several template arguments
- rename `BaseMsg` to `MsgBase` where appropriate: there was a mix of uses, and it isn't necessarily a message at all, but the raw storage underlying. So it's not a base message, but it is a message base.
- handle by-value callbacks in the indexed builder/handler.