### PR TITLE
:bug: Fix MIPI catalog builder using buffer

### DIFF
--- a/include/log/catalog/mipi_builder.hpp
+++ b/include/log/catalog/mipi_builder.hpp
@@ -103,7 +103,8 @@ template <> struct builder<defn::catalog_msg_t> {
         } else {
             constexpr auto header_size =
                 defn::catalog_msg_t::size<std::uint8_t>::value;
-            constexpr auto payload_size = (sizeof(id) + ... + sizeof(Ts));
+            constexpr auto payload_size =
+                (sizeof(id) + ... + sizeof(pack_as_t<Ts>));
             using storage_t =
                 std::array<std::uint8_t, header_size + payload_size>;
             return catalog_builder<storage_t>{}.template build<Level>(id, m,


### PR DESCRIPTION
Problem:
- The size of the catalog message payload is calculated incorrectly when using buffer storage. It assumes all the arguments are the same size as their MIPI packed types.

Solution:
- Calculate the size correctly using `pack_as_t` which reflects how the arguments are actually packed under the MIPI spec.