### PR TITLE
:sparkles: Add fixed string IDs to logs

### DIFF
--- a/include/log/catalog/catalog.hpp
+++ b/include/log/catalog/catalog.hpp
@@ -4,7 +4,7 @@
 
 namespace sc {
 template <typename...> struct args;
-template <typename, typename T, T...> struct undefined;
+template <typename, auto, typename T, T...> struct undefined;
 
 template <typename> struct message {};
 template <typename> struct module_string {};

--- a/include/log/string_id.hpp
+++ b/include/log/string_id.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <log/env.hpp>
+
+#include <utility>
+
+namespace logging {
+[[maybe_unused]] constexpr inline struct get_string_id_t {
+    template <typename T>
+        requires true // more constrained
+    CONSTEVAL auto operator()(T &&t) const noexcept(
+        noexcept(std::forward<T>(t).query(std::declval<get_string_id_t>())))
+        -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+
+    CONSTEVAL auto operator()(auto &&) const -> int { return -1; }
+} get_string_id;
+} // namespace logging

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -32,6 +32,7 @@ auto log_one_64bit_rt_arg() -> void;
 auto log_one_formatted_rt_arg() -> void;
 auto log_with_non_default_module_id() -> void;
 auto log_with_fixed_module_id() -> void;
+auto log_with_fixed_string_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
@@ -79,5 +80,14 @@ auto log_with_fixed_module_id() -> void {
         auto cfg = logging::binary::config{test_log_args_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
+    }
+}
+
+auto log_with_fixed_string_id() -> void {
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_string_id, 1337) {
+        auto cfg = logging::binary::config{test_log_args_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            stdx::ct_format<"Fixed StringID string">());
     }
 }

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -19,6 +19,7 @@ extern auto log_two_rt_args() -> void;
 extern auto log_rt_enum_arg() -> void;
 extern auto log_with_non_default_module_id() -> void;
 extern auto log_with_fixed_module_id() -> void;
+extern auto log_with_fixed_string_id() -> void;
 
 TEST_CASE("log zero arguments", "[catalog]") {
     test_critical_section::count = 0;
@@ -98,4 +99,14 @@ TEST_CASE("log with fixed module id", "[catalog]") {
     log_with_fixed_module_id();
     CHECK((last_header & expected_static) == expected_static);
     CHECK((last_header & ~expected_static) == (17u << 16u));
+}
+
+TEST_CASE("log with fixed string id", "[catalog]") {
+    test_critical_section::count = 0;
+    log_calls = 0;
+    log_with_fixed_string_id();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+    // string ID 1337 is fixed by environment
+    CHECK(last_header == ((1337u << 4u) | 1u));
 }


### PR DESCRIPTION
Problem:
- Some hardware expects certain string IDs. When logging, it would be useful to be able to fix string IDs in code and have the tooling understand that.

Solution:
- Add the ability to specify string IDs in the logging environment.