### PR TITLE
:art: Remove inlining attributes from logging functions

### DIFF
--- a/include/log/catalog/mipi_builder.hpp
+++ b/include/log/catalog/mipi_builder.hpp
@@ -17,7 +17,7 @@ template <typename> struct builder;
 
 template <> struct builder<defn::short32_msg_t> {
     template <auto Level, std::same_as<std::uint32_t>... Ts>
-    ALWAYS_INLINE static auto build(string_id id, module_id, Ts...) {
+    static auto build(string_id id, module_id, Ts...) {
         using namespace msg;
         return owning<defn::short32_msg_t>{"payload"_field = id};
     }
@@ -25,7 +25,7 @@ template <> struct builder<defn::short32_msg_t> {
 
 template <typename Storage> struct catalog_builder {
     template <auto Level, std::same_as<std::uint32_t>... Ts>
-    ALWAYS_INLINE static auto build(string_id id, module_id m, Ts... msg_data) {
+    static auto build(string_id id, module_id m, Ts... msg_data) {
         using namespace msg;
         defn::catalog_msg_t::owner_t<Storage> message{"severity"_field = Level,
                                                       "module_id"_field = m};
@@ -48,7 +48,7 @@ template <typename Storage>
     requires std::same_as<typename Storage::value_type, std::uint32_t>
 struct catalog_builder<Storage> {
     template <auto Level, std::same_as<std::uint32_t>... Ts>
-    ALWAYS_INLINE static auto build(string_id id, module_id m, Ts... msg_data) {
+    static auto build(string_id id, module_id m, Ts... msg_data) {
         using namespace msg;
         defn::catalog_msg_t::owner_t<Storage> message{"severity"_field = Level,
                                                       "module_id"_field = m};
@@ -65,7 +65,7 @@ struct catalog_builder<Storage> {
 
 template <> struct builder<defn::catalog_msg_t> {
     template <auto Level, std::same_as<std::uint32_t>... Ts>
-    ALWAYS_INLINE static auto build(string_id id, module_id m, Ts... msg_data) {
+    static auto build(string_id id, module_id m, Ts... msg_data) {
         using namespace msg;
         if constexpr (sizeof...(Ts) <= 2u) {
             constexpr auto header_size =
@@ -89,7 +89,7 @@ template <> struct builder<defn::catalog_msg_t> {
 
 struct default_builder {
     template <auto Level, std::same_as<std::uint32_t>... Ts>
-    ALWAYS_INLINE static auto build(string_id id, module_id m, Ts... msg_data) {
+    static auto build(string_id id, module_id m, Ts... msg_data) {
         if constexpr (sizeof...(Ts) == 0u) {
             return builder<defn::short32_msg_t>{}.template build<Level>(
                 id, m, msg_data...);

--- a/include/log/catalog/mipi_encoder.hpp
+++ b/include/log/catalog/mipi_encoder.hpp
@@ -43,13 +43,11 @@ template <typename TDestinations> struct log_handler {
 
     template <typename Env, typename FilenameStringType,
               typename LineNumberType, typename MsgType>
-    ALWAYS_INLINE auto log(FilenameStringType, LineNumberType,
-                           MsgType const &msg) -> void {
+    auto log(FilenameStringType, LineNumberType, MsgType const &msg) -> void {
         log_msg<Env>(msg);
     }
 
-    template <typename Env, typename Msg>
-    ALWAYS_INLINE auto log_msg(Msg msg) -> void {
+    template <typename Env, typename Msg> auto log_msg(Msg msg) -> void {
         msg.apply([&]<typename S, typename... Args>(S, Args... args) {
             constexpr auto L = stdx::to_underlying(get_level(Env{}).value);
             using Message = decltype(detail::to_message<S, Args...>());
@@ -93,7 +91,7 @@ template <typename TDestinations> struct log_handler {
 
   private:
     template <std::size_t N>
-    NEVER_INLINE auto write(stdx::span<std::uint8_t const, N> msg) -> void {
+    auto write(stdx::span<std::uint8_t const, N> msg) -> void {
         stdx::for_each(
             [&]<typename Dest>(Dest &dest) {
                 conc::call_in_critical_section<Dest>(
@@ -103,7 +101,7 @@ template <typename TDestinations> struct log_handler {
     }
 
     template <std::size_t N>
-    NEVER_INLINE auto write(stdx::span<std::uint32_t const, N> msg) -> void {
+    auto write(stdx::span<std::uint32_t const, N> msg) -> void {
         [&]<std::size_t... Is>(std::index_sequence<Is...>) {
             stdx::for_each(
                 [&]<typename Dest>(Dest &dest) {

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -39,7 +39,7 @@ struct config {
 template <typename...> inline auto config = null::config{};
 
 template <typename Env, typename... Ts>
-ALWAYS_INLINE constexpr static auto get_config() -> auto & {
+constexpr static auto get_config() -> auto & {
     using flavor_t = typename decltype(get_flavor(Env{}).value)::type;
     if constexpr (std::same_as<flavor_t, default_flavor_t>) {
         return config<Ts...>;
@@ -49,7 +49,7 @@ ALWAYS_INLINE constexpr static auto get_config() -> auto & {
 }
 
 template <typename Env, typename... Ts, typename... TArgs>
-ALWAYS_INLINE static auto log(TArgs &&...args) -> void {
+static auto log(TArgs &&...args) -> void {
     auto &cfg = get_config<Env, Ts...>();
     cfg.logger.template log<Env>(std::forward<TArgs>(args)...);
 }
@@ -89,8 +89,7 @@ ALWAYS_INLINE static auto log(TArgs &&...args) -> void {
     ((expr) ? void(0) : CIB_FATAL("Assertion failure: " #expr))
 
 namespace logging {
-template <typename Env, typename... Ts>
-ALWAYS_INLINE static auto log_version() -> void {
+template <typename Env, typename... Ts> static auto log_version() -> void {
     auto &l_cfg = get_config<Env, Ts...>();
     auto &v_cfg = ::version::config<Ts...>;
     if constexpr (requires {


### PR DESCRIPTION
Problem:
- The interplay of inlining and outlining is too complex. CE experiments show that the compiler does the right thing without it all.

Solution:
- Remove it all.