### PR TITLE
:sparkles: Allow custom log levels

### DIFF
--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -2,6 +2,8 @@
 
 #include <flow/common.hpp>
 #include <flow/log.hpp>
+#include <log/env.hpp>
+#include <log/level.hpp>
 #include <log/log.hpp>
 
 #include <stdx/ct_string.hpp>
@@ -20,9 +22,9 @@ constexpr auto run_func() -> void {
         if constexpr (not FlowName.empty()) {
             using log_spec_t =
                 decltype(get_log_spec<CTNode, log_spec_id_t<FlowName>>());
-            CIB_LOG(typename log_spec_t::flavor, log_spec_t::level,
-                    "flow.{}({})", typename CTNode::type_t{},
-                    typename CTNode::name_t{});
+            CIB_LOG_ENV(logging::get_level, log_spec_t::level);
+            CIB_LOG(typename log_spec_t::flavor, "flow.{}({})",
+                    typename CTNode::type_t{}, typename CTNode::name_t{});
         }
         typename CTNode::func_t{}();
     }
@@ -60,16 +62,16 @@ template <stdx::ct_string Name, auto... FuncPtrs> struct inlined_func_list {
 
         if constexpr (loggingEnabled) {
             using log_spec_t = decltype(get_log_spec<inlined_func_list>());
-            CIB_LOG(typename log_spec_t::flavor, log_spec_t::level,
-                    "flow.start({})", name);
+            CIB_LOG_ENV(logging::get_level, log_spec_t::level);
+            CIB_LOG(typename log_spec_t::flavor, "flow.start({})", name);
         }
 
         (FuncPtrs(), ...);
 
         if constexpr (loggingEnabled) {
             using log_spec_t = decltype(get_log_spec<inlined_func_list>());
-            CIB_LOG(typename log_spec_t::flavor, log_spec_t::level,
-                    "flow.end({})", name);
+            CIB_LOG_ENV(logging::get_level, log_spec_t::level);
+            CIB_LOG(typename log_spec_t::flavor, "flow.end({})", name);
         }
     }
 };

--- a/include/log/env.hpp
+++ b/include/log/env.hpp
@@ -69,6 +69,16 @@ template <std::size_t... Is> struct for_each_pair<std::index_sequence<Is...>> {
                                            2 * Is + 1>::value.value>()>...>;
 };
 } // namespace detail
+
+template <typename Env = env<>>
+constexpr auto make_env = []<detail::autowrap... Args> {
+    using new_env_t = typename detail::for_each_pair<
+        std::make_index_sequence<sizeof...(Args) / 2>>::template type<Args...>;
+    return boost::mp11::mp_append<new_env_t, Env>{};
+};
+
+template <detail::autowrap... Args>
+using make_env_t = decltype(make_env<>.template operator()<Args...>());
 } // namespace logging
 
 using cib_log_env_t = logging::env<>;
@@ -82,10 +92,11 @@ using cib_log_env_t = logging::env<>;
 #endif
 
 #define CIB_LOG_ENV_DECL(...)                                                  \
