### PR TITLE
:sparkles: Add `CIB_WITH_LOG_ENV`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,10 @@ target_sources(
               BASE_DIRS
               include
               FILES
+              include/log/env.hpp
               include/log/level.hpp
-              include/log/log.hpp)
+              include/log/log.hpp
+              include/log/module.hpp)
 
 add_library(cib_msg INTERFACE)
 target_compile_features(cib_msg INTERFACE cxx_std_20)


### PR DESCRIPTION
Problem:
- `CIB_LOG_ENV` defines a current logging environment, but it doesn't introduce a scope, so defining more than one in a scope is ill-formed.
- Defining a logging environment for just one log line is verbose.
- The logging macros themselves should not get overloaded with environment gunk, even if there were a suitable way to do so.

Solution:
- Add `CIB_WITH_LOG_ENV` that allows defining a logging environment scope easily.