### PR TITLE
:arrow_up: Update stdx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(10.2.1)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#2834680")
+add_versioned_package("gh:intel/cpp-std-extensions#37cc9c5")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 set(GEN_STR_CATALOG


### PR DESCRIPTION
Problem:
- LLVM18 clang-tidy flags `handled` as able to be declared `const`. This is wrong, but what we're actually doing here is better expressed as `transform_reduce` on the bitset.

Solution:
- Use `transform_reduce`.

Note:
- `transform_reduce` is the operation here because we do not want to shortcut handling the message. `any_of` would be correct for that use case.