### PR TITLE
:bug: Fix `CIB_FATAL`

### DIFF
--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -70,15 +70,14 @@ ALWAYS_INLINE static auto log(TArgs &&...args) -> void {
     CIB_LOG(logging::default_flavor_t, logging::level::ERROR, __VA_ARGS__)
 
 #define CIB_FATAL(MSG, ...)                                                    \
-    [] {                                                                       \
-        constexpr auto str = sc::format(MSG##_sc __VA_OPT__(, ) __VA_ARGS__);  \
+    [](auto &&str) {                                                           \
         logging::log<logging::default_flavor_t, logging::level::FATAL,         \
                      cib_log_env_t>(__FILE__, __LINE__, str);                  \
-        str.apply([]<typename S, typename... Args>(S s, Args... args) {        \
+        FWD(str).apply([]<typename S, typename... Args>(S s, Args... args) {   \
             constexpr auto cts = stdx::ct_string_from_type(s);                 \
             stdx::panic<cts>(args...);                                         \
         });                                                                    \
-    }()
+    }(sc::format(MSG##_sc __VA_OPT__(, ) __VA_ARGS__))
 
 #define CIB_ASSERT(expr)                                                       \
     ((expr) ? void(0) : CIB_FATAL("Assertion failure: " #expr))

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -16,7 +16,7 @@ bool panicked{};
 struct injected_handler {
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
-        static_assert(std::string_view{Why} == "Hello");
+        static_assert(std::string_view{Why}.starts_with("Hello"));
         panicked = true;
     }
 };
@@ -53,5 +53,12 @@ TEST_CASE("CIB_FATAL calls compile-time panic", "[log]") {
 TEST_CASE("CIB_FATAL pre-formats arguments passed to panic", "[log]") {
     panicked = false;
     CIB_FATAL("{}", "Hello"_sc);
+    CHECK(panicked);
+}
+
+TEST_CASE("CIB_FATAL can format stack arguments", "[log]") {
+    panicked = false;
+    auto x = 42;
+    CIB_FATAL("Hello {}", x);
     CHECK(panicked);
 }


### PR DESCRIPTION
Problem:
- Calling `CIB_FATAL` with stack variables fails because it uses a lambda to scope its action, without capturing stack variables.

Solution:
- Use the arguments outside the lambda expression.