### PR TITLE
:art: Improve flow error messages with `STATIC_ASSERT`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#5530b5d")
+add_versioned_package("gh:intel/cpp-std-extensions#73569fe")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 add_library(cib INTERFACE)

--- a/test/flow/fail/CMakeLists.txt
+++ b/test/flow/fail/CMakeLists.txt
@@ -1,5 +1,16 @@
-add_compile_fail_test(cyclic_flow.cpp LIBRARIES warnings cib)
-add_compile_fail_test(only_reference_added.cpp LIBRARIES warnings cib)
-add_compile_fail_test(mismatched_flow_runtime_conditional.cpp LIBRARIES
-                      warnings cib)
-add_compile_fail_test(node_explicitly_added_twice.cpp LIBRARIES warnings cib)
+add_compile_fail_test(cyclic_flow.cpp LIBRARIES cib)
+
+function(add_formatted_errors_tests)
+    add_compile_fail_test(only_reference_added.cpp LIBRARIES cib)
+    add_compile_fail_test(mismatched_flow_runtime_conditional.cpp LIBRARIES cib)
+    add_compile_fail_test(node_explicitly_added_twice.cpp LIBRARIES cib)
+endfunction()
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                 VERSION_GREATER_EQUAL 15)
+    add_formatted_errors_tests()
+endif()
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                               VERSION_GREATER_EQUAL 13.2)
+    add_formatted_errors_tests()
+endif()

--- a/test/flow/fail/mismatched_flow_runtime_conditional.cpp
+++ b/test/flow/fail/mismatched_flow_runtime_conditional.cpp
@@ -1,7 +1,7 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
 
-// EXPECT: The conditions on this sequence
+// EXPECT: The conditions on the sequence
 
 namespace {
 using namespace flow::literals;

--- a/test/flow/fail/node_explicitly_added_twice.cpp
+++ b/test/flow/fail/node_explicitly_added_twice.cpp
@@ -1,14 +1,14 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
 
-// EXPECT: One or more steps are explicitly added more than once
+// EXPECT: are explicitly added more than once
 
 namespace {
 using namespace flow::literals;
 
 constexpr auto a = flow::milestone<"a">();
 
-struct TestFlowAlpha : public flow::service<> {};
+struct TestFlowAlpha : public flow::service<"alpha"> {};
 
 struct FlowConfig {
     constexpr static auto config = cib::config(

--- a/test/flow/fail/only_reference_added.cpp
+++ b/test/flow/fail/only_reference_added.cpp
@@ -1,14 +1,14 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
 
-// EXPECT: One or more steps are referenced in the flow but not explicitly
+// EXPECT: One or more steps are referenced in the flow
 
 namespace {
 using namespace flow::literals;
 
 constexpr auto a = flow::milestone<"a">();
 
-struct TestFlowAlpha : public flow::service<> {};
+struct TestFlowAlpha : public flow::service<"alpha"> {};
 
 struct FlowConfig {
     constexpr static auto config =


### PR DESCRIPTION
Problem:
- Flow errors use a hacky technique to output useful information.

Solution:
- Use `STATIC_ASSERT`.