### PR TITLE
:art: Improve span for flow construction

### DIFF
--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -9,6 +9,7 @@
 #include <stdx/cx_multimap.hpp>
 #include <stdx/cx_set.hpp>
 #include <stdx/cx_vector.hpp>
+#include <stdx/span.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
@@ -20,7 +21,6 @@
 #include <cstddef>
 #include <iterator>
 #include <optional>
-#include <span>
 #include <utility>
 
 namespace flow {
@@ -186,9 +186,9 @@ struct graph_builder {
         if (not g.empty()) {
             return {};
         }
-        return std::optional<Output>{
-            std::in_place,
-            std::span{std::cbegin(ordered_list), std::size(ordered_list)}};
+        using span_t =
+            stdx::span<typename Graph::key_type const, Graph::capacity()>;
+        return std::optional<Output>{std::in_place, span_t{ordered_list}};
     }
 
     constexpr static void check_for_missing_nodes(auto nodes,

--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -5,11 +5,11 @@
 #include <log/log.hpp>
 
 #include <stdx/cx_vector.hpp>
+#include <stdx/span.hpp>
 
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
-#include <span>
 #include <type_traits>
 
 namespace flow {
@@ -60,8 +60,8 @@ template <stdx::ct_string Name, std::size_t NumSteps> class impl {
      *
      * @see flow::builder
      */
-    constexpr explicit(true) impl(std::span<node_t const> newMilestones) {
-        CIB_ASSERT(NumSteps >= std::size(newMilestones));
+    constexpr explicit(true)
+        impl(stdx::span<node_t const, NumSteps> newMilestones) {
         if constexpr (loggingEnabled) {
             for (auto const &milestone : newMilestones) {
                 functionPtrs.push_back(milestone.log_name);

--- a/include/seq/impl.hpp
+++ b/include/seq/impl.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <log/log.hpp>
 #include <seq/step.hpp>
 
 #include <stdx/ct_string.hpp>
 #include <stdx/cx_vector.hpp>
+#include <stdx/span.hpp>
 
 #include <array>
 #include <cstddef>
 #include <iterator>
-#include <span>
 
 namespace seq {
 enum struct direction { FORWARD = 0, BACKWARD = 1 };
@@ -24,8 +23,7 @@ template <stdx::ct_string, std::size_t NumSteps> struct impl {
 
     using node_t = rt_step;
 
-    constexpr explicit(true) impl(std::span<node_t const> steps) {
-        CIB_ASSERT(NumSteps >= std::size(steps));
+    constexpr explicit(true) impl(stdx::span<node_t const, NumSteps> steps) {
         for (auto const &step : steps) {
             _forward_steps.push_back(step.forward_ptr);
             _backward_steps.push_back(step.backward_ptr);


### PR DESCRIPTION
Problem:
- The span constructor used for constructing a flow impl triggers the warning `-Wunsafe-buffer-usage-in-container`.

Solution:
- We know the exact size, so the span's extent can be typed. This also means that a runtime check is unnecessary.