### PR TITLE
fix: base_extent calculation in bits_locator_t::template extent_in()

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -215,7 +215,7 @@ struct bits_locator_t {
     template <typename T> constexpr static auto extent_in() -> std::size_t {
         constexpr auto msb = Lsb + BitSize - 1;
         constexpr auto msb_extent = (msb + CHAR_BIT - 1) / CHAR_BIT;
-        constexpr auto base_extent = Index * sizeof(std::uint32_t);
+        constexpr auto base_extent = Index * sizeof(T);
         constexpr auto extent = base_extent + msb_extent;
         return (extent + sizeof(T) - 1) / sizeof(T);
     }


### PR DESCRIPTION
The `base_extent` variable in the `extent_in()` method of the `bits_locator_t` struct now uses the size of its template parameter T instead of `std::uint32_t` for calculating the base extent .