### PR TITLE
Add message environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#ec95cd6")
+add_versioned_package("gh:intel/cpp-std-extensions#7725142")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#73d95bc")
 
 set(GEN_STR_CATALOG

--- a/include/log/env.hpp
+++ b/include/log/env.hpp
@@ -18,10 +18,22 @@ using cib_log_env_t = stdx::env<>;
         return stdx::extend_env_t<cib_log_env_t, __VA_ARGS__>{};               \
     }()) cib_log_env_t
 
+#define CIB_APPEND_LOG_ENV_DECL(E)                                             \
+    [[maybe_unused]] typedef decltype([] {                                     \
+        return stdx::append_env_t<cib_log_env_t, E>{};                         \
+    }()) cib_log_env_t
+
 #define CIB_LOG_ENV(...)                                                       \
     STDX_PRAGMA(diagnostic push)                                               \
     STDX_PRAGMA(diagnostic ignored "-Wshadow")                                 \
     CIB_LOG_ENV_DECL(__VA_ARGS__)                                              \
+    CIB_PRAGMA_SEMI                                                            \
+    STDX_PRAGMA(diagnostic pop)
+
+#define CIB_APPEND_LOG_ENV(E)                                                  \
+    STDX_PRAGMA(diagnostic push)                                               \
+    STDX_PRAGMA(diagnostic ignored "-Wshadow")                                 \
+    CIB_APPEND_LOG_ENV_DECL(E)                                                 \
     CIB_PRAGMA_SEMI                                                            \
     STDX_PRAGMA(diagnostic pop)
 

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -163,12 +163,13 @@ struct indexed_builder_base {
         }
 
         using msg_t = typename CB::msg_t;
+        CIB_LOG_ENV(logging::get_level, logging::level::INFO);
         if (msg::call_with_message<msg_t>(cb.matcher, data)) {
-            CIB_INFO(
-                "Incoming message matched [{}], because [{}] (collapsed to "
-                "[{}]), executing callback",
-                stdx::ct_string_to_type<cb.name, sc::string_constant>(),
-                orig_cb.matcher.describe(), cb.matcher.describe());
+            CIB_APPEND_LOG_ENV(typename msg_t::env_t);
+            CIB_LOG("Incoming message matched [{}], because [{}] (collapsed to "
+                    "[{}]), executing callback",
+                    stdx::ct_string_to_type<cb.name, sc::string_constant>(),
+                    orig_cb.matcher.describe(), cb.matcher.describe());
             msg::call_with_message<msg_t>(cb.callable, data, args...);
             return true;
         }


### PR DESCRIPTION
Add (optional) compile-time attributes for messages using `stdx::env`.
Use a message environment to control logging for a callback match.

Closes #684 
