### PR TITLE
:art: Pass extra args through `CIB_ASSERT`

### DIFF
--- a/include/log/log.hpp
+++ b/include/log/log.hpp
@@ -129,8 +129,10 @@ template <stdx::ct_string Fmt, typename Env, typename F, typename L>
     logging::detail::panic<MSG, cib_log_env_t>(                                \
         __FILE__, __LINE__ __VA_OPT__(, ) __VA_ARGS__)
 
-#define CIB_ASSERT(expr)                                                       \
-    ((expr) ? void(0) : CIB_FATAL("Assertion failure: " #expr))
+#define CIB_ASSERT(expr, ...)                                                  \
+    ((expr)                                                                    \
+         ? void(0)                                                             \
+         : CIB_FATAL("Assertion failure: " #expr __VA_OPT__(, ) __VA_ARGS__))
 
 namespace logging {
 template <typename Env, typename... Ts> static auto log_version() -> void {

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -110,3 +110,24 @@ TEST_CASE("CIB_FATAL passes extra arguments to panic", "[log]") {
     CHECK(buffer.find("Hello 42") != std::string::npos);
     CHECK(panicked);
 }
+
+TEST_CASE("CIB_ASSERT is equivalent to CIB_FATAL on failure", "[log]") {
+    reset_test_state();
+    expected_why = "Assertion failure: true == false";
+
+    CIB_ASSERT(true == false);
+    CAPTURE(buffer);
+    CHECK(buffer.find(expected_why) != std::string::npos);
+    CHECK(panicked);
+}
+
+TEST_CASE("CIB_ASSERT passes arguments to panic", "[log]") {
+    reset_test_state();
+    expected_why = "Assertion failure: true == false";
+    expected_args = std::make_tuple(stdx::make_tuple(), 42);
+
+    CIB_ASSERT(true == false, 42);
+    CAPTURE(buffer);
+    CHECK(buffer.find(expected_why) != std::string::npos);
+    CHECK(panicked);
+}


### PR DESCRIPTION
Problem:
- `CIB_FATAL` can pass extra args through to `panic` but `CIB_ASSERT` cannot.

Solution:
- Allow extra args passed through `CIB_ASSERT`.