### PR TITLE
:fire: Remove sc from log, msg and match libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ target_sources(
 
 add_library(cib_match INTERFACE)
 target_compile_features(cib_match INTERFACE cxx_std_20)
-target_link_libraries_system(cib_match INTERFACE cib_sc stdx)
+target_link_libraries_system(cib_match INTERFACE stdx)
 
 target_sources(
     cib_match
@@ -79,7 +79,7 @@ target_sources(
 
 add_library(cib_interrupt INTERFACE)
 target_compile_features(cib_interrupt INTERFACE cxx_std_20)
-target_link_libraries_system(cib_interrupt INTERFACE cib_sc concurrency stdx)
+target_link_libraries_system(cib_interrupt INTERFACE concurrency stdx)
 
 target_sources(
     cib_interrupt
@@ -123,7 +123,7 @@ target_sources(
 
 add_library(cib_log INTERFACE)
 target_compile_features(cib_log INTERFACE cxx_std_20)
-target_link_libraries_system(cib_log INTERFACE cib_sc stdx)
+target_link_libraries_system(cib_log INTERFACE stdx)
 
 target_sources(
     cib_log
@@ -149,7 +149,6 @@ target_link_libraries_system(
     cib_log
     cib_lookup
     cib_match
-    cib_sc
     stdx)
 
 target_sources(

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -57,17 +57,15 @@ library that contains all the functionality.
 [mermaid, format="svg"]
 ----
 flowchart BT
-  sc(cib_sc)
   nexus(cib_nexus)
+  sc(cib_sc)
+  log(cib_log)
+  match(cib_match)
   lookup(cib_lookup)
 
   flow(cib_flow) --> nexus
+  flow --> sc
   flow --> log
-
-  interrupt(cib_interrupt) --> sc
-  match(cib_match) --> sc
-  log(cib_log) --> sc
-
 
   log_fmt(cib_log_fmt) --> log
   msg(cib_msg) --> log & match
@@ -76,5 +74,6 @@ flowchart BT
   log_binary(cib_log_binary) --> msg
   seq(cib_seq) --> flow
 
-  cib --> interrupt & seq & log_fmt & log_binary
+  interrupt(cib_interrupt)
+  cib --> seq & log_fmt & log_binary & interrupt
 ----

--- a/include/flow/impl.hpp
+++ b/include/flow/impl.hpp
@@ -4,6 +4,7 @@
 #include <flow/log.hpp>
 #include <log/log.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/span.hpp>
 #include <stdx/type_traits.hpp>
@@ -22,8 +23,8 @@ constexpr auto run_func() -> void {
             logging::log<
                 decltype(get_log_env<CTNode, log_env_id_t<FlowName>>())>(
                 __FILE__, __LINE__,
-                sc::format("flow.{}({})"_sc, typename CTNode::type_t{},
-                           typename CTNode::name_t{}));
+                stdx::ct_format<"flow.{}({})">(stdx::cts_t<CTNode::ct_type>{},
+                                               stdx::cts_t<CTNode::ct_name>{}));
         }
         typename CTNode::func_t{}();
     }
@@ -56,19 +57,18 @@ template <stdx::ct_string Name, auto... FuncPtrs> struct inlined_func_list {
     __attribute__((flatten, always_inline)) auto operator()() const -> void {
         constexpr static bool loggingEnabled = not Name.empty();
 
-        constexpr auto name =
-            stdx::ct_string_to_type<Name, sc::string_constant>();
-
         if constexpr (loggingEnabled) {
             logging::log<decltype(get_log_env<inlined_func_list>())>(
-                __FILE__, __LINE__, sc::format("flow.start({})"_sc, name));
+                __FILE__, __LINE__,
+                stdx::ct_format<"flow.start({})">(stdx::cts_t<Name>{}));
         }
 
         (FuncPtrs(), ...);
 
         if constexpr (loggingEnabled) {
             logging::log<decltype(get_log_env<inlined_func_list>())>(
-                __FILE__, __LINE__, sc::format("flow.end({})"_sc, name));
+                __FILE__, __LINE__,
+                stdx::ct_format<"flow.end({})">(stdx::cts_t<Name>{}));
         }
     }
 };

--- a/include/flow/step.hpp
+++ b/include/flow/step.hpp
@@ -24,6 +24,7 @@ struct ct_node {
         decltype(stdx::ct_string_to_type<Name, sc::string_constant>());
     using func_t = F;
 
+    constexpr static auto ct_type = Type;
     constexpr static auto ct_name = Name;
     constexpr static auto identity = Identity;
     constexpr static auto condition = Cond{};

--- a/include/match/and.hpp
+++ b/include/match/and.hpp
@@ -6,7 +6,6 @@
 #include <match/implies.hpp>
 #include <match/simplify.hpp>
 #include <match/sum_of_products.hpp>
-#include <sc/string_constant.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -15,7 +14,7 @@
 namespace match {
 template <matcher, matcher> struct or_t;
 
-template <matcher L, matcher R> struct and_t : bin_op_t<and_t, " and ", L, R> {
+template <matcher L, matcher R> struct and_t : bin_op_t<and_t, "and", L, R> {
     [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
         return this->lhs(event) and this->rhs(event);
     }

--- a/include/match/bin_op.hpp
+++ b/include/match/bin_op.hpp
@@ -4,8 +4,8 @@
 #include <match/cost.hpp>
 #include <match/negate.hpp>
 #include <match/simplify.hpp>
-#include <sc/string_constant.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/type_traits.hpp>
 
@@ -32,16 +32,16 @@ struct bin_op_t {
 
   private:
     [[nodiscard]] constexpr auto form_description(auto const &f) const {
+        using namespace stdx::literals;
         auto const desc = [&]<matcher M>(M const &m) {
             if constexpr (stdx::is_specialization_of_v<M, Term>) {
                 return f(m);
             } else {
-                return "("_sc + f(m) + ")"_sc;
+                return "("_ctst + f(m) + ")"_ctst;
             }
         };
-        return desc(lhs) +
-               stdx::ct_string_to_type<OpName, sc::string_constant>() +
-               desc(rhs);
+        return stdx::ct_format<"{} {} {}">(desc(lhs), stdx::cts_t<OpName>{},
+                                           desc(rhs));
     }
 };
 

--- a/include/match/concepts.hpp
+++ b/include/match/concepts.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sc/fwd.hpp>
-
 #include <concepts>
 #include <type_traits>
 
@@ -12,7 +10,7 @@ concept matcher = requires { typename std::remove_cvref_t<T>::is_matcher; };
 template <typename T, typename Event>
 concept matcher_for = matcher<T> and requires(T const &t, Event const &e) {
     { t(e) } -> std::convertible_to<bool>;
-    { t.describe() } -> sc::sc_like;
-    { t.describe_match(e) } -> sc::sc_like;
+    t.describe();
+    t.describe_match(e);
 };
 } // namespace match

--- a/include/match/constant.hpp
+++ b/include/match/constant.hpp
@@ -3,7 +3,8 @@
 #include <match/concepts.hpp>
 #include <match/implies.hpp>
 #include <match/negate.hpp>
-#include <sc/string_constant.hpp>
+
+#include <stdx/ct_string.hpp>
 
 // NOTE: the implication overloads in this file are crafted to be high priority,
 // to avoid ambiguity. Hence always_t and never_t define friend overloads that
@@ -17,7 +18,10 @@ struct always_t {
     [[nodiscard]] constexpr auto operator()(auto const &) const -> bool {
         return true;
     }
-    [[nodiscard]] constexpr static auto describe() { return "true"_sc; }
+    [[nodiscard]] constexpr static auto describe() {
+        using namespace stdx::literals;
+        return "true"_ctst;
+    }
     [[nodiscard]] constexpr static auto describe_match(auto const &) {
         return describe();
     }
@@ -35,7 +39,10 @@ struct never_t {
     [[nodiscard]] constexpr auto operator()(auto const &) const -> bool {
         return false;
     }
-    [[nodiscard]] constexpr static auto describe() { return "false"_sc; }
+    [[nodiscard]] constexpr static auto describe() {
+        using namespace stdx::literals;
+        return "false"_ctst;
+    }
     [[nodiscard]] constexpr static auto describe_match(auto const &) {
         return describe();
     }

--- a/include/match/not.hpp
+++ b/include/match/not.hpp
@@ -6,9 +6,8 @@
 #include <match/negate.hpp>
 #include <match/simplify.hpp>
 #include <match/sum_of_products.hpp>
-#include <sc/format.hpp>
-#include <sc/string_constant.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <type_traits>
@@ -26,11 +25,11 @@ template <matcher M> struct not_t {
     }
 
     [[nodiscard]] constexpr auto describe() const {
-        return format("not ({})"_sc, m.describe());
+        return stdx::ct_format<"not ({})">(m.describe());
     }
 
     [[nodiscard]] constexpr auto describe_match(auto const &event) const {
-        return format("not ({})"_sc, m.describe_match(event));
+        return stdx::ct_format<"not ({})">(m.describe_match(event));
     }
 
   private:

--- a/include/match/or.hpp
+++ b/include/match/or.hpp
@@ -5,7 +5,6 @@
 #include <match/constant.hpp>
 #include <match/simplify.hpp>
 #include <match/sum_of_products.hpp>
-#include <sc/string_constant.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -14,7 +13,7 @@
 namespace match {
 template <matcher, matcher> struct and_t;
 
-template <matcher L, matcher R> struct or_t : bin_op_t<or_t, " or ", L, R> {
+template <matcher L, matcher R> struct or_t : bin_op_t<or_t, "or", L, R> {
     [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
         return this->lhs(event) or this->rhs(event);
     }

--- a/include/match/predicate.hpp
+++ b/include/match/predicate.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <match/concepts.hpp>
-#include <sc/string_constant.hpp>
 
 #include <stdx/concepts.hpp>
 #include <stdx/ct_string.hpp>
@@ -24,7 +23,7 @@ template <stdx::ct_string Name, stdx::callable P> struct predicate_t {
     }
 
     [[nodiscard]] constexpr static auto describe() {
-        return stdx::ct_string_to_type<Name, sc::string_constant>();
+        return stdx::cts_t<Name>{};
     }
 
     [[nodiscard]] constexpr static auto describe_match(auto const &) {

--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -34,9 +34,8 @@ struct callback {
             CIB_APPEND_LOG_ENV(typename Msg::env_t);
             CIB_LOG("Incoming message matched [{}], because [{}]{}, executing "
                     "callback",
-                    stdx::ct_string_to_type<Name, sc::string_constant>(),
-                    matcher.describe(),
-                    stdx::ct_string_to_type<Extra, sc::string_constant>());
+                    stdx::cts_t<Name>{}, matcher.describe(),
+                    stdx::cts_t<Extra>{});
             msg::call_with_message<Msg>(callable, data,
                                         std::forward<Args>(args)...);
             return true;
@@ -49,8 +48,7 @@ struct callback {
         {
             CIB_APPEND_LOG_ENV(typename Msg::env_t);
             CIB_LOG(
-                "    {} - F:({})",
-                stdx::ct_string_to_type<Name, sc::string_constant>(),
+                "    {} - F:({})", stdx::cts_t<Name>{},
                 msg::call_with_message<Msg>(
                     [&]<typename T>(T &&t) -> decltype(matcher.describe_match(
                                                std::forward<T>(t))) {

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -10,7 +10,6 @@
 #include <msg/callback.hpp>
 #include <msg/detail/separate_sum_terms.hpp>
 #include <msg/field_matchers.hpp>
-#include <sc/string_constant.hpp>
 
 #include <stdx/bitset.hpp>
 #include <stdx/compiler.hpp>

--- a/include/msg/detail/indexed_handler_common.hpp
+++ b/include/msg/detail/indexed_handler_common.hpp
@@ -6,6 +6,7 @@
 
 #include <stdx/compiler.hpp>
 #include <stdx/ranges.hpp>
+#include <stdx/utility.hpp>
 
 #include <functional>
 #include <iterator>
@@ -58,7 +59,7 @@ struct indexed_handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
         if (not handled) {
             CIB_ERROR(
                 "None of the registered callbacks ({}) claimed this message.",
-                sc::uint_<stdx::tuple_size_v<Callbacks>>);
+                stdx::ct<stdx::tuple_size_v<Callbacks>>());
         }
         return handled;
     }

--- a/include/msg/field_matchers.hpp
+++ b/include/msg/field_matchers.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <match/ops.hpp>
-#include <sc/format.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_format.hpp>
+#include <stdx/ct_string.hpp>
 #include <stdx/ranges.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/type_traits.hpp>
@@ -113,18 +114,19 @@ template <typename RelOp> constexpr auto inverse_op() {
 }
 
 template <typename RelOp> constexpr auto to_string() {
+    using namespace stdx::literals;
     if constexpr (std::same_as<RelOp, std::less<>>) {
-        return "<"_sc;
+        return "<"_ctst;
     } else if constexpr (std::same_as<RelOp, std::less_equal<>>) {
-        return "<="_sc;
+        return "<="_ctst;
     } else if constexpr (std::same_as<RelOp, std::greater<>>) {
-        return ">"_sc;
+        return ">"_ctst;
     } else if constexpr (std::same_as<RelOp, std::greater_equal<>>) {
-        return ">="_sc;
+        return ">="_ctst;
     } else if constexpr (std::same_as<RelOp, std::equal_to<>>) {
-        return "=="_sc;
+        return "=="_ctst;
     } else if constexpr (std::same_as<RelOp, std::not_equal_to<>>) {
-        return "!="_sc;
+        return "!="_ctst;
     }
 }
 } // namespace detail
@@ -139,17 +141,17 @@ struct rel_matcher_t {
     }
 
     [[nodiscard]] constexpr auto describe() const {
-        return format("{} {} 0x{:x}"_sc, Field::name,
-                      detail::to_string<RelOp>(),
-                      sc::uint_<static_cast<std::uint32_t>(ExpectedValue)>);
+        return stdx::ct_format<"{} {} 0x{:x}">(
+            Field::name, detail::to_string<RelOp>(),
+            stdx::ct<static_cast<std::uint32_t>(ExpectedValue)>());
     }
 
     template <typename MsgType>
     [[nodiscard]] constexpr auto describe_match(MsgType const &msg) const {
-        return format("{} (0x{:x}) {} 0x{:x}"_sc, Field::name,
-                      static_cast<std::uint32_t>(extract_field(msg)),
-                      detail::to_string<RelOp>(),
-                      sc::uint_<static_cast<std::uint32_t>(ExpectedValue)>);
+        return stdx::ct_format<"{} (0x{:x}) {} 0x{:x}">(
+            Field::name, static_cast<std::uint32_t>(extract_field(msg)),
+            detail::to_string<RelOp>(),
+            stdx::ct<static_cast<std::uint32_t>(ExpectedValue)>());
     }
 
   private:

--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -2,9 +2,9 @@
 
 #include <log/log.hpp>
 #include <msg/handler_interface.hpp>
-#include <sc/fwd.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
+#include <stdx/utility.hpp>
 
 namespace msg {
 
@@ -30,7 +30,7 @@ struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
         if (!found_valid_callback) {
             CIB_ERROR(
                 "None of the registered callbacks ({}) claimed this message:",
-                sc::uint_<stdx::tuple_size_v<Callbacks>>);
+                stdx::ct<stdx::tuple_size_v<Callbacks>>());
             stdx::for_each([&](auto &callback) { callback.log_mismatch(msg); },
                            callbacks);
         }

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -2,6 +2,9 @@
 
 #include <log/catalog/encoder.hpp>
 
+#include <stdx/ct_format.hpp>
+#include <stdx/ct_string.hpp>
+
 #include <conc/concurrency.hpp>
 
 #include <cstdint>
@@ -32,31 +35,33 @@ auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
-    cfg.logger.log_msg<log_env1>("A string with no placeholders"_sc);
+    cfg.logger.log_msg<log_env1>(
+        stdx::ct_format<"A string with no placeholders">());
 }
 
 auto log_one_ct_arg() -> void {
+    using namespace stdx::literals;
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env1>(
-        format("B string with {} placeholder"_sc, "one"_sc));
+        stdx::ct_format<"B string with {} placeholder">("one"_ctst));
 }
 
 auto log_one_32bit_rt_arg() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env1>(
-        format("C1 string with {} placeholder"_sc, std::int32_t{1}));
+        stdx::ct_format<"C1 string with {} placeholder">(std::int32_t{1}));
 }
 
 auto log_one_64bit_rt_arg() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env1>(
-        format("C2 string with {} placeholder"_sc, std::int64_t{1}));
+        stdx::ct_format<"C2 string with {} placeholder">(std::int64_t{1}));
 }
 
 auto log_one_formatted_rt_arg() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env1>(
-        format("C3 string with {:08x} placeholder"_sc, std::int32_t{1}));
+        stdx::ct_format<"C3 string with {:08x} placeholder">(std::int32_t{1}));
 }
 
 auto log_with_non_default_module_id() -> void {
@@ -64,7 +69,7 @@ auto log_with_non_default_module_id() -> void {
                      logging::get_module, "not default") {
         auto cfg = logging::binary::config{test_log_args_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
-            format("ModuleID string with {} placeholder"_sc, 1));
+            stdx::ct_format<"ModuleID string with {} placeholder">(1));
     }
 }
 
@@ -73,6 +78,6 @@ auto log_with_fixed_module_id() -> void {
                      logging::get_module, "fixed") {
         auto cfg = logging::binary::config{test_log_args_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
-            format("Fixed ModuleID string with {} placeholder"_sc, 1));
+            stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
     }
 }

--- a/test/log/catalog2a_lib.cpp
+++ b/test/log/catalog2a_lib.cpp
@@ -3,6 +3,8 @@
 
 #include <log/catalog/encoder.hpp>
 
+#include <stdx/ct_format.hpp>
+
 #include <conc/concurrency.hpp>
 
 #include <cstdint>
@@ -28,6 +30,6 @@ auto log_two_rt_args() -> void;
 auto log_two_rt_args() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env2a>(
-        format("D string with {} and {} placeholder"_sc, std::uint32_t{1},
-               std::int64_t{2}));
+        stdx::ct_format<"D string with {} and {} placeholder">(
+            std::uint32_t{1}, std::int64_t{2}));
 }

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -3,6 +3,8 @@
 
 #include <log/catalog/encoder.hpp>
 
+#include <stdx/ct_format.hpp>
+
 #include <conc/concurrency.hpp>
 
 #include <cstdint>
@@ -25,5 +27,5 @@ auto log_rt_enum_arg() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
-        format("E string with {} placeholder"_sc, E::value));
+        stdx::ct_format<"E string with {} placeholder">(E::value));
 }

