### PR TITLE
:construction_worker: Add clang-20 support

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
   DEFAULT_CXX_STANDARD: 20
-  DEFAULT_LLVM_VERSION: 19
+  DEFAULT_LLVM_VERSION: 20
   DEFAULT_GCC_VERSION: 13
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [12, 13, 16, 17, 18, 19]
+        version: [12, 13, 16, 17, 18, 19, 20]
         cxx_standard: [20]
         stdlib: [libstdc++, libc++]
         build_type: [Debug]
@@ -36,6 +36,15 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             cxx_flags: "-stdlib=libstdc++"
+          - version: 20
+            compiler: clang
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20 all
+            toolchain_root: "/usr/lib/llvm-20"
+          - version: 20
+            compiler: clang
+            stdlib: libc++
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20 && sudo apt install -y libc++-20-dev libc++abi-20-dev
+            cxx_flags: "-stdlib=libc++"
           - version: 19
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 19 all
@@ -87,6 +96,8 @@ jobs:
             cxx: "g++-12"
             cxx_flags: ""
         exclude:
+          - compiler: gcc
+            version: 20
           - compiler: gcc
             version: 19
           - compiler: gcc
@@ -300,8 +311,8 @@ jobs:
           - compiler: clang
             cc: "clang"
             cxx: "clang++"
-            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 19
-            toolchain_root: "/usr/lib/llvm-19"
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20
+            toolchain_root: "/usr/lib/llvm-20"
           - compiler: gcc
             cc: "gcc-13"
             cxx: "g++-13"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#7c5b26c")
-add_versioned_package("gh:intel/cpp-std-extensions#01be679")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#0525974")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
+add_versioned_package("gh:intel/cpp-std-extensions#7e1cbc7")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#22c8006")
 
 set(GEN_STR_CATALOG
     ${CMAKE_CURRENT_LIST_DIR}/tools/gen_str_catalog.py

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to implement *cib* and others extend *cib*.
 ## Compiler/Standard support
 
 The main branch of *cib* currently uses C++20 and is tested with:
-- Clang 14 thru 19
+- Clang 14 thru 20
 - GCC 12 thru 13
 
 An older version of *cib* that uses C++17 is tagged at v1.7.0. It

--- a/include/cib/callback.hpp
+++ b/include/cib/callback.hpp
@@ -46,7 +46,7 @@ template <int NumFuncs = 0, typename... ArgTypes> struct builder {
     template <std::convertible_to<func_ptr_t>... Fs>
     [[nodiscard]] constexpr auto add(Fs &&...fs) const {
         builder<NumFuncs + sizeof...(Fs), ArgTypes...> cb;
-        auto i = std::size_t{};
+        auto i = 0;
         while (i < NumFuncs) {
             cb.funcs[i] = funcs[i];
             ++i;

--- a/include/log/catalog/mipi_builder.hpp
+++ b/include/log/catalog/mipi_builder.hpp
@@ -139,8 +139,8 @@ template <> struct builder<defn::normal_build_msg_t> {
         auto dest = &message.data()[header_size];
 
         auto const ver = stdx::to_le(static_cast<std::uint64_t>(Version));
-        dest = std::copy_n(stdx::bit_cast<std::uint8_t const *>(&ver),
-                           sizeof(std::uint64_t), dest);
+        std::memcpy(dest, &ver, sizeof(std::uint64_t));
+        dest += sizeof(std::uint64_t);
         std::copy_n(std::cbegin(S.value), S.size(), dest);
         return message;
     }

--- a/include/lookup/linear_search_lookup.hpp
+++ b/include/lookup/linear_search_lookup.hpp
@@ -6,7 +6,7 @@
 #include <stdx/compiler.hpp>
 
 #include <cstddef>
-#include <iterator>
+#include <type_traits>
 
 namespace lookup {
 template <std::size_t MaxSize> struct linear_search_lookup {
@@ -28,7 +28,7 @@ template <std::size_t MaxSize> struct linear_search_lookup {
   public:
     [[nodiscard]] CONSTEVAL static auto make(compile_time auto i) {
         if constexpr (constexpr auto input = i(); input.size <= MaxSize) {
-            return impl<decltype(input)>{input};
+            return impl<std::remove_cv_t<decltype(input)>>{input};
         } else {
             return strategy_failed_t{};
         }

--- a/include/seq/step.hpp
+++ b/include/seq/step.hpp
@@ -22,7 +22,7 @@ struct rt_step {
     log_func_ptr log_name{};
 
   private:
-    [[nodiscard]] constexpr friend auto operator==(rt_step const &,
+    [[nodiscard]] friend constexpr auto operator==(rt_step const &,
                                                    rt_step const &)
         -> bool = default;
 };


### PR DESCRIPTION
Problem:
- clang-20 is stable and not yet used to compile this repo.

Solution:
- Add clang-20 support to CI.