### PR TITLE
Split off a few libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,34 @@ add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
 add_versioned_package("gh:intel/cpp-std-extensions#2512bcf")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
+add_library(cib_sc INTERFACE)
+target_compile_features(cib_sc INTERFACE cxx_std_20)
+target_link_libraries_system(cib_sc INTERFACE fmt::fmt-header-only stdx)
+
+target_sources(
+    cib_sc
+    INTERFACE FILE_SET
+              sc
+              TYPE
+              HEADERS
+              BASE_DIRS
+              include
+              FILES
+              include/sc/format.hpp
+              include/sc/fwd.hpp
+              include/sc/lazy_string_format.hpp
+              include/sc/string_constant.hpp)
+
 add_library(cib INTERFACE)
 target_compile_features(cib INTERFACE cxx_std_20)
-target_link_libraries_system(cib INTERFACE async concurrency
-                             fmt::fmt-header-only stdx)
+target_link_libraries_system(
+    cib
+    INTERFACE
+    async
+    cib_sc
+    concurrency
+    fmt::fmt-header-only
+    stdx)
 
 target_sources(
     cib
@@ -178,20 +202,6 @@ target_sources(
               include/msg/message.hpp
               include/msg/send.hpp
               include/msg/service.hpp)
-
-target_sources(
-    cib
-    INTERFACE FILE_SET
-              sc
-              TYPE
-              HEADERS
-              BASE_DIRS
-              include
-              FILES
-              include/sc/format.hpp
-              include/sc/fwd.hpp
-              include/sc/lazy_string_format.hpp
-              include/sc/string_constant.hpp)
 
 target_sources(
     cib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,35 @@ target_sources(
               include/match/simplify.hpp
               include/match/sum_of_products.hpp)
 
+add_library(cib_interrupt INTERFACE)
+target_compile_features(cib_interrupt INTERFACE cxx_std_20)
+target_link_libraries_system(cib_interrupt INTERFACE cib_sc concurrency stdx)
+
+target_sources(
+    cib_interrupt
+    INTERFACE FILE_SET
+              interrupt
+              TYPE
+              HEADERS
+              BASE_DIRS
+              include
+              FILES
+              include/interrupt/concepts.hpp
+              include/interrupt/config.hpp
+              include/interrupt/dynamic_controller.hpp
+              include/interrupt/fwd.hpp
+              include/interrupt/hal.hpp
+              include/interrupt/impl.hpp
+              include/interrupt/manager.hpp
+              include/interrupt/policies.hpp)
+
 add_library(cib INTERFACE)
 target_compile_features(cib INTERFACE cxx_std_20)
 target_link_libraries_system(
     cib
     INTERFACE
     async
+    cib_interrupt
     cib_match
     cib_sc
     concurrency
@@ -131,24 +154,6 @@ target_sources(
               include/flow/impl.hpp
               include/flow/run.hpp
               include/flow/step.hpp)
-
-target_sources(
-    cib
-    INTERFACE FILE_SET
-              interrupt
-              TYPE
-              HEADERS
-              BASE_DIRS
-              include
-              FILES
-              include/interrupt/concepts.hpp
-              include/interrupt/config.hpp
-              include/interrupt/dynamic_controller.hpp
-              include/interrupt/fwd.hpp
-              include/interrupt/hal.hpp
-              include/interrupt/impl.hpp
-              include/interrupt/manager.hpp
-              include/interrupt/policies.hpp)
 
 target_sources(
     cib
@@ -224,6 +229,9 @@ target_sources(
 if(PROJECT_IS_TOP_LEVEL)
     add_docs(docs)
     clang_tidy_interface(cib)
+    clang_tidy_interface(cib_interrupt)
+    clang_tidy_interface(cib_match)
+    clang_tidy_interface(cib_sc)
 
     # Enable functional and performance test suites.
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,40 @@ target_sources(
               include/sc/lazy_string_format.hpp
               include/sc/string_constant.hpp)
 
+add_library(cib_match INTERFACE)
+target_compile_features(cib_match INTERFACE cxx_std_20)
+target_link_libraries_system(cib_match INTERFACE cib_sc stdx)
+
+target_sources(
+    cib_match
+    INTERFACE FILE_SET
+              match
+              TYPE
+              HEADERS
+              BASE_DIRS
+              include
+              FILES
+              include/match/and.hpp
+              include/match/bin_op.hpp
+              include/match/concepts.hpp
+              include/match/constant.hpp
+              include/match/cost.hpp
+              include/match/implies.hpp
+              include/match/negate.hpp
+              include/match/not.hpp
+              include/match/ops.hpp
+              include/match/or.hpp
+              include/match/predicate.hpp
+              include/match/simplify.hpp
+              include/match/sum_of_products.hpp)
+
 add_library(cib INTERFACE)
 target_compile_features(cib INTERFACE cxx_std_20)
 target_link_libraries_system(
     cib
     INTERFACE
     async
+    cib_match
     cib_sc
     concurrency
     fmt::fmt-header-only
@@ -154,29 +182,6 @@ target_sources(
               include/lookup/pseudo_pext_lookup.hpp
               include/lookup/strategies.hpp
               include/lookup/strategy_failed.hpp)
-
-target_sources(
-    cib
-    INTERFACE FILE_SET
-              match
-              TYPE
-              HEADERS
-              BASE_DIRS
-              include
-              FILES
-              include/match/and.hpp
-              include/match/bin_op.hpp
-              include/match/concepts.hpp
-              include/match/constant.hpp
-              include/match/cost.hpp
-              include/match/implies.hpp
-              include/match/negate.hpp
-              include/match/not.hpp
-              include/match/ops.hpp
-              include/match/or.hpp
-              include/match/predicate.hpp
-              include/match/simplify.hpp
-              include/match/sum_of_products.hpp)
 
 target_sources(
     cib

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -32,11 +32,6 @@ struct config {
 
 template <typename...> inline auto config = null::config{};
 
-template <typename T>
-concept loggable = requires(T const &t) {
-    t.apply([]<typename StringType>(StringType, auto const &...) {});
-};
-
 struct default_flavor_t;
 
 template <typename Flavor, typename... Ts>

--- a/include/match/concepts.hpp
+++ b/include/match/concepts.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <log/log.hpp>
+#include <sc/fwd.hpp>
 
 #include <concepts>
 #include <type_traits>
@@ -12,7 +12,7 @@ concept matcher = requires { typename std::remove_cvref_t<T>::is_matcher; };
 template <typename T, typename Event>
 concept matcher_for = matcher<T> and requires(T const &t, Event const &e) {
     { t(e) } -> std::convertible_to<bool>;
-    { t.describe() } -> logging::loggable;
-    { t.describe_match(e) } -> logging::loggable;
+    { t.describe() } -> sc::sc_like;
+    { t.describe_match(e) } -> sc::sc_like;
 };
 } // namespace match

--- a/include/msg/detail/separate_sum_terms.hpp
+++ b/include/msg/detail/separate_sum_terms.hpp
@@ -7,6 +7,7 @@
 
 #include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <type_traits>

--- a/include/sc/fwd.hpp
+++ b/include/sc/fwd.hpp
@@ -37,5 +37,10 @@ template <stdx::ct_string S> CONSTEVAL auto operator""_sc() {
     return stdx::ct_string_to_type<S, string_constant>();
 }
 } // namespace literals
+
+template <typename T>
+concept sc_like = requires(T const &t) {
+    t.apply([]<typename StringType>(StringType, auto const &...) {});
+};
 } // namespace sc
 using sc::literals::operator""_sc;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,9 @@
 function(add_tests)
+    set(multiValueArgs FILES LIBRARIES)
+    cmake_parse_arguments(AT "" "" "${multiValueArgs}" ${ARGN})
+
     get_filename_component(prefix ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-    foreach(name ${ARGN})
+    foreach(name ${AT_FILES})
         string(REPLACE "/" "_" test ${name})
         add_unit_test(
             "${prefix}_${test}_test"
@@ -9,7 +12,7 @@ function(add_tests)
             "${name}.cpp"
             LIBRARIES
             warnings
-            cib)
+            ${AT_LIBRARIES})
     endforeach()
 endfunction()
 

--- a/test/cib/CMakeLists.txt
+++ b/test/cib/CMakeLists.txt
@@ -1,1 +1,8 @@
-add_tests(builder_meta callback nexus readme_hello_world)
+add_tests(
+    FILES
+    builder_meta
+    callback
+    nexus
+    readme_hello_world
+    LIBRARIES
+    cib)

--- a/test/flow/CMakeLists.txt
+++ b/test/flow/CMakeLists.txt
@@ -8,6 +8,15 @@ add_unit_test(
     warnings
     cib)
 
-add_tests(flow graph graph_builder logging log_levels custom_log_levels)
+add_tests(
+    FILES
+    flow
+    graph
+    graph_builder
+    logging
+    log_levels
+    custom_log_levels
+    LIBRARIES
+    cib)
 
 add_subdirectory(fail)

--- a/test/interrupt/CMakeLists.txt
+++ b/test/interrupt/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_tests(
+    FILES
     dynamic_controller
     irq_impl
     manager
     shared_irq_impl
     shared_sub_irq_impl
     sub_irq_impl
-    policies)
+    policies
+    LIBRARIES
+    cib)

--- a/test/interrupt/CMakeLists.txt
+++ b/test/interrupt/CMakeLists.txt
@@ -8,4 +8,4 @@ add_tests(
     sub_irq_impl
     policies
     LIBRARIES
-    cib)
+    cib_interrupt)

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_tests(fmt_logger log mipi_encoder mipi_logger module_id)
+add_tests(
+    FILES
+    fmt_logger
+    log
+    mipi_encoder
+    mipi_logger
+    module_id
+    LIBRARIES
+    cib)
 
 add_library(catalog1_lib STATIC catalog1_lib.cpp)
 add_library(catalog2_lib OBJECT catalog2a_lib.cpp catalog2b_lib.cpp)

--- a/test/lookup/CMakeLists.txt
+++ b/test/lookup/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_tests(input linear_search pseudo_pext_lookup lookup)
+add_tests(
+    FILES
+    input
+    linear_search
+    pseudo_pext_lookup
+    lookup
+    LIBRARIES
+    cib)
 
 add_versioned_package("gh:boost-ext/mph#v1.0.8")
 add_versioned_package("gh:serge-sans-paille/frozen#292a811")

--- a/test/match/CMakeLists.txt
+++ b/test/match/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_tests(
+    FILES
     and
     constant
     equivalence
@@ -10,4 +11,6 @@ add_tests(
     simplify_custom
     simplify_not
     simplify_or
-    sum_of_products)
+    sum_of_products
+    LIBRARIES
+    cib)

--- a/test/match/CMakeLists.txt
+++ b/test/match/CMakeLists.txt
@@ -13,4 +13,4 @@ add_tests(
     simplify_or
     sum_of_products
     LIBRARIES
-    cib)
+    cib_match)

--- a/test/msg/CMakeLists.txt
+++ b/test/msg/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_tests(
+    FILES
     callback
     field_extract
     field_insert
@@ -9,7 +10,9 @@ add_tests(
     indexed_callback
     indexed_handler
     message
-    send)
+    send
+    LIBRARIES
+    cib)
 
 add_subdirectory(fail)
 

--- a/test/sc/CMakeLists.txt
+++ b/test/sc/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_tests(format string_constant)
+add_tests(FILES format string_constant LIBRARIES cib_sc)

--- a/test/sc/format.cpp
+++ b/test/sc/format.cpp
@@ -120,3 +120,9 @@ TEST_CASE("format a formatted string", "[sc::format]") {
                   (sc::lazy_string_format{"a1{}2{}3b4{}5{}6c"_sc,
                                           stdx::make_tuple(10, 20, 30, 40)}));
 }
+
+TEST_CASE("lazy_string_format is sc_like", "[sc::format]") {
+    [[maybe_unused]] auto lsf =
+        sc::lazy_string_format{"{}"_sc, stdx::make_tuple(0)};
+    static_assert(sc::sc_like<decltype(lsf)>);
+}

--- a/test/sc/string_constant.cpp
+++ b/test/sc/string_constant.cpp
@@ -33,3 +33,8 @@ TEST_CASE("join", "[sc::string_constant]") {
     static_assert(""_sc + "Luke"_sc == "Luke"_sc);
     static_assert("Computer"_sc + ""_sc == "Computer"_sc);
 }
+
+TEST_CASE("string_constant is sc_like", "[sc::string_constant]") {
+    [[maybe_unused]] auto hi = "Hello, cruel world!"_sc;
+    static_assert(sc::sc_like<decltype(hi)>);
+}

--- a/test/seq/CMakeLists.txt
+++ b/test/seq/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_tests(sequencer)
+add_tests(FILES sequencer LIBRARIES cib)


### PR DESCRIPTION
In general, CIB does not have a well-defined dependency DAG between its sublibraries; but three are able to be split off quite easily: `sc`, `match` and `interrupt`.