### PR TITLE
:art: Allow flow steps to override log environment

### DIFF
--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -2,9 +2,6 @@
 
 #include <flow/common.hpp>
 #include <flow/log.hpp>
-#include <log/env.hpp>
-#include <log/flavor.hpp>
-#include <log/level.hpp>
 #include <log/log.hpp>
 
 #include <stdx/ct_string.hpp>
@@ -22,13 +19,11 @@ template <stdx::ct_string FlowName, typename CTNode>
 constexpr auto run_func() -> void {
     if (CTNode::condition) {
         if constexpr (not FlowName.empty()) {
-            using log_spec_t =
-                decltype(get_log_spec<CTNode, log_spec_id_t<FlowName>>());
-            CIB_LOG_ENV(logging::get_level, log_spec_t::level,
-                        logging::get_flavor,
-                        stdx::type_identity<typename log_spec_t::flavor>{});
-            CIB_LOG("flow.{}({})", typename CTNode::type_t{},
-                    typename CTNode::name_t{});
+            logging::log<
+                decltype(get_log_env<CTNode, log_env_id_t<FlowName>>())>(
+                __FILE__, __LINE__,
+                sc::format("flow.{}({})"_sc, typename CTNode::type_t{},
+                           typename CTNode::name_t{}));
         }
         typename CTNode::func_t{}();
     }
@@ -65,21 +60,15 @@ template <stdx::ct_string Name, auto... FuncPtrs> struct inlined_func_list {
             stdx::ct_string_to_type<Name, sc::string_constant>();
 
         if constexpr (loggingEnabled) {
-            using log_spec_t = decltype(get_log_spec<inlined_func_list>());
-            CIB_LOG_ENV(logging::get_level, log_spec_t::level,
-                        logging::get_flavor,
-                        stdx::type_identity<typename log_spec_t::flavor>{});
-            CIB_LOG("flow.start({})", name);
+            logging::log<decltype(get_log_env<inlined_func_list>())>(
+                __FILE__, __LINE__, sc::format("flow.start({})"_sc, name));
         }
 
         (FuncPtrs(), ...);
 
         if constexpr (loggingEnabled) {
-            using log_spec_t = decltype(get_log_spec<inlined_func_list>());
-            CIB_LOG_ENV(logging::get_level, log_spec_t::level,
-                        logging::get_flavor,
-                        stdx::type_identity<typename log_spec_t::flavor>{});
-            CIB_LOG("flow.end({})", name);
+            logging::log<decltype(get_log_env<inlined_func_list>())>(
+                __FILE__, __LINE__, sc::format("flow.end({})"_sc, name));
         }
     }
 };

--- a/include/flow/log.hpp
+++ b/include/flow/log.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <log/env.hpp>
 #include <log/log.hpp>
 
 #include <stdx/ct_string.hpp>
@@ -7,30 +8,28 @@
 #include <type_traits>
 
 namespace flow {
-struct default_log_spec {
-    using flavor = logging::default_flavor_t;
-    constexpr static auto level = logging::level::TRACE;
-};
+using default_log_env =
+    logging::make_env_t<logging::get_level, logging::level::TRACE>;
 template <stdx::ct_string, typename...>
-constexpr auto log_spec = default_log_spec{};
+constexpr auto log_env = default_log_env{};
 
-template <stdx::ct_string Name> struct log_spec_id_t {
+template <stdx::ct_string Name> struct log_env_id_t {
     constexpr static auto ct_name = Name;
 };
 
-template <typename T, typename Fallback = log_spec_id_t<"default">,
+template <typename T, typename Fallback = log_env_id_t<"default">,
           typename... DummyArgs>
     requires(sizeof...(DummyArgs) == 0)
-constexpr static auto get_log_spec() {
-    using log_spec_t = decltype(log_spec<T::ct_name, DummyArgs...>);
-    if constexpr (std::is_same_v<log_spec_t, default_log_spec const>) {
+constexpr static auto get_log_env() {
+    using log_env_t = decltype(log_env<T::ct_name, DummyArgs...>);
+    if constexpr (std::is_same_v<log_env_t, default_log_env const>) {
         if constexpr (Fallback::ct_name == stdx::ct_string{"default"}) {
-            return log_spec<Fallback::ct_name, DummyArgs...>;
+            return log_env<Fallback::ct_name, DummyArgs...>;
         } else {
-            return get_log_spec<Fallback>();
+            return get_log_env<Fallback>();
         }
     } else {
-        return log_spec_t{};
+        return log_env_t{};
     }
 }
 } // namespace flow

--- a/test/flow/custom_log_levels.cpp
+++ b/test/flow/custom_log_levels.cpp
@@ -50,16 +50,19 @@ struct log_config {
 
 template <> inline auto logging::config<> = log_config{};
 
-struct user1_log_spec : flow::default_log_spec {
-    constexpr static auto level = logging::level::USER1;
-};
-struct user2_log_spec : flow::default_log_spec {
-    constexpr static auto level = logging::level::USER2;
-};
-struct info_log_spec : flow::default_log_spec {
-    constexpr static auto level = logging::level::INFO;
-};
-template <> constexpr auto flow::log_spec<"default"> = info_log_spec{};
+using user1_log_env =
+    logging::extend_env_t<flow::default_log_env, logging::get_level,
+                          logging::level::USER1>;
+
+using user2_log_env =
+    logging::extend_env_t<flow::default_log_env, logging::get_level,
+                          logging::level::USER2>;
+
+using info_log_env =
+    logging::extend_env_t<flow::default_log_env, logging::get_level,
+                          logging::level::INFO>;
+
+template <> constexpr auto flow::log_env<"default"> = info_log_env{};
 
 TEST_CASE("override default log level", "[flow_custom_log_levels]") {
     run_flow<TestFlowA, cib::exports<TestFlowA>,
@@ -70,8 +73,8 @@ TEST_CASE("override default log level", "[flow_custom_log_levels]") {
                   [](auto level) { CHECK(level == logging::level::INFO); });
 }
 
-template <> constexpr auto flow::log_spec<"B"> = user1_log_spec{};
-template <> constexpr auto flow::log_spec<"msB"> = user2_log_spec{};
+template <> constexpr auto flow::log_env<"B"> = user1_log_env{};
+template <> constexpr auto flow::log_env<"msB"> = user2_log_env{};
 
 TEST_CASE("override log level by name", "[flow_custom_log_levels]") {
     run_flow<TestFlowB, cib::exports<TestFlowB>,
@@ -83,7 +86,7 @@ TEST_CASE("override log level by name", "[flow_custom_log_levels]") {
     CHECK(log_calls[2] == logging::level::USER1);
 }
 
-template <> constexpr auto flow::log_spec<"C"> = user1_log_spec{};
+template <> constexpr auto flow::log_env<"C"> = user1_log_env{};
 
 TEST_CASE("default log spec for step will use overridden log spec for flow",
           "[flow_custom_log_levels]") {


### PR DESCRIPTION
Problem:
- Flow steps allow specialization of a log spec that can contain a custom level and flavor, but not the general mechanism available to log environments.

Solution:
- Change a flow log spec to a log environment.