### PR TITLE
:fire: Remove `level` from logging message symbols

### DIFF
--- a/include/log/catalog/catalog.hpp
+++ b/include/log/catalog/catalog.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <log/level.hpp>
-
 #include <cstdint>
 
 namespace sc {
 template <typename...> struct args;
 template <typename, typename T, T...> struct undefined;
 
-template <logging::level, typename> struct message {};
+template <typename> struct message {};
 template <typename> struct module_string {};
 } // namespace sc
 

--- a/include/log/catalog/mipi_encoder.hpp
+++ b/include/log/catalog/mipi_encoder.hpp
@@ -20,12 +20,11 @@
 
 namespace logging::mipi {
 namespace detail {
-template <auto L, typename S, typename... Args> constexpr auto to_message() {
+template <typename S, typename... Args> constexpr auto to_message() {
     constexpr auto s = S::value;
     using char_t = typename std::remove_cv_t<decltype(s)>::value_type;
     return [&]<std::size_t... Is>(std::integer_sequence<std::size_t, Is...>) {
         return sc::message<
-            static_cast<logging::level>(L),
             sc::undefined<sc::args<Args...>, char_t, s[Is]...>>{};
     }(std::make_integer_sequence<std::size_t, std::size(s)>{});
 }
@@ -114,7 +113,7 @@ template <typename TDestinations> struct log_handler {
     ALWAYS_INLINE auto log_msg(Msg msg) -> void {
         msg.apply([&]<typename S, typename... Args>(S, Args... args) {
             constexpr auto L = stdx::to_underlying(get_level(Env{}).value);
-            using Message = decltype(detail::to_message<L, S, Args...>());
+            using Message = decltype(detail::to_message<S, Args...>());
             using Module =
                 decltype(detail::to_module<get_module(Env{}).value>());
             dispatch_message<L>(catalog<Message>(), module<Module>(),

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -32,25 +32,21 @@ def split_args(s: str) -> list[str]:
 
 
 string_re = re.compile(
-    r"sc::message<\(logging::level\)(\d+), sc::undefined<sc::args<(.*)>, char, (.*)>\s*>"
+    r"sc::message<sc::undefined<sc::args<(.*)>, char, (.*)>\s*>"
 )
 
 
 def extract_string_id(line_m):
-    levels = ["MAX", "FATAL", "ERROR", "WARN", "INFO", "USER1", "USER2", "TRACE"]
-
     catalog_type = line_m.group(1)
     string_m = string_re.match(line_m.group(3))
-    log_level = string_m.group(1)
-    arg_tuple = string_m.group(2)
-    string_tuple = string_m.group(3).replace("(char)", "")
+    arg_tuple = string_m.group(1)
+    string_tuple = string_m.group(2).replace("(char)", "")
     string_value = "".join((chr(int(c)) for c in re.split(r"\s*,\s*", string_tuple)))
     args = split_args(arg_tuple)
 
     return (
         (catalog_type, arg_tuple),
         dict(
-            level=levels[int(log_level)],
             msg=string_value,
             type="flow" if string_value.startswith("flow.") else "msg",
             arg_types=args,
@@ -85,7 +81,7 @@ def extract(line_num: int, line_m):
 
 
 def stable_msg_key(msg: dict):
-    return hash(msg["level"]) ^ hash(msg["msg"]) ^ hash("".join(msg["arg_types"]))
+    return hash(msg["msg"]) ^ hash("".join(msg["arg_types"]))
 
 
 def stable_module_key(module: str):


### PR DESCRIPTION
Level is not a property of a message string, it's a property of a message instance.