### PR TITLE
:art: :boom: Apply consistent naming between callback and flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ a simple example takes a few more lines than a typical "Hello, world!"
 #include <cib/cib.hpp>
 #include <iostream>
 
-struct say_message : public cib::callback_meta<>{};
+struct say_message : public callback::service<>{};
 
 // the 'core' component exposes the 'say_message' service for others to extend
 struct core {

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -33,7 +33,7 @@ functionality.
 
 ```c++
 /// Invoked for each byte of data received on the serial port
-struct serial_port_rx : public cib::callback_meta<0, std::uint8_t>{};
+struct serial_port_rx : public callback::service<0, std::uint8_t>{};
 ```
 
 In *cib*, *features* have source-code dependencies on *services*. This follows
@@ -57,13 +57,13 @@ initialized before they can be used. The `runtime_init` and `main_loop`
 
 ```c++
 /// Invoked once on startup before interrupts are enabled
-struct runtime_init : public cib::callback_meta<>{};
+struct runtime_init : public callback::service<>{};
 
 /// Invoked each iteration through the main loop
-struct main_loop : public cib::callback_meta<>{};
+struct main_loop : public callback::service<>{};
 
 /// Invoked each time the serial port interrupt is triggered
-struct serial_port_interrupt : public cib::callback_meta<>{};
+struct serial_port_interrupt : public callback::service<>{};
 ```
 
 *Components* use `cib::exports` in their configuration to *export* services to 
@@ -157,7 +157,7 @@ INTERRUPT void serial_port_isr() {
 
 Services can be accessed with the `service<...>` template variable on a 
 `cib::nexus` instance. Because the `runtime_init` and `main_loop` services
-extend `cib::callback_meta`, their *service implementation* is a simple 
+extend `callback::service`, their *service implementation* is a simple 
 function pointer.
 
 ### `cib::service`
@@ -170,7 +170,7 @@ instance is not available. For example, when registering interrupts with
 an interrupt service. 
 
 ```c++
-struct serial_port_rx : public cib::callback_meta<0, char>{};
+struct serial_port_rx : public callback::service<0, char>{};
 
 struct serial_component {
     constexpr static auto config =
@@ -193,12 +193,12 @@ struct serial_component {
 ### `cib::service_meta`
 
 The *service metadata* describes to *cib* how a *service* is built and its 
-type-erased implementation interface. (`cib::callback_meta`)[include/cib/callback.hpp]
+type-erased implementation interface. (`callback::service`)[include/cib/callback.hpp]
 is an example of *service metadata*. Services that use the callback *service*
-type extend `cib::callback_meta`.
+type extend `callback::service`.
 
 ```c++
-struct main_loop : public cib::callback_meta<> {};
+struct main_loop : public callback::service<> {};
 ```
 
 ### Service Builder

--- a/benchmark/big_nexus.cpp
+++ b/benchmark/big_nexus.cpp
@@ -3,7 +3,7 @@
 template <int Id> [[maybe_unused]] static bool is_callback_invoked = false;
 
 template <int Id, typename... Args>
-struct TestCallback : public cib::callback_meta<Args...> {};
+struct TestCallback : public callback::service<Args...> {};
 
 template <int Id> struct TestComponent {
     constexpr static auto offset = Id * 100;

--- a/examples/cib_serial_port/main.cpp
+++ b/examples/cib_serial_port/main.cpp
@@ -4,13 +4,13 @@
 
 // Services - basically like a function prototypes.
 //          - callback function declaration.
-struct send_byte_t : public cib::callback_meta<uint8_t> {};
+struct send_byte_t : public callback::service<uint8_t> {};
 
-struct get_byte_t : public cib::callback_meta<> {};
+struct get_byte_t : public callback::service<> {};
 
-struct serial_port_init_t : public cib::callback_meta<> {};
+struct serial_port_init_t : public callback::service<> {};
 
-struct run_t : public cib::callback_meta<> {};
+struct run_t : public callback::service<> {};
 
 // components defintion
 struct core_component_t {

--- a/examples/flow_daily_routine/main.cpp
+++ b/examples/flow_daily_routine/main.cpp
@@ -42,7 +42,7 @@
 
   Note::
     services can be defined using
-      + cib::callback_meta<>  - can have only one function pointer assigned to
+      + callback::service<>  - can have only one function pointer assigned to
   execute.
       + flow::service<>       - set of actions/milestones which are to be
   executed in specific order. So basically sequential execution of multiple

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -12,7 +12,7 @@ attention to the `#include` directives in each file.
 ```c++
 #include <cib/cib.hpp>
 
-struct say_message : public cib::callback_meta<>{};
+struct say_message : public callback::service<>{};
 
 struct core {
     constexpr static auto config =

--- a/examples/hello_world/core.hpp
+++ b/examples/hello_world/core.hpp
@@ -2,7 +2,7 @@
 
 #include <cib/cib.hpp>
 
-struct say_message : public cib::callback_meta<> {};
+struct say_message : public callback::service<> {};
 
 struct core {
     constexpr static auto config = cib::config(cib::exports<say_message>);

--- a/include/cib/builder_meta.hpp
+++ b/include/cib/builder_meta.hpp
@@ -17,7 +17,7 @@ namespace cib {
  *
  * @see cib::built
  *
- * @example cib::callback_meta
+ * @example callback::service
  */
 template <typename Builder, typename Interface> struct builder_meta {
     using builder_t = Builder;

--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace cib {
+namespace callback {
 /**
  * Builder for simple callbacks.
  *
@@ -23,9 +23,9 @@ namespace cib {
  *      List of argument types that must be passed into the callback when it is
  * invoked.
  *
- * @see cib::callback_meta
+ * @see callback::service
  */
-template <int NumFuncs = 0, typename... ArgTypes> struct callback {
+template <int NumFuncs = 0, typename... ArgTypes> struct builder {
     using func_ptr_t = void (*)(ArgTypes...);
     std::array<func_ptr_t, NumFuncs> funcs{};
 
@@ -44,7 +44,7 @@ template <int NumFuncs = 0, typename... ArgTypes> struct callback {
      */
     template <std::convertible_to<func_ptr_t>... Fs>
     [[nodiscard]] constexpr auto add(Fs &&...fs) const {
-        callback<NumFuncs + sizeof...(Fs), ArgTypes...> cb;
+        builder<NumFuncs + sizeof...(Fs), ArgTypes...> cb;
         auto i = std::size_t{};
         while (i < NumFuncs) {
             cb.funcs[i] = funcs[i];
@@ -117,6 +117,7 @@ template <int NumFuncs = 0, typename... ArgTypes> struct callback {
  * @see cib::extend
  */
 template <typename... ArgTypes>
-struct callback_meta : public cib::builder_meta<callback<0, ArgTypes...>,
-                                                void (*)(ArgTypes...)> {};
-} // namespace cib
+struct service
+    : public cib::builder_meta<builder<0, ArgTypes...>, void (*)(ArgTypes...)> {
+};
+} // namespace callback

--- a/test/cib/callback.cpp
+++ b/test/cib/callback.cpp
@@ -1,4 +1,6 @@
-#include <cib/cib.hpp>
+#include <cib/callback.hpp>
+
+#include <stdx/tuple.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -9,14 +11,14 @@ template <typename BuilderValue> constexpr static auto build() {
 }
 
 template <typename BuilderMeta, typename BuiltCallback>
-constexpr static bool built_is_convertable_to_interface(BuiltCallback) {
+constexpr static bool built_is_convertible_to_interface(BuiltCallback) {
     using interface_type = cib::interface_t<BuilderMeta>;
     return std::is_convertible_v<BuiltCallback, interface_type>;
 }
 
 struct EmptyCallbackNoArgs {
-    using meta = cib::callback_meta<>;
-    constexpr static auto value = cib::builder_t<meta>{};
+    using service = callback::service<>;
+    constexpr static auto value = cib::builder_t<service>{};
 };
 
 TEST_CASE("empty callback with no args", "[callback]") {
@@ -24,8 +26,8 @@ TEST_CASE("empty callback with no args", "[callback]") {
 
     SECTION("can be called without issue") { built_callback(); }
 
-    SECTION("built type is convertable to the interface type") {
-        REQUIRE(built_is_convertable_to_interface<EmptyCallbackNoArgs::meta>(
+    SECTION("built type is convertible to the interface type") {
+        REQUIRE(built_is_convertible_to_interface<EmptyCallbackNoArgs::service>(
             built_callback));
     }
 }
@@ -33,9 +35,9 @@ TEST_CASE("empty callback with no args", "[callback]") {
 template <int Id> static bool is_callback_invoked = false;
 
 struct CallbackNoArgsWithSingleExtension {
-    using meta = cib::callback_meta<>;
+    using service = callback::service<>;
     constexpr static auto value = []() {
-        auto const builder = cib::builder_t<meta>{};
+        auto const builder = cib::builder_t<service>{};
         return builder.add([]() { is_callback_invoked<0> = true; });
     }();
 };
@@ -50,14 +52,14 @@ TEST_CASE("callback with no args with single extension", "[callback]") {
         REQUIRE(is_callback_invoked<0>);
     }
 
-    SECTION("built type is convertable to the interface type") {
-        REQUIRE(built_is_convertable_to_interface<
-                CallbackNoArgsWithSingleExtension::meta>(built_callback));
+    SECTION("built type is convertible to the interface type") {
+        REQUIRE(built_is_convertible_to_interface<
+                CallbackNoArgsWithSingleExtension::service>(built_callback));
     }
 }
 
 struct CallbackNoArgsWithMultipleExtensions {
-    using meta = cib::callback_meta<>;
+    using service = callback::service<>;
 
     static void extension_one() { is_callback_invoked<1> = true; }
 
@@ -66,7 +68,7 @@ struct CallbackNoArgsWithMultipleExtensions {
     };
 
     constexpr static auto value = []() {
-        auto const builder = cib::builder_t<meta>{};
+        auto const builder = cib::builder_t<service>{};
 
         return builder.add([]() { is_callback_invoked<0> = true; })
             .add(extension_one)
@@ -89,15 +91,15 @@ TEST_CASE("callback with no args with multiple extensions", "[callback]") {
         REQUIRE(is_callback_invoked<2>);
     }
 
-    SECTION("built type is convertable to the interface type") {
-        REQUIRE(built_is_convertable_to_interface<
-                CallbackNoArgsWithMultipleExtensions::meta>(built_callback));
+    SECTION("built type is convertible to the interface type") {
+        REQUIRE(built_is_convertible_to_interface<
+                CallbackNoArgsWithMultipleExtensions::service>(built_callback));
     }
 }
 
 struct CallbackWithArgsWithNoExtensions {
-    using meta = cib::callback_meta<int, bool>;
-    constexpr static auto value = cib::builder_t<meta>{};
+    using service = callback::service<int, bool>;
+    constexpr static auto value = cib::builder_t<service>{};
 };
 
 TEST_CASE("callback with args with no extensions", "[callback]") {
@@ -105,9 +107,9 @@ TEST_CASE("callback with args with no extensions", "[callback]") {
 
     SECTION("can be called") { built_callback(42, true); }
 
-    SECTION("built type is convertable to the interface type") {
-        REQUIRE(built_is_convertable_to_interface<
-                CallbackWithArgsWithNoExtensions::meta>(built_callback));
+    SECTION("built type is convertible to the interface type") {
+        REQUIRE(built_is_convertible_to_interface<
+                CallbackWithArgsWithNoExtensions::service>(built_callback));
     }
 }
 
@@ -115,7 +117,7 @@ template <int Id, typename... ArgTypes>
 static stdx::tuple<ArgTypes...> callback_args{};
 
 struct CallbackWithArgsWithMultipleExtensions {
-    using meta = cib::callback_meta<int, bool>;
+    using service = callback::service<int, bool>;
 
     static void extension_one(int a, bool b) {
         is_callback_invoked<1> = true;
@@ -128,7 +130,7 @@ struct CallbackWithArgsWithMultipleExtensions {
     };
 
     constexpr static auto value = []() {
-        auto const builder = cib::builder_t<meta>{};
+        auto const builder = cib::builder_t<service>{};
 
         return builder
             .add([](int a, bool b) {
@@ -168,8 +170,9 @@ TEST_CASE("callback with args with multiple extensions", "[callback]") {
         REQUIRE(get<1>(callback_args<2, int, bool>) == false);
     }
 
-    SECTION("built type is convertable to the interface type") {
-        REQUIRE(built_is_convertable_to_interface<
-                CallbackWithArgsWithMultipleExtensions::meta>(built_callback));
+    SECTION("built type is convertible to the interface type") {
+        REQUIRE(built_is_convertible_to_interface<
+                CallbackWithArgsWithMultipleExtensions::service>(
+            built_callback));
     }
 }

--- a/test/cib/nexus.cpp
+++ b/test/cib/nexus.cpp
@@ -14,7 +14,7 @@ TEST_CASE("an empty configuration should compile and initialize") {
 template <int Id> static bool is_callback_invoked = false;
 
 template <int Id, typename... Args>
-struct TestCallback : public cib::callback_meta<Args...> {};
+struct TestCallback : public callback::service<Args...> {};
 
 struct SimpleConfig {
     constexpr static auto config = cib::config(

--- a/test/cib/readme_hello_world.cpp
+++ b/test/cib/readme_hello_world.cpp
@@ -4,7 +4,7 @@
 
 #include <cstdio>
 
-struct say_message : public cib::callback_meta<> {};
+struct say_message : public callback::service<> {};
 
 // the 'core' component exposes the 'say_message' service for others to extend
 struct core {

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -33,7 +33,7 @@ struct test_service : indexed_service<index_spec, test_msg_t> {};
 
 bool callback_success;
 
-constexpr auto test_callback = callback<"TestCallback", msg_defn>(
+constexpr auto test_callback = msg::callback<"TestCallback", msg_defn>(
     msg::in<test_id_field, 0x80>, [](auto) { callback_success = true; });
 
 struct test_project {
@@ -430,7 +430,7 @@ struct raw_service : indexed_service<index_spec, base_storage_t> {};
 
 int callback_count{};
 
-constexpr auto raw_view_callback = callback<"raw view", msg_defn>(
+constexpr auto raw_view_callback = msg::callback<"raw view", msg_defn>(
     msg::in<test_id_field, 0x80>,
     [](msg::const_view<msg_defn>) { ++callback_count; });
 
@@ -451,7 +451,7 @@ TEST_CASE("handle raw message by view", "[indexed_builder]") {
 }
 
 namespace {
-constexpr auto raw_owning_callback = callback<"raw owning", msg_defn>(
+constexpr auto raw_owning_callback = msg::callback<"raw owning", msg_defn>(
     msg::in<test_id_field, 0x80>,
     [](msg::owning<msg_defn>) { ++callback_count; });
 


### PR DESCRIPTION
Problem:
- `flow` constructs are called `flow::builder` and `flow::service`.
- `callback` constructs are called `cib::callback` and `cib::callback_meta`, which is confusing.

Solution:
- Rename the `callback` constructs to `callback::builder` and `callback::service` to match the `flow` pattern.