### PR TITLE
:art: Collapse flow step run/log functions

### DIFF
--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -241,7 +241,7 @@ struct graph_builder {
                           "Topological sort failed: cycle in flow");
 
             constexpr auto functionPtrs = built->functionPtrs;
-            constexpr auto size = functionPtrs.size();
+            constexpr auto size = std::size(functionPtrs);
             constexpr auto name = built->name;
 
             return [&]<std::size_t... Is>(std::index_sequence<Is...>) {

--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -2,109 +2,48 @@
 
 #include <flow/common.hpp>
 #include <flow/log.hpp>
-#include <flow/step.hpp>
 #include <log/log.hpp>
 
 #include <stdx/ct_string.hpp>
-#include <stdx/cx_vector.hpp>
 #include <stdx/span.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <iterator>
-#include <type_traits>
 
 namespace flow {
 namespace detail {
-template <typename CTNode> constexpr auto run_func() -> void {
+template <stdx::ct_string FlowName, typename CTNode>
+constexpr auto run_func() -> void {
     if (CTNode::condition) {
+        if constexpr (not FlowName.empty()) {
+            using log_spec_t =
+                decltype(get_log_spec<CTNode, log_spec_id_t<FlowName>>());
+            CIB_LOG(typename log_spec_t::flavor, log_spec_t::level,
+                    "flow.{}({})", typename CTNode::type_t{},
+                    typename CTNode::name_t{});
+        }
         typename CTNode::func_t{}();
-    }
-}
-
-template <typename Flow, typename CTNode> constexpr auto log_func() -> void {
-    if (CTNode::condition) {
-        using log_spec_t = decltype(get_log_spec<CTNode, Flow>());
-        CIB_LOG(typename log_spec_t::flavor, log_spec_t::level, "flow.{}({})",
-                typename CTNode::type_t{}, typename CTNode::name_t{});
     }
 }
 } // namespace detail
 
-struct rt_node {
-    FunctionPtr run{};
-    FunctionPtr log_name{};
+template <stdx::ct_string Name, std::size_t NumSteps> struct impl {
+    using node_t = FunctionPtr;
+    std::array<FunctionPtr, NumSteps> functionPtrs{};
 
-  private:
-    friend constexpr auto operator==(rt_node const &,
-                                     rt_node const &) -> bool = default;
-};
-
-/**
- * flow::impl is a constant representation of a series of Milestones and actions
- * to be executed in a specific order.
- *
- * flow::builder allows multiple independent components to collaboratively
- * specify a flow::impl. Use flow::builder to create Flows. Independent
- * components can then add their own actions and milestones to a flow::impl
- * relative to other actions and milestones.
- *
- * @tparam Name
- *      Name of flow as a compile-time string.
- *
- * @tparam NumSteps
- *      The number of Milestones this flow::impl represents.
- *
- * @see flow::builder
- */
-template <stdx::ct_string Name, std::size_t NumSteps> class impl {
-  private:
-    constexpr static bool loggingEnabled = not Name.empty();
-
-    constexpr static auto capacity = [] {
-        if constexpr (loggingEnabled) {
-            return NumSteps * 2;
-        } else {
-            return NumSteps;
-        }
-    }();
-
-  public:
-    stdx::cx_vector<FunctionPtr, capacity> functionPtrs{};
-
-    constexpr static bool active = capacity > 0;
     constexpr static auto name = Name;
-
-    using node_t = rt_node;
 
     template <typename CTNode>
     constexpr static auto create_node(CTNode) -> node_t {
-        constexpr auto rf = detail::run_func<CTNode>;
-        constexpr auto lf = detail::log_func<log_spec_id_t<Name>, CTNode>;
-        return node_t{rf, lf};
+        constexpr auto fp = detail::run_func<Name, CTNode>;
+        return fp;
     }
 
-    /**
-     * Create a new flow::impl of Milestones.
-     *
-     * Do not call this constructor directly, use flow::builder instead.
-     *
-     * @param newMilestones
-     *      Array of Milestones to execute in the flow.
-     *
-     * @see flow::builder
-     */
     constexpr explicit(true) impl(stdx::span<node_t const, NumSteps> steps) {
-        if constexpr (loggingEnabled) {
-            for (auto const &step : steps) {
-                functionPtrs.push_back(step.log_name);
-                functionPtrs.push_back(step.run);
-            }
-        } else {
-            std::transform(std::cbegin(steps), std::cend(steps),
-                           std::back_inserter(functionPtrs),
-                           [](auto const &step) { return step.run; });
-        }
+        std::copy(std::cbegin(steps), std::cend(steps),
+                  std::begin(functionPtrs));
     }
 };
 
@@ -135,5 +74,4 @@ template <stdx::ct_string Name, auto... FuncPtrs> struct inlined_func_list {
     }
 };
 } // namespace detail
-
 } // namespace flow


### PR DESCRIPTION
Problem:
- Now that built flow steps have been refactored to have access to the right compile-time information, there's no need to have separate `run` and `log` functions.

Solution:
- Collapse built flow steps so that one function logs the step and runs it.