### PR TITLE
:art: Allow GEN_STR_CATALOG to be defaulted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
 add_versioned_package("gh:intel/cpp-std-extensions#4d57b2e")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
+set(GEN_STR_CATALOG
+    ${CMAKE_CURRENT_LIST_DIR}/tools/gen_str_catalog.py
+    CACHE FILEPATH "Location of script to generate a string catalog")
+
 add_library(cib_sc INTERFACE)
 target_compile_features(cib_sc INTERFACE cxx_std_20)
 target_link_libraries_system(cib_sc INTERFACE fmt::fmt-header-only stdx)

--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -63,6 +63,9 @@ function(gen_str_catalog)
     if(SC_GUID_MASK)
         set(GUID_MASK_ARG --guid_mask ${SC_GUID_MASK})
     endif()
+    if(NOT SC_GEN_STR_CATALOG)
+        set(SC_GEN_STR_CATALOG ${GEN_STR_CATALOG})
+    endif()
 
     add_custom_command(
         OUTPUT ${SC_OUTPUT_CPP} ${SC_OUTPUT_JSON} ${SC_OUTPUT_XML}

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -9,8 +9,6 @@ target_include_directories(catalog2_lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(catalog1_lib PRIVATE warnings cib)
 target_link_libraries(catalog2_lib PRIVATE warnings cib)
 gen_str_catalog(
-    GEN_STR_CATALOG
-    ${CMAKE_SOURCE_DIR}/tools/gen_str_catalog.py
     OUTPUT_CPP
     ${CMAKE_CURRENT_BINARY_DIR}/strings.cpp
     OUTPUT_JSON


### PR DESCRIPTION
Problem:
- It's awkward for a caller of `gen_str_catalog()` to supply the path to `gen_str_catalog.py`. CIB owns the python script; it already knows the path.

Solution:
- Cache the path to the script so that the caller can omit it.