### PR TITLE
:bug: Fix `size_t` handling in `lookup::input`

### DIFF
--- a/include/lookup/input.hpp
+++ b/include/lookup/input.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>
 
 namespace lookup {
-template <typename K, typename V = K, auto N = 0ul> struct input {
+template <typename K, typename V = K, std::size_t N = 0> struct input {
     using key_type = K;
     using value_type = V;
 

--- a/test/lookup/input.cpp
+++ b/test/lookup/input.cpp
@@ -9,22 +9,22 @@ TEST_CASE("an input with no entries (type deduced)", "[input]") {
     constexpr auto input = lookup::input{1};
     CHECK(input.default_value == 1);
     static_assert(
-        std::is_same_v<decltype(input), lookup::input<int, int, 0ul> const>);
-    CHECK(std::size(input) == 0ul);
+        std::is_same_v<decltype(input), lookup::input<int, int, 0> const>);
+    CHECK(std::size(input) == 0);
 }
 
 TEST_CASE("an input with no entries (explicit types)", "[input]") {
     constexpr auto input = lookup::input<float, int>{1};
     CHECK(input.default_value == 1);
     static_assert(
-        std::is_same_v<decltype(input), lookup::input<float, int, 0ul> const>);
-    CHECK(std::size(input) == 0ul);
+        std::is_same_v<decltype(input), lookup::input<float, int, 0> const>);
+    CHECK(std::size(input) == 0);
 }
 
 TEST_CASE("an input with some entries (type deduced)", "[input]") {
     constexpr auto input = lookup::input(1, std::array{lookup::entry{1.0f, 2}});
     CHECK(input.default_value == 1);
     static_assert(
-        std::is_same_v<decltype(input), lookup::input<float, int, 1ul> const>);
-    CHECK(std::size(input) == 1ul);
+        std::is_same_v<decltype(input), lookup::input<float, int, 1> const>);
+    CHECK(std::size(input) == 1);
 }


### PR DESCRIPTION
Problem:
- `lookup::input` takes an `auto` template parameter.
- Platform-specific definitions of `std::size_t` make it awkward to ensure instantiations of `lookup::input` with the same size are in fact the same type.

Solution:
- fix the type of the `lookup::input` template parameter to `std::size_t`