--- a/test/log/encoder.cpp
+++ b/test/log/encoder.cpp
@@ -1,6 +1,7 @@
 #include <log/catalog/encoder.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_format.hpp>
 #include <stdx/span.hpp>
 
 #include <conc/concurrency.hpp>
@@ -164,7 +165,7 @@ TEST_CASE("log zero arguments", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::binary::config{
         test_log_args_destination<logging::level::TRACE>{}};
-    cfg.logger.log_msg<log_env>("Hello"_sc);
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"Hello">());
     CHECK(test_critical_section::count == 2);
 }
 
@@ -173,7 +174,7 @@ TEST_CASE("log one 32-bit argument", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::binary::config{
         test_log_args_destination<logging::level::TRACE, 42u, 17u>{}};
-    cfg.logger.log_msg<log_env>(format("{}"_sc, 17u));
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"{}">(17u));
     CHECK(test_critical_section::count == 2);
 }
 
@@ -184,7 +185,7 @@ TEST_CASE("log one 64-bit argument", "[mipi]") {
     auto cfg = logging::binary::config{
         test_log_args_destination<logging::level::TRACE, 42u, 0x90ab'cdefu,
                                   0x1234'5678u>{}};
-    cfg.logger.log_msg<log_env>(format("{}"_sc, x));
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"{}">(x));
     CHECK(test_critical_section::count == 2);
 }
 
