### PR TITLE
:sparkles: Add ability to log runtime floating-point values

### DIFF
--- a/include/log/catalog/arguments.hpp
+++ b/include/log/catalog/arguments.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <stdx/type_traits.hpp>
+
+#include <concepts>
+#include <cstdint>
+#include <type_traits>
+
+template <typename> struct encode_32;
+template <typename> struct encode_64;
+template <typename> struct encode_u32;
+template <typename> struct encode_u64;
+
+namespace logging {
+template <typename T>
+concept signed_packable = std::signed_integral<stdx::underlying_type_t<T>> and
+                          sizeof(T) <= sizeof(std::int64_t);
+
+template <typename T>
+concept unsigned_packable =
+    std::unsigned_integral<stdx::underlying_type_t<T>> and
+    sizeof(T) <= sizeof(std::int64_t);
+
+template <typename T>
+concept float_packable = std::floating_point<stdx::underlying_type_t<T>> and
+                         sizeof(T) <= sizeof(std::int64_t);
+
+template <typename T>
+concept packable =
+    signed_packable<T> or unsigned_packable<T> or float_packable<T>;
+
+template <typename T> struct encoding;
+
+template <signed_packable T> struct encoding<T> {
+    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::int32_t),
+                                         encode_32<T>, encode_64<T>>;
+    using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::int32_t),
+                                       std::int32_t, std::int64_t>;
+};
+
+template <unsigned_packable T> struct encoding<T> {
+    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
+                                         encode_u32<T>, encode_u64<T>>;
+    using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
+                                       std::uint32_t, std::uint64_t>;
+};
+
+template <float_packable T> struct encoding<T> {
+    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
+                                         encode_u32<T>, encode_u64<T>>;
+    using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
+                                       std::uint32_t, std::uint64_t>;
+};
+
+struct default_arg_packer {
+    template <packable T> using pack_as_t = typename encoding<T>::pack_t;
+    template <packable T> using encode_as_t = typename encoding<T>::encode_t;
+};
+} // namespace logging

--- a/include/log/catalog/builder.hpp
+++ b/include/log/catalog/builder.hpp
@@ -17,7 +17,7 @@ namespace logging::binary {
     }
 
     CONSTEVAL auto operator()(auto &&) const {
-        return logging::mipi::default_builder{};
+        return logging::mipi::default_builder<>{};
     }
 } get_builder;
 } // namespace logging::binary

--- a/include/log/catalog/catalog.hpp
+++ b/include/log/catalog/catalog.hpp
@@ -15,8 +15,3 @@ using module_id = std::uint32_t;
 
 template <typename> extern auto catalog() -> string_id;
 template <typename> extern auto module() -> module_id;
-
-template <typename> struct encode_32;
-template <typename> struct encode_64;
-template <typename> struct encode_u32;
-template <typename> struct encode_u64;

--- a/include/log/catalog/encoder.hpp
+++ b/include/log/catalog/encoder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <log/catalog/arguments.hpp>
 #include <log/catalog/builder.hpp>
 #include <log/catalog/catalog.hpp>
 #include <log/log.hpp>

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -22,10 +22,26 @@ using log_env2b = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_rt_enum_arg() -> void;
+auto log_rt_float_arg() -> void;
+auto log_rt_double_arg() -> void;
 
 auto log_rt_enum_arg() -> void {
     auto cfg = logging::binary::config{test_log_args_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
         stdx::ct_format<"E string with {} placeholder">(E::value));
+}
+
+auto log_rt_float_arg() -> void {
+    auto cfg = logging::binary::config{test_log_args_destination{}};
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Float string with {} placeholder">(3.14f));
+}
+
+auto log_rt_double_arg() -> void {
+    auto cfg = logging::binary::config{test_log_args_destination{}};
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Double string with {} placeholder">(3.14));
 }

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -21,6 +21,8 @@ extern auto log_with_non_default_module() -> void;
 extern auto log_with_fixed_module() -> void;
 extern auto log_with_fixed_string_id() -> void;
 extern auto log_with_fixed_module_id() -> void;
+extern auto log_rt_float_arg() -> void;
+extern auto log_rt_double_arg() -> void;
 
 TEST_CASE("log zero arguments", "[catalog]") {
     test_critical_section::count = 0;
@@ -54,6 +56,22 @@ TEST_CASE("log one 64-bit runtime argument", "[catalog]") {
     log_calls = 0;
     test_critical_section::count = 0;
     log_one_64bit_rt_arg();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+}
+
+TEST_CASE("log one float runtime argument", "[catalog]") {
+    log_calls = 0;
+    test_critical_section::count = 0;
+    log_rt_float_arg();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+}
+
+TEST_CASE("log one double runtime argument", "[catalog]") {
+    log_calls = 0;
+    test_critical_section::count = 0;
+    log_rt_double_arg();
     CHECK(test_critical_section::count == 2);
     CHECK(log_calls == 1);
 }

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -224,6 +224,7 @@ template<> auto module<{m.to_cpp_type()}>() -> module_id {{
 def write_cpp(messages, modules, extra_headers: list[str], filename: str):
     with open(filename, "w") as f:
         f.write("\n".join(f'#include "{h}"' for h in extra_headers))
+        f.write("\n#include <log/catalog/arguments.hpp>\n")
         f.write("\n#include <log/catalog/catalog.hpp>\n\n")
         cpp_catalog_defns = [make_cpp_catalog_defn(m) for m in messages]
         f.write("\n".join(cpp_catalog_defns))
@@ -357,9 +358,11 @@ def arg_printf_spec(arg: str):
         "encode_u32": "%u",
         "encode_64": "%lld",
         "encode_u64": "%llu",
+        "float": "%f",
+        "double": "%f",
     }
-    enc, _ = arg_type_encoding(arg)
-    return printf_dict.get(enc, "%d")
+    enc, t = arg_type_encoding(arg)
+    return printf_dict.get(t, printf_dict.get(enc, "%d"))
 
 
 def serialize_messages(


### PR DESCRIPTION
Problem:
- The binary logging does not support floating-point values (`float` and `double`).

Solution:
- Separate argument encoding/packing into a type so that it can be customized, and passed through builders.
- Allow `float` and `double` to encoded/packed.
- Support `%f` specifiers in JSON collateral.

Note:
- The MIPI-SysT spec v1.1 (section 9.2 table 16) specifies that a `float` is packed into 64 bits even when using 32-bit packing. This implementation packs a `float` into 32 bits by default.