### PR TITLE
:sparkles: Add check for module ID limit

### DIFF
--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -9,7 +9,8 @@ function(gen_str_catalog)
         CLIENT_NAME
         VERSION
         GUID_ID
-        GUID_MASK)
+        GUID_MASK
+        MODULE_ID_MAX)
     set(multiValueArgs INPUT_JSON INPUT_LIBS INPUT_HEADERS STABLE_JSON)
     cmake_parse_arguments(SC "${options}" "${oneValueArgs}" "${multiValueArgs}"
                           ${ARGN})
@@ -63,6 +64,9 @@ function(gen_str_catalog)
     if(SC_GUID_MASK)
         set(GUID_MASK_ARG --guid_mask ${SC_GUID_MASK})
     endif()
+    if(SC_MODULE_ID_MAX)
+        set(MODULE_ID_MAX_ARG --module_id_max ${SC_MODULE_ID_MAX})
+    endif()
     if(NOT SC_GEN_STR_CATALOG)
         set(SC_GEN_STR_CATALOG ${GEN_STR_CATALOG})
     endif()
@@ -75,7 +79,7 @@ function(gen_str_catalog)
             --cpp_output ${SC_OUTPUT_CPP} --json_output ${SC_OUTPUT_JSON}
             --xml_output ${SC_OUTPUT_XML} --stable_json ${STABLE_JSON}
             ${FORGET_ARG} ${CLIENT_NAME_ARG} ${VERSION_ARG} ${GUID_ID_ARG}
-            ${GUID_MASK_ARG}
+            ${GUID_MASK_ARG} ${MODULE_ID_MAX_ARG}
         DEPENDS ${UNDEFS} ${INPUT_JSON} ${SC_GEN_STR_CATALOG} ${STABLE_JSON}
         COMMAND_EXPAND_LISTS)
     if(SC_OUTPUT_LIB)

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -308,6 +308,14 @@ def write_xml(
         xf.write(xml_string)
 
 
+def check_module_limit(modules, max):
+    for m in modules.values():
+        if m["id"] > max:
+            raise Exception(
+                f"Module ({m}) assigned value exceeds the module ID max ({max})."
+            )
+
+
 def parse_cmdline():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -379,6 +387,12 @@ def parse_cmdline():
         action="store_true",
         help="When on, stable IDs from a previous run are forgotten. By default, those strings are remembered in the output so that they will not be reused in future.",
     )
+    parser.add_argument(
+        "--module_id_max",
+        type=int,
+        default=127,
+        help="The maximum value of a module ID.",
+    )
     return parser.parse_args()
 
 
@@ -414,6 +428,8 @@ def main():
         stable_output = dict(
             messages=stable_catalog["messages"], modules=stable_catalog["modules"]
         )
+
+    check_module_limit(modules, args.module_id_max)
 
     if args.json_output is not None:
         write_json(messages, modules, args.json_input, args.json_output, stable_output)


### PR DESCRIPTION
Problem:
- The MIPI-SyST spec allows 7 bits for the module ID field. A codebase could accidentally exceed this limit, leading to unpredictable effects.

Solution:
- Check the max value of a module is not exceeded.
- Allow the max value to be customized so that alternative backends can provide alternative limits.