@@ -193,7 +194,7 @@ TEST_CASE("log two arguments", "[mipi]") {
     test_critical_section::count = 0;
     auto cfg = logging::binary::config{
         test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{}};
-    cfg.logger.log_msg<log_env>(format("{} {}"_sc, 17u, 18u));
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"{} {}">(17u, 18u));
     CHECK(test_critical_section::count == 2);
 }
 
@@ -204,7 +205,7 @@ TEST_CASE("log more than two arguments", "[mipi]") {
         auto cfg = logging::binary::config{
             test_log_buf_destination<logging::level::TRACE, log_env, 42u, 17u,
                                      18u, 19u>{}};
-        cfg.logger.log_msg<log_env>(format("{} {} {}"_sc, 17u, 18u, 19u));
+        cfg.logger.log_msg<log_env>(stdx::ct_format<"{} {} {}">(17u, 18u, 19u));
         CHECK(test_critical_section::count == 2);
     }
     {
@@ -213,7 +214,7 @@ TEST_CASE("log more than two arguments", "[mipi]") {
             test_log_buf_destination<logging::level::TRACE, log_env, 42u, 17u,
                                      18u, 19u, 20u>{}};
         cfg.logger.log_msg<log_env>(
-            format("{} {} {} {}"_sc, 17u, 18u, 19u, 20u));
+            stdx::ct_format<"{} {} {} {}">(17u, 18u, 19u, 20u));
         CHECK(test_critical_section::count == 2);
     }
 }
