### PR TITLE
:bug: Add missing include to `flow/impl.hpp`

### DIFF
--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <flow/common.hpp>
+#include <flow/log.hpp>
 #include <flow/step.hpp>
 #include <log/log.hpp>
 


### PR DESCRIPTION
Problem:
- `flow/impl.hpp` references `flow::get_log_spec` but does not include `flow/log.hpp`.

Solution:
- Add the include.