### PR TITLE
:arrow_up: Update stdx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#4d57b2e")
+add_versioned_package("gh:intel/cpp-std-extensions#2834680")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 set(GEN_STR_CATALOG

--- a/include/cib/detail/runtime_conditional.hpp
+++ b/include/cib/detail/runtime_conditional.hpp
@@ -85,7 +85,7 @@ operator and(runtime_condition<LhsName, LhsPs...> const &lhs,
         constexpr auto name =
             stdx::ct_format<"{} and {}">(CX_VALUE(LhsName), CX_VALUE(RhsName));
 
-        return runtime_condition<name, LhsPs..., RhsPs...>{};
+        return runtime_condition<name.str.value, LhsPs..., RhsPs...>{};
     }
 }
 


### PR DESCRIPTION
Problem:
- `stdx` added a breaking change, viz. the ct_string format result always being returned from `ct_format`.

Solution:
- Update code to deal with that.