@@ -226,7 +227,7 @@ TEST_CASE("log to multiple destinations", "[mipi]") {
         test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{},
         test_log_args_destination<logging::level::TRACE, 42u, 17u, 18u>{}};
 
-    cfg.logger.log_msg<log_env>(format("{} {}"_sc, 17u, 18u));
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"{} {}">(17u, 18u));
     CHECK(test_critical_section::count == 4);
     CHECK(num_log_args_calls == 2);
 }
@@ -312,6 +313,6 @@ TEST_CASE("log with overridden builder", "[mipi]") {
     auto cfg = logging::binary::config{
         test_catalog_args_destination<logging::level::TRACE>{}};
 
-    cfg.logger.log_msg<catalog_env>("Hello"_sc);
+    cfg.logger.log_msg<catalog_env>(stdx::ct_format<"Hello">());
     CHECK(num_catalog_args_calls == 1);
 }

--- a/test/log/fmt_logger.cpp
+++ b/test/log/fmt_logger.cpp
@@ -1,5 +1,6 @@
 #include <log/fmt/logger.hpp>
 
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
@@ -166,7 +167,7 @@ inline auto logging::config<secure_t> =
     logging::log<stdx::extend_env_t<                                           \
         cib_log_env_t, logging::get_level, logging::level::TRACE,              \
         logging::get_flavor, stdx::type_identity<secure_t>{}>>(                \
-        __FILE__, __LINE__, sc::format(MSG##_sc __VA_OPT__(, ) __VA_ARGS__))
+        __FILE__, __LINE__, stdx::ct_format<MSG>(__VA_ARGS__))
 
 TEST_CASE("logging can be flavored", "[fmt_logger]") {
     buffer.clear();

--- a/test/log/level.cpp
+++ b/test/log/level.cpp
@@ -1,9 +1,9 @@
 #include <log/catalog/encoder.hpp>
 #include <log/fmt/logger.hpp>
 #include <log/level.hpp>
-#include <sc/format.hpp>
 
 #include <stdx/ct_conversions.hpp>
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -59,7 +59,7 @@ TEST_CASE("mipi logger works with custom level", "[level]") {
     log_calls = 0;
     CIB_LOG_ENV(logging::get_level, custom_level::THE_ONE_LEVEL);
     auto cfg = logging::binary::config{test_destination{}};
-    cfg.logger.log_msg<cib_log_env_t>(sc::format("Hello {} {}"_sc, 17, 42));
+    cfg.logger.log_msg<cib_log_env_t>(stdx::ct_format<"Hello {} {}">(17, 42));
     CHECK(log_calls == 1);
 }
 

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -3,6 +3,7 @@
 
 #include <stdx/ct_string.hpp>
 #include <stdx/panic.hpp>
+#include <stdx/utility.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -74,10 +75,11 @@ TEST_CASE("CIB_FATAL calls compile-time panic", "[log]") {
 }
 
 TEST_CASE("CIB_FATAL pre-formats arguments passed to panic", "[log]") {
+    using namespace stdx::literals;
     reset_test_state();
     expected_why = "Hello 42";
 
-    CIB_FATAL("{} {}", "Hello"_sc, sc::int_<42>);
+    CIB_FATAL("{} {}", "Hello"_ctst, stdx::ct<42>());
     CAPTURE(buffer);
     CHECK(buffer.find("Hello 42") != std::string::npos);
     CHECK(panicked);

--- a/test/log/module_id.cpp
+++ b/test/log/module_id.cpp
@@ -1,5 +1,4 @@
 #include <log/log.hpp>
-#include <sc/string_constant.hpp>
 
 #include <stdx/ct_string.hpp>
 

--- a/test/match/and.cpp
+++ b/test/match/and.cpp
@@ -1,8 +1,8 @@
 #include "test_matcher.hpp"
 
 #include <match/ops.hpp>
-#include <sc/format.hpp>
-#include <sc/string_constant.hpp>
+
+#include <stdx/ct_format.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -16,31 +16,33 @@ TEST_CASE("AND fulfils matcher concept", "[match and]") {
 
 TEST_CASE("AND describes itself", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    static_assert(e.describe() == format("({}) and ({})"_sc,
-                                         test_m<0>{}.describe(),
-                                         test_m<1>{}.describe()));
+    static_assert(e.describe() ==
+                  stdx::ct_format<"({}) and ({})">(test_m<0>{}.describe(),
+                                                   test_m<1>{}.describe()));
 }
 
 TEST_CASE("AND description flattens", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    static_assert(e.describe() ==
-                  format("({}) and ({}) and ({})"_sc, test_m<0>{}.describe(),
-                         test_m<1>{}.describe(), test_m<2>{}.describe()));
+    static_assert(e.describe() == stdx::ct_format<"({}) and ({}) and ({})">(
+                                      test_m<0>{}.describe(),
+                                      test_m<1>{}.describe(),
+                                      test_m<2>{}.describe()));
 }
 
 TEST_CASE("AND describes a match", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    static_assert(e.describe_match(1) == format("({}) and ({})"_sc,
-                                                test_m<0>{}.describe_match(1),
-                                                test_m<1>{}.describe_match(1)));
+    static_assert(e.describe_match(1) == stdx::ct_format<"({}) and ({})">(
+                                             test_m<0>{}.describe_match(1),
+                                             test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("AND match description flattens", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    static_assert(e.describe_match(1) == format("({}) and ({}) and ({})"_sc,
-                                                test_m<0>{}.describe_match(1),
-                                                test_m<1>{}.describe_match(1),
-                                                test_m<2>{}.describe_match(1)));
+    static_assert(e.describe_match(1) ==
+                  stdx::ct_format<"({}) and ({}) and ({})">(
+                      test_m<0>{}.describe_match(1),
+                      test_m<1>{}.describe_match(1),
+                      test_m<2>{}.describe_match(1)));
 }
 
 TEST_CASE("AND matches correctly", "[match and]") {

--- a/test/match/constant.cpp
+++ b/test/match/constant.cpp
@@ -1,5 +1,7 @@
 #include <match/ops.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("constant fulfils matcher concepts", "[match constant]") {
@@ -12,17 +14,19 @@ TEST_CASE("constant fulfils matcher concepts", "[match constant]") {
 }
 
 TEST_CASE("constant describes itself", "[match constant]") {
+    using namespace stdx::literals;
     using A = decltype(match::always);
     using N = decltype(match::never);
-    static_assert(A{}.describe() == "true"_sc);
-    static_assert(N{}.describe() == "false"_sc);
+    static_assert(A{}.describe() == "true"_ctst);
+    static_assert(N{}.describe() == "false"_ctst);
 }
 
 TEST_CASE("constant describes a match", "[match not]") {
+    using namespace stdx::literals;
     using A = decltype(match::always);
     using N = decltype(match::never);
-    static_assert(A{}.describe_match(0) == "true"_sc);
-    static_assert(N{}.describe_match(0) == "false"_sc);
+    static_assert(A{}.describe_match(0) == "true"_ctst);
+    static_assert(N{}.describe_match(0) == "false"_ctst);
 }
 
 TEST_CASE("constant matches correctly", "[match constant]") {

--- a/test/match/not.cpp
+++ b/test/match/not.cpp
@@ -1,8 +1,8 @@
 #include "test_matcher.hpp"
 
 #include <match/ops.hpp>
-#include <sc/format.hpp>
-#include <sc/string_constant.hpp>
+
+#include <stdx/ct_format.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -17,13 +17,13 @@ TEST_CASE("NOT fulfils matcher concept", "[match not]") {
 TEST_CASE("NOT describes itself", "[match not]") {
     constexpr auto e = not test_matcher{};
     static_assert(e.describe() ==
-                  format("not ({})"_sc, test_m<0>{}.describe()));
+                  stdx::ct_format<"not ({})">(test_m<0>{}.describe()));
 }
 
 TEST_CASE("NOT describes a match", "[match not]") {
     constexpr auto e = not test_matcher{};
-    static_assert(e.describe_match(1) ==
-                  format("not ({})"_sc, test_matcher{}.describe_match(1)));
+    static_assert(e.describe_match(1) == stdx::ct_format<"not ({})">(
+                                             test_matcher{}.describe_match(1)));
 }
 
 TEST_CASE("NOT matches correctly", "[match not]") {

--- a/test/match/or.cpp
+++ b/test/match/or.cpp
@@ -1,8 +1,8 @@
 #include "test_matcher.hpp"
 
 #include <match/ops.hpp>
-#include <sc/format.hpp>
-#include <sc/string_constant.hpp>
+
+#include <stdx/ct_format.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -16,29 +16,31 @@ TEST_CASE("OR fulfils matcher concept", "[match or]") {
 
 TEST_CASE("OR describes itself", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    static_assert(e.describe() == format("({}) or ({})"_sc,
-                                         test_m<0>{}.describe(),
-                                         test_m<1>{}.describe()));
+    static_assert(e.describe() ==
+                  stdx::ct_format<"({}) or ({})">(test_m<0>{}.describe(),
+                                                  test_m<1>{}.describe()));
 }
 
 TEST_CASE("OR description flattens", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    static_assert(e.describe() ==
-                  format("({}) or ({}) or ({})"_sc, test_m<0>{}.describe(),
-                         test_m<1>{}.describe(), test_m<2>{}.describe()));
+    static_assert(e.describe() == stdx::ct_format<"({}) or ({}) or ({})">(
+                                      test_m<0>{}.describe(),
+                                      test_m<1>{}.describe(),
+                                      test_m<2>{}.describe()));
 }
 
 TEST_CASE("OR describes a match", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    static_assert(e.describe_match(1) == format("({}) or ({})"_sc,
-                                                test_m<0>{}.describe_match(1),
-                                                test_m<1>{}.describe_match(1)));
+    static_assert(e.describe_match(1) == stdx::ct_format<"({}) or ({})">(
+                                             test_m<0>{}.describe_match(1),
+                                             test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("OR match description flattens", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    static_assert(e.describe_match(1) == format("({}) or ({}) or ({})"_sc,
-                                                test_m<0>{}.describe_match(1),
+    static_assert(
+        e.describe_match(1) ==
+        stdx::ct_format<"({}) or ({}) or ({})">(test_m<0>{}.describe_match(1),
                                                 test_m<1>{}.describe_match(1),
                                                 test_m<2>{}.describe_match(1)));
 }

--- a/test/match/predicate.cpp
+++ b/test/match/predicate.cpp
@@ -1,6 +1,8 @@
 #include <match/concepts.hpp>
 #include <match/predicate.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("predicate fulfils matcher concepts", "[match predicate]") {
@@ -12,15 +14,17 @@ TEST_CASE("predicate fulfils matcher concepts", "[match predicate]") {
 }
 
 TEST_CASE("predicate describes itself", "[match predicate]") {
+    using namespace stdx::literals;
     [[maybe_unused]] constexpr auto p =
         match::predicate<"P">([](int) { return true; });
-    static_assert(p.describe() == "P"_sc);
+    static_assert(p.describe() == "P"_ctst);
 }
 
 TEST_CASE("unnamed predicate", "[match predicate]") {
+    using namespace stdx::literals;
     [[maybe_unused]] constexpr auto p =
         match::predicate([](int) { return true; });
-    static_assert(p.describe() == "<predicate>"_sc);
+    static_assert(p.describe() == "<predicate>"_ctst);
 }
 
 TEST_CASE("predicate matches correctly", "[match predicate]") {

--- a/test/match/test_matcher.hpp
+++ b/test/match/test_matcher.hpp
@@ -3,8 +3,9 @@
 #include <match/concepts.hpp>
 #include <match/implies.hpp>
 #include <match/negate.hpp>
-#include <sc/format.hpp>
-#include <sc/string_constant.hpp>
+
+#include <stdx/ct_format.hpp>
+#include <stdx/ct_string.hpp>
 
 #include <concepts>
 #include <functional>
@@ -16,9 +17,12 @@ struct test_matcher {
     [[nodiscard]] constexpr auto operator()(int i) const -> bool {
         return i == 1;
     }
-    [[nodiscard]] constexpr static auto describe() { return "test"_sc; }
+    [[nodiscard]] constexpr static auto describe() {
+        using namespace stdx::literals;
+        return "test"_ctst;
+    }
     [[nodiscard]] constexpr auto describe_match(int i) const {
-        return format("{}({} == 1)"_sc, (*this)(i) ? 'T' : 'F', i);
+        return stdx::ct_format<"{}({} == 1)">((*this)(i) ? 'T' : 'F', i);
     }
 };
 static_assert(match::matcher<test_matcher>);
@@ -40,15 +44,16 @@ template <typename RelOp> constexpr auto inverse_op() {
         return std::less{};
     }
 }
-template <typename RelOp> constexpr auto to_string() -> std::string_view {
+template <typename RelOp> constexpr auto to_string() {
+    using namespace stdx::literals;
     if constexpr (std::same_as<RelOp, std::less<>>) {
-        return "<";
+        return "<"_ctst;
     } else if constexpr (std::same_as<RelOp, std::less_equal<>>) {
-        return "<=";
+        return "<="_ctst;
     } else if constexpr (std::same_as<RelOp, std::greater<>>) {
-        return ">";
+        return ">"_ctst;
     } else if constexpr (std::same_as<RelOp, std::greater_equal<>>) {
-        return ">=";
+        return ">="_ctst;
     }
 }
 } // namespace detail
@@ -59,10 +64,14 @@ template <typename RelOp, auto Value> struct rel_matcher {
     [[nodiscard]] constexpr auto operator()(int i) const -> bool {
         return RelOp{}(i, Value);
     }
-    [[nodiscard]] constexpr static auto describe() { return "test"_sc; }
+    [[nodiscard]] constexpr static auto describe() {
+        using namespace stdx::literals;
+        return "test"_ctst;
+    }
     [[nodiscard]] constexpr auto describe_match(int i) const {
-        return format("{}({} {} {})"_sc, (*this)(i) ? 'T' : 'F', i,
-                      detail::to_string<RelOp>(), Value);
+        return stdx::ct_format<"{}({} {} {})">((*this)(i) ? 'T' : 'F', i,
+                                               detail::to_string<RelOp>(),
+                                               stdx::ct<Value>());
     }
 
   private:

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -3,6 +3,8 @@
 #include <msg/field.hpp>
 #include <msg/message.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
@@ -31,7 +33,10 @@ constexpr struct custom_match_t {
         return true;
     }
 
-    [[nodiscard]] constexpr static auto describe() { return "custom"_sc; }
+    [[nodiscard]] constexpr static auto describe() {
+        using namespace stdx::literals;
+        return "custom"_ctst;
+    }
 
     [[nodiscard]] constexpr static auto describe_match(msg::owning<msg_defn>) {
         return describe();

--- a/test/msg/indexed_callback.cpp
+++ b/test/msg/indexed_callback.cpp
@@ -4,7 +4,6 @@
 #include <msg/detail/separate_sum_terms.hpp>
 #include <msg/field_matchers.hpp>
 #include <msg/message.hpp>
-#include <sc/string_constant.hpp>
 
 #include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>


### PR DESCRIPTION
Problem:
- `sc` is superseded by stdx::ct_string functionality.

Solution:
- Remove dependency on `sc` for some libraries.

Note:
- For now, the flow library still uses `sc`.