### PR TITLE
:art: Allow extra arguments to CIB_FATAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#7725142")
+add_versioned_package("gh:intel/cpp-std-extensions#01be679")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#0525974")
 
 set(GEN_STR_CATALOG

--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -9,6 +9,9 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/panic.hpp>
+#if __cpp_pack_indexing < 202311L
+#include <stdx/tuple.hpp>
+#endif
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
 
@@ -74,14 +77,57 @@ static auto log(TArgs &&...args) -> void {
 #define CIB_ERROR(...)                                                         \
     CIB_LOG_WITH_LEVEL(logging::level::ERROR __VA_OPT__(, ) __VA_ARGS__)
 
+namespace logging::detail {
+template <stdx::ct_string Fmt, typename Env, typename F, typename L>
+[[nodiscard]] constexpr auto panic(F file, L line, auto &&...args) {
+    STDX_PRAGMA(diagnostic push)
+#ifdef __clang__
+    STDX_PRAGMA(diagnostic ignored "-Wunknown-warning-option")
+    STDX_PRAGMA(diagnostic ignored "-Wc++26-extensions")
+#endif
+
+    constexpr auto N = stdx::num_fmt_specifiers<Fmt>;
+    constexpr auto sz = sizeof...(args);
+    using env_t =
+        stdx::extend_env_t<Env, logging::get_level, logging::level::FATAL>;
+
+#if __cpp_pack_indexing >= 202311L
+    auto s = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        return stdx::ct_format<Fmt>(FWD(args...[Is])...);
+    }(std::make_index_sequence<N>{});
+    logging::log<env_t>(file, line, s);
+
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        stdx::panic<decltype(s.str)::value>(std::move(s).args,
+                                            FWD(args...[N + Is])...);
+    }(std::make_index_sequence<sz - N>{});
+#else
+    auto tup = stdx::make_tuple(FWD(args)...);
+    auto t = [&]<std::size_t... Is, std::size_t... Js>(
+                 std::index_sequence<Is...>, std::index_sequence<Js...>) {
+        return stdx::make_tuple(
+            stdx::make_tuple(stdx::get<Is>(std::move(tup))...),
+            stdx::make_tuple(stdx::get<sizeof...(Is) + Js>(std::move(tup))...));
+    }(std::make_index_sequence<N>{}, std::make_index_sequence<sz - N>{});
+
+    auto s = stdx::get<0>(std::move(t)).apply([](auto &&...fmt_args) {
+        return stdx::ct_format<Fmt>(FWD(fmt_args)...);
+    });
+    logging::log<env_t>(file, line, s);
+
+    stdx::get<1>(std::move(t)).apply([&](auto &&...extra_args) {
+        stdx::panic<decltype(s.str)::value>(std::move(s).args,
+                                            FWD(extra_args)...);
+    });
+#endif
+
+    STDX_PRAGMA(diagnostic pop)
+}
+} // namespace logging::detail
+
 #define CIB_FATAL(MSG, ...)                                                    \
-    [](auto &&s) {                                                             \
-        CIB_LOG_ENV(logging::get_level, logging::level::FATAL);                \
-        logging::log<cib_log_env_t>(__FILE__, __LINE__, s);                    \
-        FWD(s).args.apply([](auto &&...args) {                                 \
-            stdx::panic<decltype(s.str)::value>(FWD(args)...);                 \
-        });                                                                    \
-    }(stdx::ct_format<MSG>(__VA_ARGS__))
+    logging::detail::panic<MSG, cib_log_env_t>(                                \
+        __FILE__, __LINE__ __VA_OPT__(, ) __VA_ARGS__)
 
 #define CIB_ASSERT(expr)                                                       \
     ((expr) ? void(0) : CIB_FATAL("Assertion failure: " #expr))


### PR DESCRIPTION
Problem:
- `CIB_FATAL` expects log arguments to be interpolated into the format string, but there is no way to pass extra arguments along to `stdx::panic`.

Solution:
- Use the `format_result` tuple as the first argument to `stdx::panic`, and allow any further arguments passed to `CIB_FATAL` to be forwarded through.

Note:
- Splitting a tuple may be worthwhile to move to stdx in due course. Surprisingly I don't think we've had cause for it yet. And since clang backports pack indexing, when that is available we can use it without pulling in `stdx::tuple`.