### PR TITLE
:sparkles: Add `relaxed_message`

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -532,5 +532,8 @@ struct field {
     using located = detail::field_t<
         decltype(stdx::ct_string_to_type<Name, sc::string_constant>()), T,
         Default, M, Ats...>;
+
+    constexpr static auto bitsize = sizeof(T) * CHAR_BIT;
+    using default_located = located<at{msb_t{bitsize - 1}, lsb_t{}}>;
 };
 } // namespace msg

--- a/test/msg/CMakeLists.txt
+++ b/test/msg/CMakeLists.txt
@@ -12,6 +12,7 @@ add_tests(
     indexed_handler
     indexed_handler_uninit
     message
+    relaxed_message
     send
     LIBRARIES
     cib)

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -621,3 +621,24 @@ TEST_CASE("pack 1 message", "[message]") {
     using expected_defn = message<"defn", f1, f2>;
     static_assert(std::is_same_v<defn, expected_defn>);
 }
+
+TEST_CASE("pack with empty messages", "[message]") {
+    using m0 = message<"m0">;
+
+    using f1 = field<"f1", std::uint32_t>::located<at{15_msb, 0_lsb}>;
+    using f2 = field<"f2", std::uint32_t>::located<at{23_msb, 16_lsb}>;
+    using m1 = message<"m1", f1, f2>;
+
+    using m2 = message<"m2">;
+
+    using f3 = field<"f3", std::uint32_t>::located<at{15_msb, 0_lsb}>;
+    using f4 = field<"f4", std::uint32_t>::located<at{23_msb, 16_lsb}>;
+    using m3 = message<"m3", f3, f4>;
+
+    using defn = pack<"defn", std::uint8_t, m0, m1, m2, m3>;
+    using expected_defn =
+        message<"defn", f1, f2,
+                f3::shifted_by<m1::size<std::uint8_t>::value, std::uint8_t>,
+                f4::shifted_by<m1::size<std::uint8_t>::value, std::uint8_t>>;
+    static_assert(std::is_same_v<defn, expected_defn>);
+}

--- a/test/msg/relaxed_message.cpp
+++ b/test/msg/relaxed_message.cpp
@@ -1,0 +1,45 @@
+#include <msg/message.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+using namespace msg;
+
+using fixed_f =
+    field<"fixed", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using auto_f1 = field<"auto1", std::uint32_t>;
+using auto_f2 = field<"auto2", std::uint8_t>;
+
+} // namespace
+
+TEST_CASE("message with automatically packed fields", "[relaxed_message]") {
+    using defn = relaxed_message<"msg", auto_f1, auto_f2>;
+    using expected_defn =
+        msg::message<"msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>,
+                     auto_f2::located<at{1_dw, 7_msb, 0_lsb}>>;
+    static_assert(std::is_same_v<defn, expected_defn>);
+}
+
+TEST_CASE("automatically packed fields are sorted by size",
+          "[relaxed_message]") {
+    using defn = relaxed_message<"msg", auto_f2, auto_f1>;
+    using expected_defn =
+        msg::message<"msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>,
+                     auto_f2::located<at{1_dw, 7_msb, 0_lsb}>>;
+    static_assert(std::is_same_v<defn, expected_defn>);
+}
+
+TEST_CASE("message with mixed fixed and automatically packed fields",
+          "[relaxed_message]") {
+    using defn = relaxed_message<"msg", auto_f2, fixed_f, auto_f1>;
+    using expected_defn =
+        msg::message<"msg", fixed_f, auto_f1::located<at{1_dw, 31_msb, 0_lsb}>,
+                     auto_f2::located<at{2_dw, 7_msb, 0_lsb}>>;
+    static_assert(std::is_same_v<defn, expected_defn>);
+}
+
+TEST_CASE("message with no automatically packed fields", "[relaxed_message]") {
+    using defn = relaxed_message<"msg", fixed_f>;
+    using expected_defn = msg::message<"msg", fixed_f>;
+    static_assert(std::is_same_v<defn, expected_defn>);
+}


### PR DESCRIPTION
Problem:
- Developing message formats is onerous; we'd like the compiler to take care of packing messages until we know exactly where to put fields.

Solution:
- Add `relaxed_message` as in #664

Note:
- All auto-located fields are put after the fixed spec fields.
- Auto-located fields are sorted from largest to smallest to ease alignment.

Closes #664 