-    [[maybe_unused]] typedef decltype([]<logging::detail::autowrap... Args> {  \
+    [[maybe_unused]] typedef decltype([]<logging::detail::                     \
+                                             autowrap... _env_args> {          \
         using new_env_t =                                                      \
             typename logging::detail::for_each_pair<std::make_index_sequence<  \
-                sizeof...(Args) / 2>>::template type<Args...>;                 \
+                sizeof...(_env_args) / 2>>::template type<_env_args...>;       \
         return boost::mp11::mp_append<new_env_t, cib_log_env_t>{};             \
     }.template operator()<__VA_ARGS__>()) cib_log_env_t
 

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <log/level.hpp>
 #include <log/log.hpp>
 #include <log/module.hpp>
 
@@ -31,7 +32,7 @@ namespace logging::fmt {
 template <typename TDestinations> struct log_handler {
     constexpr explicit log_handler(TDestinations &&ds) : dests{std::move(ds)} {}
 
-    template <logging::level L, typename Env, typename FilenameStringType,
+    template <typename Env, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
     auto log(FilenameStringType, LineNumberType, MsgType const &msg) -> void {
         auto const currentTime =
@@ -42,7 +43,7 @@ template <typename TDestinations> struct log_handler {
         stdx::for_each(
             [&](auto &out) {
                 ::fmt::format_to(out, "{:>8}us {} [{}]: ", currentTime,
-                                 stdx::ct<L>(), get_module(Env{}).value);
+                                 get_level(Env{}), get_module(Env{}).value);
                 msg.apply(
                     [&]<typename StringType>(StringType, auto const &...args) {
                         ::fmt::format_to(out, StringType::value, args...);

--- a/include/log/fmt/logger.hpp
+++ b/include/log/fmt/logger.hpp
@@ -6,19 +6,23 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
+#include <stdx/utility.hpp>
 
 #include <fmt/format.h>
 
 #include <chrono>
+#include <type_traits>
 #include <utility>
 
-template <auto L> struct fmt::formatter<logging::level_constant<L>> {
+template <logging::level L>
+struct fmt::formatter<std::integral_constant<logging::level, L>> {
     constexpr static auto parse(format_parse_context &ctx) {
         return ctx.begin();
     }
 
     template <typename FormatContext>
-    auto format(logging::level_constant<L>, FormatContext &ctx) const {
+    auto format(std::integral_constant<logging::level, L>,
+                FormatContext &ctx) const {
         return ::fmt::format_to(ctx.out(), logging::to_text<L>());
     }
 };
@@ -38,7 +42,7 @@ template <typename TDestinations> struct log_handler {
         stdx::for_each(
             [&](auto &out) {
                 ::fmt::format_to(out, "{:>8}us {} [{}]: ", currentTime,
-                                 level_constant<L>{}, get_module(Env{}).value);
+                                 stdx::ct<L>(), get_module(Env{}).value);
                 msg.apply(
                     [&]<typename StringType>(StringType, auto const &...args) {
                         ::fmt::format_to(out, StringType::value, args...);

--- a/include/log/level.hpp
+++ b/include/log/level.hpp
@@ -29,6 +29,4 @@ template <level L>
                                     "INFO"sv, "USER1"sv, "USER2"sv, "TRACE"sv};
     return level_text[stdx::to_underlying(L)];
 }
-
-template <level L> struct level_constant : std::integral_constant<level, L> {};
 } // namespace logging

--- a/include/log/level.hpp
+++ b/include/log/level.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <log/env.hpp>
+
 #include <stdx/type_traits.hpp>
 
 #include <array>
 #include <cstdint>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 namespace logging {
 // enum assignment is according to Mipi_Sys-T Severity definition
@@ -29,4 +32,13 @@ template <level L>
                                     "INFO"sv, "USER1"sv, "USER2"sv, "TRACE"sv};
     return level_text[stdx::to_underlying(L)];
 }
+
+[[maybe_unused]] constexpr inline struct get_level_t {
+    template <typename T>
+    CONSTEVAL auto operator()(T &&t) const noexcept(
+        noexcept(std::forward<T>(t).query(std::declval<get_level_t>())))
+        -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+} get_level;
 } // namespace logging

--- a/test/flow/custom_log_levels.cpp
+++ b/test/flow/custom_log_levels.cpp
@@ -1,5 +1,6 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
+#include <log/level.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -37,11 +38,10 @@ constexpr auto msB = flow::milestone<"msB">();
 
 struct log_config {
     struct log_handler {
-        template <logging::level Level, typename ModuleId,
-                  typename FilenameStringType, typename LineNumberType,
-                  typename MsgType>
+        template <typename Env, typename FilenameStringType,
+                  typename LineNumberType, typename MsgType>
         auto log(FilenameStringType, LineNumberType, MsgType const &) -> void {
-            log_calls.push_back(Level);
+            log_calls.push_back(logging::get_level(Env{}).value);
         }
     };
     log_handler logger;

--- a/test/flow/log_levels.cpp
+++ b/test/flow/log_levels.cpp
@@ -1,5 +1,6 @@
 #include <cib/cib.hpp>
 #include <flow/flow.hpp>
+#include <log/level.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -34,11 +35,10 @@ constexpr auto ms = flow::milestone<"ms">();
 
 struct log_config {
     struct log_handler {
-        template <logging::level Level, typename ModuleId,
-                  typename FilenameStringType, typename LineNumberType,
-                  typename MsgType>
+        template <typename Env, typename FilenameStringType,
+                  typename LineNumberType, typename MsgType>
         auto log(FilenameStringType, LineNumberType, MsgType const &) -> void {
-            log_calls.push_back(Level);
+            log_calls.push_back(logging::get_level(Env{}).value);
         }
     };
     log_handler logger;

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_tests(FILES log module_id env LIBRARIES cib_log)
+add_tests(
+    FILES
+    level
+    log
+    module_id
+    env
+    LIBRARIES
+    cib_log)
 add_tests(FILES fmt_logger LIBRARIES cib_log_fmt)
 add_tests(FILES mipi_encoder mipi_logger LIBRARIES cib_log_mipi)
 

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -17,6 +17,8 @@ struct test_log_args_destination {
         last_header = hdr;
     }
 };
+
+using log_env1 = logging::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_zero_args() -> void;
@@ -27,32 +29,34 @@ auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        "A string with no placeholders"_sc);
+    cfg.logger.log_msg<log_env1>("A string with no placeholders"_sc);
 }
 
 auto log_one_ct_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
+    cfg.logger.log_msg<log_env1>(
         format("B string with {} placeholder"_sc, "one"_sc));
 }
 
 auto log_one_rt_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("C string with {} placeholder"_sc, 1));
+    cfg.logger.log_msg<log_env1>(format("C string with {} placeholder"_sc, 1));
 }
 
 auto log_with_non_default_module_id() -> void {
-    CIB_LOG_MODULE("not default");
-    auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("ModuleID string with {} placeholder"_sc, 1));
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_module, "not default") {
+        auto cfg = logging::mipi::config{test_log_args_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            format("ModuleID string with {} placeholder"_sc, 1));
+    }
 }
 
 auto log_with_fixed_module_id() -> void {
-    CIB_LOG_MODULE("fixed");
-    auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("Fixed ModuleID string with {} placeholder"_sc, 1));
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_module, "fixed") {
+        auto cfg = logging::mipi::config{test_log_args_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            format("Fixed ModuleID string with {} placeholder"_sc, 1));
+    }
 }

--- a/test/log/catalog2a_lib.cpp
+++ b/test/log/catalog2a_lib.cpp
@@ -14,12 +14,15 @@ namespace {
 struct test_log_args_destination {
     auto log_by_args(std::uint32_t, auto...) -> void { ++log_calls; }
 };
+
+using log_env2a =
+    logging::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_two_rt_args() -> void;
 
 auto log_two_rt_args() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
+    cfg.logger.log_msg<log_env2a>(
         format("D string with {} and {} placeholder"_sc, 1, 2));
 }

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -14,6 +14,9 @@ namespace {
 struct test_log_args_destination {
     auto log_by_args(std::uint32_t, auto...) -> void { ++log_calls; }
 };
+
+using log_env2b =
+    logging::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_rt_enum_arg() -> void;
@@ -21,6 +24,6 @@ auto log_rt_enum_arg() -> void;
 auto log_rt_enum_arg() -> void {
     auto cfg = logging::mipi::config{test_log_args_destination{}};
     using namespace ns;
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
+    cfg.logger.log_msg<log_env2b>(
         format("E string with {} placeholder"_sc, E::value));
 }

--- a/test/log/env.cpp
+++ b/test/log/env.cpp
@@ -59,7 +59,7 @@ namespace {
 auto logged_modules = std::vector<std::string_view>{};
 
 struct log_handler {
-    template <logging::level L, typename Env, typename FilenameStringType,
+    template <typename Env, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
     auto log(FilenameStringType, LineNumberType, MsgType const &) -> void {
         using namespace stdx::literals;

--- a/test/log/fmt_logger.cpp
+++ b/test/log/fmt_logger.cpp
@@ -1,6 +1,7 @@
 #include <log/fmt/logger.hpp>
 
 #include <stdx/ct_string.hpp>
+#include <stdx/utility.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -61,49 +62,49 @@ TEST_CASE("log levels are properly represented", "[fmt_logger]") {
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::TRACE>{});
+                       stdx::ct<logging::level::TRACE>());
         CHECK(level == "TRACE");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::INFO>{});
+                       stdx::ct<logging::level::INFO>());
         CHECK(level == "INFO");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::WARN>{});
