### PR TITLE
:bug: Make `field_name` assignment operation `const`

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -128,7 +128,7 @@ template <stdx::ct_string Name> struct field_name {
     using name_t = stdx::cts_t<Name>;
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator)
-    template <typename T> constexpr auto operator=(T value) {
+    template <typename T> constexpr auto operator=(T value) const {
         return field_value<Name, T>{value};
     }
 

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -72,6 +72,15 @@ TEST_CASE("construct with field values", "[message]") {
     CHECK(0x0042'd00d == data[1]);
 }
 
+TEST_CASE("use field names as template args", "[message]") {
+    auto msg = []<auto F>() {
+        return test_msg{F = 0xba11};
+    }.template operator()<"f1"_field>();
+
+    auto const data = msg.data();
+    CHECK(0x8000'ba11 == data[0]);
+}
+
 TEST_CASE("construct with field defaults", "[message]") {
     test_msg msg{};
 


### PR DESCRIPTION
Problem:
- `field_name` is an empty type, and `field_name` assignment is an overloaded operator that returns a different type. Without making it `const`-qualified it cannot be called on template arguments.

Solution:
- `const`-qualify `field_name::operator=`.