### PR TITLE
:sparkles: Introduce log environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#4d57b2e")
+add_versioned_package("gh:intel/cpp-std-extensions#2834680")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 set(GEN_STR_CATALOG

--- a/include/cib/detail/runtime_conditional.hpp
+++ b/include/cib/detail/runtime_conditional.hpp
@@ -85,7 +85,7 @@ operator and(runtime_condition<LhsName, LhsPs...> const &lhs,
         constexpr auto name =
             stdx::ct_format<"{} and {}">(CX_VALUE(LhsName), CX_VALUE(RhsName));
 
-        return runtime_condition<name, LhsPs..., RhsPs...>{};
+        return runtime_condition<name.str.value, LhsPs..., RhsPs...>{};
     }
 }
 

--- a/include/log/env.hpp
+++ b/include/log/env.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <stdx/compiler.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/utility.hpp>
+
+#include <boost/mp11/algorithm.hpp>
+
+#ifdef __clang__
+#define CIB_PRAGMA_SEMI
+#else
+#define CIB_PRAGMA_SEMI ;
+#endif
+
+namespace logging {
+template <auto Query, auto Value> struct prop {
+    [[nodiscard]] CONSTEVAL static auto query(decltype(Query)) noexcept {
+        return Value;
+    }
+};
+
+namespace detail {
+template <typename Q, typename Env>
+concept valid_query_for = requires { Env::query(Q{}); };
+
+template <typename Q, typename... Envs>
+concept valid_query_over = (... or valid_query_for<Q, Envs>);
+
+template <typename Q> struct has_query {
+    template <typename Env>
+    using fn = std::bool_constant<valid_query_for<Q, Env>>;
+};
+} // namespace detail
+
+template <typename... Envs> struct env {
+    template <detail::valid_query_over<Envs...> Q>
+    CONSTEVAL static auto query(Q) noexcept {
+        using I = boost::mp11::mp_find_if_q<boost::mp11::mp_list<Envs...>,
+                                            detail::has_query<Q>>;
+        using E = boost::mp11::mp_at<boost::mp11::mp_list<Envs...>, I>;
+        return Q{}(E{});
+    }
+};
+
+namespace detail {
+template <typename T> struct autowrap {
+    CONSTEVAL autowrap(T t) : value(t) {}
+    T value;
+};
+
+template <std::size_t N> using str_lit_t = char const (&)[N];
+
+template <std::size_t N> struct autowrap<str_lit_t<N>> {
+    CONSTEVAL autowrap(str_lit_t<N> str) : value(str) {}
+    stdx::ct_string<N> value;
+};
+
+template <typename T> autowrap(T) -> autowrap<T>;
+template <std::size_t N> autowrap(str_lit_t<N>) -> autowrap<str_lit_t<N>>;
+
+template <auto V> struct wrap {
+    constexpr static auto value = V;
+};
+
+template <typename> struct for_each_pair;
+template <std::size_t... Is> struct for_each_pair<std::index_sequence<Is...>> {
+    template <auto... Args>
+    using type = env<
+        prop<boost::mp11::mp_at_c<boost::mp11::mp_list<wrap<Args>...>,
+                                  2 * Is>::value.value,
+             stdx::ct<boost::mp11::mp_at_c<boost::mp11::mp_list<wrap<Args>...>,
+                                           2 * Is + 1>::value.value>()>...>;
+};
+} // namespace detail
+} // namespace logging
+
+using cib_log_env_t = logging::env<>;
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define CIB_LOG_ENV(...)                                                       \
+    STDX_PRAGMA(diagnostic push)                                               \
+    STDX_PRAGMA(diagnostic ignored "-Wshadow")                                 \
+    using cib_log_env_t [[maybe_unused]] =                                     \
+        decltype([]<logging::detail::autowrap... Args> {                       \
+            using new_env_t = typename logging::detail::for_each_pair<         \
+                std::make_index_sequence<sizeof...(Args) /                     \
+                                         2>>::template type<Args...>;          \
+            return boost::mp11::mp_append<new_env_t, cib_log_env_t>{};         \
+        }.template operator()<__VA_ARGS__>()) CIB_PRAGMA_SEMI                  \
+            STDX_PRAGMA(diagnostic pop)
+// NOLINTEND(cppcoreguidelines-macro-usage)

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <log/log.hpp>
+#include <log/module.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 
@@ -25,7 +27,7 @@ namespace logging::fmt {
 template <typename TDestinations> struct log_handler {
     constexpr explicit log_handler(TDestinations &&ds) : dests{std::move(ds)} {}
 
-    template <logging::level L, typename ModuleId, typename FilenameStringType,
+    template <logging::level L, typename Env, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
     auto log(FilenameStringType, LineNumberType, MsgType const &msg) -> void {
         auto const currentTime =
@@ -36,7 +38,7 @@ template <typename TDestinations> struct log_handler {
         stdx::for_each(
             [&](auto &out) {
                 ::fmt::format_to(out, "{:>8}us {} [{}]: ", currentTime,
-                                 level_constant<L>{}, ModuleId::value);
+                                 level_constant<L>{}, get_module(Env{}).value);
                 msg.apply(
                     [&]<typename StringType>(StringType, auto const &...args) {
                         ::fmt::format_to(out, StringType::value, args...);

--- a/include/log/module.hpp
+++ b/include/log/module.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <log/env.hpp>
+
+#include <stdx/ct_string.hpp>
+
+#include <utility>
+
+namespace logging {
+[[maybe_unused]] constexpr inline struct get_module_t {
+    template <typename T>
+        requires true // more constrained
+    CONSTEVAL auto operator()(T &&t) const noexcept(
+        noexcept(std::forward<T>(t).query(std::declval<get_module_t>())))
+        -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+
+    CONSTEVAL auto operator()(auto &&) const {
+        using namespace stdx::literals;
+        return "default"_ctst;
+    }
+} get_module;
+} // namespace logging
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CIB_LOG_MODULE(S) CIB_LOG_ENV(logging::get_module, S)

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_tests(FILES log module_id LIBRARIES cib_log)
+add_tests(FILES log module_id env LIBRARIES cib_log)
 add_tests(FILES fmt_logger LIBRARIES cib_log_fmt)
 add_tests(FILES mipi_encoder mipi_logger LIBRARIES cib_log_mipi)
 

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -27,32 +27,32 @@ auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         "A string with no placeholders"_sc);
 }
 
 auto log_one_ct_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("B string with {} placeholder"_sc, "one"_sc));
 }
 
 auto log_one_rt_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("C string with {} placeholder"_sc, 1));
 }
 
 auto log_with_non_default_module_id() -> void {
     CIB_LOG_MODULE("not default");
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("ModuleID string with {} placeholder"_sc, 1));
 }
 
 auto log_with_fixed_module_id() -> void {
     CIB_LOG_MODULE("fixed");
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("Fixed ModuleID string with {} placeholder"_sc, 1));
 }

