### PR TITLE
:sparkles: Add typo detection/fixing for string generation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -126,13 +126,13 @@ jobs:
       - name: Install build tools
         run: |
           ${{ matrix.install }}
-          sudo apt install -y ninja-build
+          sudo apt install -y ninja-build python3-venv python3-pip
 
-      - name: Install libclang for string catalog
+      - name: Install python requirements for string catalog
         run: |
           python3 -m venv ${{github.workspace}}/test_venv
           source ${{github.workspace}}/test_venv/bin/activate
-          pip install libclang
+          pip install -r ${{github.workspace}}/tools/requirements.txt
           echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
 
       - name: Restore CPM cache
@@ -212,7 +212,14 @@ jobs:
       - name: Install build tools
         run: |
           ${{ matrix.install }}
-          sudo apt install -y ninja-build
+          sudo apt install -y ninja-build python3-venv python3-pip
+
+      - name: Install python requirements for string catalog
+        run: |
+          python3 -m venv ${{github.workspace}}/test_venv
+          source ${{github.workspace}}/test_venv/bin/activate
+          pip install -r ${{github.workspace}}/tools/requirements.txt
+          echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
 
       - name: Restore CPM cache
         env:
@@ -332,7 +339,14 @@ jobs:
       - name: Install build tools
         run: |
           ${{ matrix.install }}
-          sudo apt install -y ninja-build
+          sudo apt install -y ninja-build python3-venv python3-pip
+
+      - name: Install python requirements for string catalog
+        run: |
+          python3 -m venv ${{github.workspace}}/test_venv
+          source ${{github.workspace}}/test_venv/bin/activate
+          pip install -r ${{github.workspace}}/tools/requirements.txt
+          echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
 
       - name: Restore CPM cache
         env:
@@ -378,7 +392,14 @@ jobs:
 
       - name: Install build tools
         run: |
-          sudo apt update && sudo apt install -y gcc-${{env.DEFAULT_GCC_VERSION}} g++-${{env.DEFAULT_GCC_VERSION}} ninja-build valgrind
+          sudo apt update && sudo apt install -y gcc-${{env.DEFAULT_GCC_VERSION}} g++-${{env.DEFAULT_GCC_VERSION}} ninja-build python3-venv python3-pip valgrind
+
+      - name: Install python requirements for string catalog
+        run: |
+          python3 -m venv ${{github.workspace}}/test_venv
+          source ${{github.workspace}}/test_venv/bin/activate
+          pip install -r ${{github.workspace}}/tools/requirements.txt
+          echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
 
       - name: Restore CPM cache
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@
 CMakePresets.json
 /toolchains
 mull.yml
-requirements.txt
+/requirements.txt
 docs/puppeteer_config.json

--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -10,7 +10,9 @@ function(gen_str_catalog)
         VERSION
         GUID_ID
         GUID_MASK
-        MODULE_ID_MAX)
+        MODULE_ID_MAX
+        STABLE_TYPO_DISTANCE
+        TYPO_DETECT)
     set(multiValueArgs INPUT_JSON INPUT_LIBS INPUT_HEADERS STABLE_JSON)
     cmake_parse_arguments(SC "${options}" "${oneValueArgs}" "${multiValueArgs}"
                           ${ARGN})
@@ -67,6 +69,13 @@ function(gen_str_catalog)
     if(SC_MODULE_ID_MAX)
         set(MODULE_ID_MAX_ARG --module_id_max ${SC_MODULE_ID_MAX})
     endif()
+    if(SC_STABLE_TYPO_DISTANCE)
+        set(STABLE_TYPO_DISTANCE_ARG --stable_typo_distance
+                                     ${SC_STABLE_TYPO_DISTANCE})
+    endif()
+    if(SC_TYPO_DETECT)
+        set(TYPO_DETECT_ARG --typo_detect ${SC_TYPO_DETECT})
+    endif()
     if(NOT SC_GEN_STR_CATALOG)
         set(SC_GEN_STR_CATALOG ${GEN_STR_CATALOG})
     endif()
@@ -79,7 +88,8 @@ function(gen_str_catalog)
             --cpp_output ${SC_OUTPUT_CPP} --json_output ${SC_OUTPUT_JSON}
             --xml_output ${SC_OUTPUT_XML} --stable_json ${STABLE_JSON}
             ${FORGET_ARG} ${CLIENT_NAME_ARG} ${VERSION_ARG} ${GUID_ID_ARG}
