### PR TITLE
⬆️ Bump cpp-std-extensions to 2512bcf git sha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#7cdfadd")
+add_versioned_package("gh:intel/cpp-std-extensions#2512bcf")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 add_library(cib INTERFACE)


### PR DESCRIPTION
Integrate recent commits from https://github.com/intel/cpp-std-extensions
```
2435169 | * :fire: Remove AppleClang missing braces warning
32c9bce | * :arrow_up: Update CPM to v0.40.2
363928c | * :sparkles: Allow `bitset` construction with enums for place_bits
ec147d5 | * :sparkles: Add `is_scoped_enum`
```