### PR TITLE
:art: Show number of callbacks considered on match failure

### DIFF
--- a/include/msg/detail/indexed_handler_common.hpp
+++ b/include/msg/detail/indexed_handler_common.hpp
@@ -56,7 +56,9 @@ struct indexed_handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
             std::logical_or{}, false, callback_candidates);
 
         if (not handled) {
-            CIB_ERROR("None of the registered callbacks claimed this message.");
+            CIB_ERROR(
+                "None of the registered callbacks ({}) claimed this message.",
+                sc::uint_<stdx::tuple_size_v<Callbacks>>);
         }
         return handled;
     }

--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -2,6 +2,7 @@
 
 #include <log/log.hpp>
 #include <msg/handler_interface.hpp>
+#include <sc/fwd.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
 
@@ -27,7 +28,9 @@ struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
             },
             callbacks);
         if (!found_valid_callback) {
-            CIB_ERROR("None of the registered callbacks claimed this message:");
+            CIB_ERROR(
+                "None of the registered callbacks ({}) claimed this message:",
+                sc::uint_<stdx::tuple_size_v<Callbacks>>);
             stdx::for_each([&](auto &callback) { callback.log_mismatch(msg); },
                            callbacks);
         }

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -87,7 +87,7 @@ TEST_CASE("log mismatch when no match", "[handler]") {
     CHECK(not handler.handle(msg));
     CAPTURE(log_buffer);
     CHECK(log_buffer.find(
-              "None of the registered callbacks claimed this message") !=
+              "None of the registered callbacks (0) claimed this message") !=
           std::string::npos);
 }
 

--- a/test/msg/handler_builder.cpp
+++ b/test/msg/handler_builder.cpp
@@ -111,7 +111,7 @@ TEST_CASE("match output failure", "[handler_builder]") {
 
     CAPTURE(log_buffer);
     CHECK(log_buffer.find(
-              "None of the registered callbacks claimed this message") !=
+              "None of the registered callbacks (1) claimed this message") !=
           std::string::npos);
     CHECK(log_buffer.find("cb") != std::string::npos);
     CHECK(log_buffer.find("id (0x81) == 0x80") != std::string::npos);

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -113,8 +113,9 @@ TEST_CASE("match output failure", "[indexed_builder]") {
 
     CHECK(not cib::service<test_service>->handle(
         test_msg_t{"test_id_field"_field = 0x81}));
+    CAPTURE(log_buffer);
     CHECK(log_buffer.find(
-              "None of the registered callbacks claimed this message") !=
+              "None of the registered callbacks (1) claimed this message") !=
           std::string::npos);
 }
 


### PR DESCRIPTION
Problem:
- When a callback fails to match, it should be obvious if there were no callbacks considered.

Solution:
- Show the number of callbacks considered in the match error.

Note:
- For the non-indexed matcher, `log_mismatch` is called for each callback; however the absence of output when there are no callbacks still confuses folks.