--- a/test/log/catalog2a_lib.cpp
+++ b/test/log/catalog2a_lib.cpp
@@ -20,6 +20,6 @@ auto log_two_rt_args() -> void;
 
 auto log_two_rt_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("D string with {} and {} placeholder"_sc, 1, 2));
 }

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -21,6 +21,6 @@ auto log_rt_enum_arg() -> void;
 auto log_rt_enum_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
     using namespace ns;
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("E string with {} placeholder"_sc, E::value));
 }

--- a/test/log/env.cpp
+++ b/test/log/env.cpp
@@ -1,0 +1,50 @@
+#include <log/env.hpp>
+#include <log/module.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+[[maybe_unused]] constexpr inline struct custom_t {
+    template <typename T>
+        requires true // more constrained
+    CONSTEVAL auto operator()(T &&t) const
+        noexcept(noexcept(std::forward<T>(t).query(std::declval<custom_t>())))
+            -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+
+    CONSTEVAL auto operator()(auto &&) const {
+        using namespace stdx::literals;
+        return 42;
+    }
+} custom;
+} // namespace
+
+TEST_CASE("override environment", "[log_env]") {
+    static_assert(custom(cib_log_env_t{}) == 42);
+    CIB_LOG_ENV(custom, 1);
+    static_assert(custom(cib_log_env_t{}) == 1);
+    {
+        CIB_LOG_ENV(custom, 2);
+        static_assert(custom(cib_log_env_t{}) == 2);
+    }
+}
+
+TEST_CASE("supplement environment", "[log_env]") {
+    CIB_LOG_ENV(custom, 1);
+    static_assert(custom(cib_log_env_t{}) == 1);
+    {
+        using namespace stdx::literals;
+        CIB_LOG_ENV(logging::get_module, "hello");
+        static_assert(custom(cib_log_env_t{}) == 1);
+        static_assert(logging::get_module(cib_log_env_t{}) == "hello"_ctst);
+    }
+}
+
+TEST_CASE("multi-value environment", "[log_env]") {
+    CIB_LOG_ENV(custom, 1, logging::get_module, "hello");
+
+    using namespace stdx::literals;
+    static_assert(custom(cib_log_env_t{}) == 1);
+    static_assert(logging::get_module(cib_log_env_t{}) == "hello"_ctst);
+}

