### PR TITLE
:art: Unify message callbacks between indexed and normal handlers

### DIFF
--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -27,15 +27,16 @@ struct callback {
         return msg::call_with_message<Msg>(matcher, data);
     }
 
-    template <typename... Args>
+    template <stdx::ct_string Extra = "", typename... Args>
     [[nodiscard]] auto handle(auto const &data, Args &&...args) const -> bool {
         CIB_LOG_ENV(logging::get_level, logging::level::INFO);
         if (msg::call_with_message<Msg>(matcher, data)) {
             CIB_APPEND_LOG_ENV(typename Msg::env_t);
-            CIB_LOG("Incoming message matched [{}], because [{}], executing "
+            CIB_LOG("Incoming message matched [{}], because [{}]{}, executing "
                     "callback",
                     stdx::ct_string_to_type<Name, sc::string_constant>(),
-                    matcher.describe());
+                    matcher.describe(),
+                    stdx::ct_string_to_type<Extra, sc::string_constant>());
             msg::call_with_message<Msg>(callable, data,
                                         std::forward<Args>(args)...);
             return true;

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -179,7 +179,8 @@ TEST_CASE("build handler multi fields", "[indexed_builder]") {
     CHECK(callback_success);
     CHECK(not callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 
     callback_success = false;
     callback_success_single_field = false;
@@ -197,7 +198,8 @@ TEST_CASE("build handler multi fields", "[indexed_builder]") {
     CHECK(not callback_success);
     CHECK(callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 }
 
 namespace {
@@ -253,7 +255,8 @@ TEST_CASE("build handler not single field", "[indexed_builder]") {
         test_msg_t{"test_id_field"_field = 0x51});
     CHECK(callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 }
 
 namespace {
@@ -284,7 +287,8 @@ TEST_CASE("build handler not multi fields", "[indexed_builder]") {
     CHECK(callback_success);
     CHECK(not callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 
     log_buffer.clear();
     callback_success = false;
@@ -294,7 +298,8 @@ TEST_CASE("build handler not multi fields", "[indexed_builder]") {
     CHECK(not callback_success);
     CHECK(callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 
     log_buffer.clear();
     callback_success = false;
@@ -304,7 +309,8 @@ TEST_CASE("build handler not multi fields", "[indexed_builder]") {
     CHECK(callback_success);
     CHECK(callback_success_single_field);
     CAPTURE(log_buffer);
-    CHECK(log_buffer.find("(collapsed to [true])") != std::string::npos);
+    CHECK(log_buffer.find("because [true]") != std::string::npos);
+    CHECK(log_buffer.find("(collapsed by index from") != std::string::npos);
 }
 
 namespace {


### PR DESCRIPTION
Problem:
- The indexed handler callback duplicates code from the regular callback `handle` function, just for the purpose of adding a little to the logged message.

Solution:
- Allow an extra string to be passed to the regular callback `handle`.