### PR TITLE
:sparkles: Add fixed module ID query to logging

### DIFF
--- a/include/log/catalog/encoder.hpp
+++ b/include/log/catalog/encoder.hpp
@@ -4,6 +4,7 @@
 #include <log/catalog/catalog.hpp>
 #include <log/log.hpp>
 #include <log/module.hpp>
+#include <log/module_id.hpp>
 #include <log/string_id.hpp>
 
 #include <stdx/ct_string.hpp>
@@ -31,10 +32,10 @@ constexpr static auto to_message() {
     }(std::make_integer_sequence<std::size_t, std::size(s)>{});
 }
 
-template <stdx::ct_string S> constexpr static auto to_module() {
+template <stdx::ct_string S, auto Id> constexpr static auto to_module() {
     constexpr auto s = std::string_view{S};
     return [&]<std::size_t... Is>(std::integer_sequence<std::size_t, Is...>) {
-        return sc::module_string<sc::undefined<void, -1, char, s[Is]...>>{};
+        return sc::module_string<sc::undefined<void, Id, char, s[Is]...>>{};
     }(std::make_integer_sequence<std::size_t, std::size(s)>{});
 }
 
@@ -91,7 +92,9 @@ template <typename Writer> struct log_handler {
                 detail::to_message_t<decltype(fr.str), logging::get_string_id(
                                                            Env{})>::template fn,
                 std::remove_cvref_t<Args>...>;
-            using Module = decltype(detail::to_module<get_module(Env{})>());
+            using Module =
+                decltype(detail::to_module<get_module(Env{}),
+                                           logging::get_module_id(Env{})>());
             w(builder.template build<L>(catalog<Message>(), module<Module>(),
                                         std::forward<Args>(args)...));
         });

--- a/include/log/module_id.hpp
+++ b/include/log/module_id.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <log/env.hpp>
+
+#include <utility>
+
+namespace logging {
+[[maybe_unused]] constexpr inline struct get_module_id_t {
+    template <typename T>
+        requires true // more constrained
+    CONSTEVAL auto operator()(T &&t) const noexcept(
+        noexcept(std::forward<T>(t).query(std::declval<get_module_id_t>())))
+        -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+
+    CONSTEVAL auto operator()(auto &&) const -> int { return -1; }
+} get_module_id;
+} // namespace logging

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -30,9 +30,10 @@ auto log_one_ct_arg() -> void;
 auto log_one_32bit_rt_arg() -> void;
 auto log_one_64bit_rt_arg() -> void;
 auto log_one_formatted_rt_arg() -> void;
-auto log_with_non_default_module_id() -> void;
-auto log_with_fixed_module_id() -> void;
+auto log_with_non_default_module() -> void;
+auto log_with_fixed_module() -> void;
 auto log_with_fixed_string_id() -> void;
+auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
@@ -65,7 +66,7 @@ auto log_one_formatted_rt_arg() -> void {
         stdx::ct_format<"C3 string with {:08x} placeholder">(std::int32_t{1}));
 }
 
-auto log_with_non_default_module_id() -> void {
+auto log_with_non_default_module() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_module, "not default") {
         auto cfg = logging::binary::config{test_log_args_destination{}};
@@ -74,7 +75,7 @@ auto log_with_non_default_module_id() -> void {
     }
 }
 
-auto log_with_fixed_module_id() -> void {
+auto log_with_fixed_module() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_module, "fixed") {
         auto cfg = logging::binary::config{test_log_args_destination{}};
@@ -89,5 +90,15 @@ auto log_with_fixed_string_id() -> void {
         auto cfg = logging::binary::config{test_log_args_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed StringID string">());
+    }
+}
+
+auto log_with_fixed_module_id() -> void {
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_module_id, 7, logging::get_module,
+                     "fixed_id") {
+        auto cfg = logging::binary::config{test_log_args_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
     }
 }

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -17,9 +17,10 @@ extern auto log_one_64bit_rt_arg() -> void;
 extern auto log_one_formatted_rt_arg() -> void;
 extern auto log_two_rt_args() -> void;
 extern auto log_rt_enum_arg() -> void;
-extern auto log_with_non_default_module_id() -> void;
-extern auto log_with_fixed_module_id() -> void;
+extern auto log_with_non_default_module() -> void;
+extern auto log_with_fixed_module() -> void;
 extern auto log_with_fixed_string_id() -> void;
+extern auto log_with_fixed_module_id() -> void;
 
 TEST_CASE("log zero arguments", "[catalog]") {
     test_critical_section::count = 0;
@@ -88,16 +89,17 @@ TEST_CASE("log module ids change", "[catalog]") {
     CHECK((last_header & expected_static) == expected_static);
 
     auto default_header = last_header;
-    log_with_non_default_module_id();
+    log_with_non_default_module();
     CHECK((last_header & expected_static) == expected_static);
     CHECK((last_header ^ default_header) == (1u << 16u));
 }
 
-TEST_CASE("log with fixed module id", "[catalog]") {
+TEST_CASE("log with stable module id", "[catalog]") {
     std::uint32_t expected_static = (1u << 24u) | (7u << 4u) | 3u;
 
-    log_with_fixed_module_id();
+    log_with_fixed_module();
     CHECK((last_header & expected_static) == expected_static);
+    // module ID 17 is fixed by stable_strings.json
     CHECK((last_header & ~expected_static) == (17u << 16u));
 }
 
@@ -109,4 +111,13 @@ TEST_CASE("log with fixed string id", "[catalog]") {
     CHECK(log_calls == 1);
     // string ID 1337 is fixed by environment
     CHECK(last_header == ((1337u << 4u) | 1u));
+}
+
+TEST_CASE("log with fixed module id", "[catalog]") {
+    std::uint32_t expected_static = (1u << 24u) | (7u << 4u) | 3u;
+
+    log_with_fixed_module_id();
+    CHECK((last_header & expected_static) == expected_static);
+    // module ID 7 is fixed by environment
+    CHECK((last_header & ~expected_static) == (7u << 16u));
 }

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -163,6 +163,8 @@ def assign_ids(messages, modules, stable_data):
     stable_msgs, stable_modules = stable_data
     for msg in filter(lambda m: m.id != -1, messages):
         stable_msgs[msg.key()] = msg
+    for module in filter(lambda m: m.id != -1, modules):
+        stable_modules[module.key()] = module
 
     old_msg_ids = set(m.id for m in stable_msgs.values())
     msg_id_gen = itertools.filterfalse(old_msg_ids.__contains__, itertools.count(0))


### PR DESCRIPTION
Problem:
- String IDs can be fixed in code, but module IDs cannot. It's only a matter of time before someone asks for that.

Solution:
- Allow module IDs to be fixed in code with a `get_module_id` query.

Note:
- If a module ID is fixed in an environment, it is advisable also to provide the module string. Otherwise it will be fixing the ID of the "default" module.