+                       stdx::ct<logging::level::WARN>());
         CHECK(level == "WARN");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::ERROR>{});
+                       stdx::ct<logging::level::ERROR>());
         CHECK(level == "ERROR");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::FATAL>{});
+                       stdx::ct<logging::level::FATAL>());
         CHECK(level == "FATAL");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::MAX>{});
+                       stdx::ct<logging::level::MAX>());
         CHECK(level == "MAX");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::USER1>{});
+                       stdx::ct<logging::level::USER1>());
         CHECK(level == "USER1");
     }
     {
         std::string level{};
         fmt::format_to(std::back_inserter(level), "{}",
-                       logging::level_constant<logging::level::USER2>{});
+                       stdx::ct<logging::level::USER2>());
         CHECK(level == "USER2");
     }
 }

--- a/test/log/fmt_logger.cpp
+++ b/test/log/fmt_logger.cpp
@@ -162,9 +162,10 @@ inline auto logging::config<secure_t> =
     logging::fmt::config{std::back_inserter(secure_buffer)};
 
 TEST_CASE("logging can be flavored", "[fmt_logger]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     buffer.clear();
     secure_buffer.clear();
-    CIB_LOG(secure_t, logging::level::TRACE, "Hello");
+    CIB_LOG(secure_t, "Hello");
     CAPTURE(secure_buffer);
     CHECK(secure_buffer.substr(secure_buffer.size() - std::size("Hello")) ==
           "Hello\n");

--- a/test/log/level.cpp
+++ b/test/log/level.cpp
@@ -1,0 +1,68 @@
+#include <log/catalog/mipi_encoder.hpp>
+#include <log/fmt/logger.hpp>
+#include <log/level.hpp>
+#include <sc/format.hpp>
+
+#include <stdx/ct_conversions.hpp>
+#include <stdx/ct_string.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <type_traits>
+
+namespace {
+enum struct custom_level { THE_ONE_LEVEL = 5 };
+
+std::string buffer{};
+} // namespace
+
+template <>
+inline auto logging::config<> =
+    logging::fmt::config{std::back_inserter(buffer)};
+
+template <custom_level L>
+struct fmt::formatter<std::integral_constant<custom_level, L>> {
+    constexpr static auto parse(format_parse_context &ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(std::integral_constant<custom_level, L>,
+                FormatContext &ctx) const {
+        return ::fmt::format_to(ctx.out(), stdx::enum_as_string<L>());
+    }
+};
+
+TEST_CASE("fmt logger works with custom level", "[level]") {
+    CIB_LOG_ENV(logging::get_level, custom_level::THE_ONE_LEVEL);
+    buffer.clear();
+    CIB_LOG(logging::default_flavor_t, "Hello");
+    CAPTURE(buffer);
+    CHECK(buffer.find("THE_ONE_LEVEL [default]:") != std::string::npos);
+}
+
+template <typename> auto catalog() -> string_id { return 0xdeadbeef; }
+template <typename> auto module() -> module_id { return 0x5a; }
+
+namespace {
+int log_calls{};
+
+struct test_destination {
+    auto log_by_args(std::uint32_t header, auto id, auto &&...) {
+        CHECK(header == 0x01'5a'00'53);
+        CHECK(id == 0xdeadbeef);
+        ++log_calls;
+    }
+};
+} // namespace
+
+TEST_CASE("mipi logger works with custom level", "[level]") {
+    log_calls = 0;
+    CIB_LOG_ENV(logging::get_level, custom_level::THE_ONE_LEVEL);
+    auto cfg = logging::mipi::config{test_destination{}};
+    cfg.logger.log_msg<cib_log_env_t>(sc::format("Hello {} {}"_sc, 17, 42));
+    CHECK(log_calls == 1);
+}

--- a/test/log/mipi_encoder.cpp
+++ b/test/log/mipi_encoder.cpp
@@ -61,12 +61,6 @@ expected_msg_header(logging::level level, module_id m,
                   : expected_short32_header();
 }
 
-template <auto ExpectedId> struct test_log_id_destination {
-    template <typename Id> static auto log_by_args(Id id) {
-        CHECK(id == ((ExpectedId << 4u) | 1u));
-    }
-};
-
 int num_log_args_calls{};
 
 constexpr auto check = [](auto value, auto expected) {

--- a/test/log/mipi_encoder.cpp
+++ b/test/log/mipi_encoder.cpp
@@ -126,69 +126,72 @@ struct test_log_version_destination {
         ++num_log_args_calls;
     }
 };
+
+using log_env = logging::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 template <> inline auto conc::injected_policy<> = test_conc_policy{};
 
 TEST_CASE("log zero arguments", "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_env_t>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>("Hello"_sc);
+        test_log_args_destination<logging::level::TRACE, log_env>{}};
+    cfg.logger.log_msg<log_env>("Hello"_sc);
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log one argument", "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                  17u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("{}"_sc, 17u));
+        test_log_args_destination<logging::level::TRACE, log_env, 42u, 17u>{}};
+    cfg.logger.log_msg<log_env>(format("{}"_sc, 17u));
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log two arguments", "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     test_critical_section::count = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                  17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("{} {}"_sc, 17u, 18u));
+        test_log_args_destination<logging::level::TRACE, log_env, 42u, 17u,
+                                  18u>{}};
+    cfg.logger.log_msg<log_env>(format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 2);
 }
 
 TEST_CASE("log more than two arguments", "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                     17u, 18u, 19u>{}};
-        cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-            format("{} {} {}"_sc, 17u, 18u, 19u));
+            test_log_buf_destination<logging::level::TRACE, log_env, 42u, 17u,
+                                     18u, 19u>{}};
+        cfg.logger.log_msg<log_env>(format("{} {} {}"_sc, 17u, 18u, 19u));
         CHECK(test_critical_section::count == 2);
     }
     {
         test_critical_section::count = 0;
         auto cfg = logging::mipi::config{
-            test_log_buf_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                     17u, 18u, 19u, 20u>{}};
-        cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
+            test_log_buf_destination<logging::level::TRACE, log_env, 42u, 17u,
+                                     18u, 19u, 20u>{}};
+        cfg.logger.log_msg<log_env>(
             format("{} {} {} {}"_sc, 17u, 18u, 19u, 20u));
         CHECK(test_critical_section::count == 2);
     }
 }
 
 TEST_CASE("log to multiple destinations", "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     test_critical_section::count = 0;
     num_log_args_calls = 0;
     auto cfg = logging::mipi::config{
-        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                  17u, 18u>{},
-        test_log_args_destination<logging::level::TRACE, cib_log_env_t, 42u,
-                                  17u, 18u>{}};
-    cfg.logger.log_msg<logging::level::TRACE, cib_log_env_t>(
-        format("{} {}"_sc, 17u, 18u));
+        test_log_args_destination<logging::level::TRACE, log_env, 42u, 17u,
+                                  18u>{},
+        test_log_args_destination<logging::level::TRACE, log_env, 42u, 17u,
+                                  18u>{}};
+
+    cfg.logger.log_msg<log_env>(format("{} {}"_sc, 17u, 18u));
     CHECK(test_critical_section::count == 4);
     CHECK(num_log_args_calls == 2);
 }
@@ -229,4 +232,14 @@ TEST_CASE("log version information (long with string)", "[mipi]") {
     cfg.logger.log_build<0x1234'5678'8765'4321ull, "hello">();
     CHECK(test_critical_section::count == 2);
     CHECK(num_log_args_calls == 1);
+}
+
+template <>
+inline auto logging::config<> = logging::mipi::config{
+    test_log_args_destination<logging::level::TRACE, log_env>{}};
+
+TEST_CASE("injection", "[mipi]") {
+    test_critical_section::count = 0;
+    CIB_TRACE("Hello");
+    CHECK(test_critical_section::count == 2);
 }


### PR DESCRIPTION
Problem:
- Many logging backends have varying ideas of what a log level is. The MIPI-SysT
  spec defines two user-defined values. It would be nice to use a strongly-typed
  enumeration in application code that can re-spell the `USER1` and `USER2`
  values.

Solution:
- Make logging level-agnostic.
- The MIPI-SysT levels are provided for default use, but they aren't required.