### PR TITLE
:art: Refactor `msg::send` to use `incite_on`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
 add_versioned_package("gh:intel/cpp-std-extensions#7725142")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#6acab81")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#0525974")
 
 set(GEN_STR_CATALOG
     ${CMAKE_CURRENT_LIST_DIR}/tools/gen_str_catalog.py

--- a/test/msg/send.cpp
+++ b/test/msg/send.cpp
@@ -6,7 +6,7 @@
 #include <msg/service.hpp>
 
 #include <async/schedulers/trigger_manager.hpp>
-#include <async/start_detached.hpp>
+#include <async/sync_wait.hpp>
 
 #include <stdx/ct_conversions.hpp>
 #include <stdx/ct_string.hpp>
@@ -29,7 +29,7 @@ TEMPLATE_TEST_CASE("request-response", "[send]", decltype([] {})) {
              msg::then_receive<name, int>(
                  [&](auto recvd, auto x) { var = recvd + x; }, 17);
     CHECK(var == 0);
-    CHECK(async::start_detached_unstoppable(s));
+    CHECK(async::sync_wait(s));
     CHECK(var == 59);
 }
 
@@ -77,6 +77,6 @@ TEST_CASE("request-response through handler", "[send]") {
             0x80) |
         msg::then_receive<"cb", msg_view_t>(
             [&](auto v) { var = v.get("id"_f); });
-    CHECK(async::start_detached_unstoppable(s));
+    CHECK(async::sync_wait(s));
     CHECK(var == 0x80);
 }


### PR DESCRIPTION
Problem:
- `msg::send` rolls its own receiver and op state. The functionality is composable using `just | incite_on`.

Solution:
- Use the tools available in `async`.