### PR TITLE
:bug: Fix usage test to Ubuntu 22.04

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   usage_test:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 


### PR DESCRIPTION
Problem:
- `ubuntu-latest` will be `ubuntu-24.04` imminently, and that version doesn't handle pip in the same way.

Solution:
- Pin usage test to `ubuntu-22.04`.

Note:
- When we update to `ubuntu-24.04` for real, we'll probably want to use pipx. We may also need to separate unit test workflows to support older compilers.