-            ${GUID_MASK_ARG} ${MODULE_ID_MAX_ARG}
+            ${GUID_MASK_ARG} ${MODULE_ID_MAX_ARG} ${STABLE_TYPO_DISTANCE_ARG}
+            ${TYPO_DETECT_ARG}
         DEPENDS ${UNDEFS} ${INPUT_JSON} ${SC_GEN_STR_CATALOG} ${STABLE_JSON}
         COMMAND_EXPAND_LISTS)
 

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -38,7 +38,11 @@ gen_str_catalog(
     GUID_ID
     "01234567-89ab-cdef-0123-456789abcdef"
     GUID_MASK
-    "ffffffff-ffff-ffff-ffff-ffffffffffff")
+    "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    STABLE_TYPO_DISTANCE
+    1
+    TYPO_DETECT
+    fix_quiet)
 
 add_library(catalog_strings STATIC ${CMAKE_CURRENT_BINARY_DIR}/strings.cpp)
 target_link_libraries(catalog_strings PUBLIC cib)

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -26,6 +26,7 @@ using log_env1 = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_zero_args() -> void;
+auto log_zero_args_typo() -> void;
 auto log_one_ct_arg() -> void;
 auto log_one_32bit_rt_arg() -> void;
 auto log_one_64bit_rt_arg() -> void;
@@ -37,6 +38,12 @@ auto log_zero_args() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"A string with no placeholders">());
+}
+
+auto log_zero_args_typo() -> void {
+    auto cfg = logging::binary::config{test_log_args_destination{}};
+    cfg.logger.log_msg<log_env1>(
+        stdx::ct_format<"A string with ni placeholders">());
 }
 
 auto log_one_ct_arg() -> void {

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -11,6 +11,7 @@ template <> inline auto conc::injected_policy<> = test_conc_policy{};
 extern int log_calls;
 extern std::uint32_t last_header;
 extern auto log_zero_args() -> void;
+extern auto log_zero_args_typo() -> void;
 extern auto log_one_ct_arg() -> void;
 extern auto log_one_32bit_rt_arg() -> void;
 extern auto log_one_64bit_rt_arg() -> void;
@@ -24,6 +25,16 @@ TEST_CASE("log zero arguments", "[catalog]") {
     test_critical_section::count = 0;
     log_calls = 0;
     log_zero_args();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+    // ID 42 is fixed by stable input
+    CHECK(last_header == ((42u << 4u) | 1u));
+}
+
+TEST_CASE("log fixed string with typo", "[catalog]") {
+    test_critical_section::count = 0;
+    log_calls = 0;
+    log_zero_args_typo();
     CHECK(test_critical_section::count == 2);
     CHECK(log_calls == 1);
     // ID 42 is fixed by stable input

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -118,12 +118,14 @@ typo_behavior = {
 }
 
 
-def handle_typo(stable_ids: dict, s: str, d: int, fn, gen) -> str:
+def handle_typo(stable_ids: dict, s: str, d: int, behavior: str, gen) -> str:
+    if behavior == "stable_only":
+        raise Exception(f"Error (using policy stable_only): \"{s}\" not found in stable strings.")
     if d != 0:
         from Levenshtein import distance
         for (i, value) in stable_ids.values():
             if distance(s, value) <= d:
-                if fn(s, value, i) == value:
+                if typo_behavior[behavior](s, value, i) == value:
                     return i
     return next(gen)
 
@@ -148,7 +150,7 @@ def read_input(filenames: list[str], stable_ids, typo_distance: int, typo_detect
         if key in stable_ids:
             return stable_ids[key][0]
         else:
-            return handle_typo(stable_ids, string_fn(obj), typo_distance, typo_behavior[typo_detect], gen)
+            return handle_typo(stable_ids, string_fn(obj), typo_distance, typo_detect, gen)
 
     stable_msg_ids, stable_module_ids = stable_ids
 
@@ -454,9 +456,9 @@ def parse_cmdline():
     parser.add_argument(
         "--typo_detect",
         type=str,
-        choices=["error", "warn", "fix", "fix_quiet"],
+        choices=["stable_only", "error", "warn", "fix", "fix_quiet"],
         default="error",
-        help="What to do when detecting a typo against stable strings.",
+        help="Policy to handle detecting a typo against stable strings.",
     )
     parser.add_argument(
         "--module_id_max",

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+levenshtein==0.27.1
+libclang==18.1.1


### PR DESCRIPTION
Problem:
- Stable strings can be fixed not just to be consistent from one build to the next, but because hardware expects certain string IDs or ranges. Accidentally having a string in code with a typo could result in another string ID being generated, with unfortunate results.

Solution:
- Allow typos to be detected and fixed.