--- a/test/log/mipi_encoder.cpp
+++ b/test/log/mipi_encoder.cpp
@@ -132,19 +132,18 @@ template <> inline auto conc::injected_policy<> = test_conc_policy{};
 
 TEST_CASE("log zero arguments", "[mipi]") {
     test_critical_section::count = 0;
-    auto cfg =
-        logging::mipi::config{test_log_args_destination<logging::level::TRACE,
-                                                        cib_log_module_id_t>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>("Hello"_sc);
+    auto cfg = logging::mipi::config{
+        test_log_args_destination<logging::level::TRACE, cib_log_env_t>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>("Hello"_sc);
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log one argument", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
-                                  42u, 17u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                  17u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("{}"_sc, 17u));
     CHECK(test_critical_section::count == 2);
 }
@@ -152,9 +151,9 @@ TEST_CASE("log one argument", "[mipi]") {
 TEST_CASE("log two arguments", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
-                                  42u, 17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                  17u, 18u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 2);
 }
@@ -163,18 +162,18 @@ TEST_CASE("log more than two arguments", "[mipi]") {
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, cib_log_module_id_t,
-                                     42u, 17u, 18u, 19u>{}};
-        cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+            test_log_buf_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                     17u, 18u, 19u>{}};
+        cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
             format("{} {} {}"_sc, 17u, 18u, 19u));
         CHECK(test_critical_section::count == 2);
     }
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, cib_log_module_id_t,
-                                     42u, 17u, 18u, 19u, 20u>{}};
-        cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+            test_log_buf_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                     17u, 18u, 19u, 20u>{}};
+        cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
             format("{} {} {} {}"_sc, 17u, 18u, 19u, 20u));
         CHECK(test_critical_section::count == 2);
     }
@@ -184,11 +183,11 @@ TEST_CASE("log to multiple destinations", "[mipi]") {
     test_critical_section::count = 0;
     num_log_args_calls = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
-                                  42u, 17u, 18u>{},
-        test_log_args_destination<logging::level::TRACE, cib_log_module_id_t,
-                                  42u, 17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_module_id_t>(
+        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                  17u, 18u>{},
+        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
+                                  17u, 18u>{}};
+    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
         format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 4);
     CHECK(num_log_args_calls == 2);

--- a/test/log/module_id.cpp
+++ b/test/log/module_id.cpp
@@ -8,23 +8,26 @@
 #include <type_traits>
 
 TEST_CASE("default log module id", "[module_id]") {
-    static_assert(std::is_same_v<cib_log_module_id_t, decltype("default"_sc)>);
+    using namespace stdx::literals;
+    static_assert(logging::get_module(cib_log_env_t{}) == "default"_ctst);
 }
 
 namespace ns {
 CIB_LOG_MODULE("ns");
 
 TEST_CASE("log module id overridden at namespace scope", "[module_id]") {
-    static_assert(std::is_same_v<cib_log_module_id_t, decltype("ns"_sc)>);
+    using namespace stdx::literals;
+    static_assert(logging::get_module(cib_log_env_t{}) == "ns"_ctst);
 }
 } // namespace ns
 
 struct S {
-    CIB_LOG_MODULE("S");
-
     template <typename = void> constexpr static auto test() {
-        static_assert(std::is_same_v<cib_log_module_id_t, decltype("S"_sc)>);
+        using namespace stdx::literals;
+        static_assert(logging::get_module(cib_log_env_t{}) == "S"_ctst);
     }
+
+    CIB_LOG_MODULE("S");
 };
 
 TEST_CASE("log module id overridden at class scope", "[module_id]") {
@@ -33,7 +36,8 @@ TEST_CASE("log module id overridden at class scope", "[module_id]") {
 
 template <typename = void> constexpr static auto func_test() {
     CIB_LOG_MODULE("fn");
-    static_assert(std::is_same_v<cib_log_module_id_t, decltype("fn"_sc)>);
+    using namespace stdx::literals;
+    static_assert(logging::get_module(cib_log_env_t{}) == "fn"_ctst);
 }
 
 TEST_CASE("log module id overridden at function scope", "[module_id]") {
@@ -45,7 +49,7 @@ TEST_CASE("log module id overridden at statement scope", "[module_id]") {
 
     {
         CIB_LOG_MODULE("statement");
-        static_assert(
-            std::is_same_v<cib_log_module_id_t, decltype("statement"_sc)>);
+        using namespace stdx::literals;
+        static_assert(logging::get_module(cib_log_env_t{}) == "statement"_ctst);
     }
 }


### PR DESCRIPTION
Problem:
- Logging is parameterized on many axes. Most logging systems include the level.
  Some also include a module or source. Some include other parameters.
- Logging machinery should be agnostic to the parameterizations of each logging
  backend. Adding extra parameters to logging macros is not scalable.

Solution:
- Expand the current logging module to the idea of a logging environment. An
  environment allows compile-time scope-based arguments to be passed through the
  logging machinery; logging backends can extract whichever values they can use
  from the current environment.