### PR TITLE
:white_check_mark: Use `STATIC_REQUIRE` instead of `static_assert`

### DIFF
--- a/test/cib/builder_meta.cpp
+++ b/test/cib/builder_meta.cpp
@@ -18,13 +18,13 @@ struct test_builder_meta {
 } // namespace
 
 TEST_CASE("builder_meta concept") {
-    static_assert(cib::builder_meta<test_builder_meta>);
+    STATIC_REQUIRE(cib::builder_meta<test_builder_meta>);
 }
 
 TEST_CASE(
     "builder_meta builder and interface type traits return correct values") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<TestBuilder, cib::builder_t<test_builder_meta>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<TestInterface, cib::interface_t<test_builder_meta>>);
 }

--- a/test/flow/graph.cpp
+++ b/test/flow/graph.cpp
@@ -22,30 +22,30 @@ constexpr auto c = flow::action<"c">([] {});
 
 TEST_CASE("node size (empty graph)", "[graph]") {
     constexpr auto g = flow::graph<>{};
-    static_assert(node_size(g) == 0);
+    STATIC_REQUIRE(node_size(g) == 0);
 }
 
 TEST_CASE("node size (single action)", "[graph]") {
     constexpr auto g = flow::graph<>{}.add(*a >> *b);
-    static_assert(node_size(g) == 2);
+    STATIC_REQUIRE(node_size(g) == 2);
 }
 
 TEST_CASE("node size (overlapping actions)", "[graph]") {
     constexpr auto g = flow::graph<>{}.add(*a >> *b).add(b >> *c);
-    static_assert(node_size(g) == 3);
+    STATIC_REQUIRE(node_size(g) == 3);
 }
 
 TEST_CASE("edge size (empty flow)", "[graph]") {
     constexpr auto g = flow::graph<>{};
-    static_assert(edge_size(g) == 1);
+    STATIC_REQUIRE(edge_size(g) == 1);
 }
 
 TEST_CASE("edge size (single action)", "[graph]") {
     constexpr auto g = flow::graph<>{}.add(*a >> *b);
-    static_assert(edge_size(g) == 1);
+    STATIC_REQUIRE(edge_size(g) == 1);
 }
 
 TEST_CASE("edge size (overlapping actions)", "[graph]") {
     constexpr auto g = flow::graph<>{}.add(*a >> *b).add(*b >> *c);
-    static_assert(edge_size(g) == 2);
+    STATIC_REQUIRE(edge_size(g) == 2);
 }

--- a/test/flow/graph_builder.cpp
+++ b/test/flow/graph_builder.cpp
@@ -207,8 +207,8 @@ TEST_CASE("add dependency rhs", "[graph_builder]") {
 }
 
 TEST_CASE("reference vs non-reference", "[graph_builder]") {
-    static_assert(a.identity == flow::subgraph_identity::REFERENCE);
-    static_assert((*a).identity == flow::subgraph_identity::VALUE);
+    STATIC_REQUIRE(a.identity == flow::subgraph_identity::REFERENCE);
+    STATIC_REQUIRE((*a).identity == flow::subgraph_identity::VALUE);
 }
 
 TEST_CASE("reference in order with non-reference added twice",

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -15,8 +15,8 @@ struct without_enable_field {};
 } // namespace
 
 TEST_CASE("detect enable_field", "[dynamic controller]") {
-    static_assert(interrupt::has_enable_field<with_enable_field>);
-    static_assert(not interrupt::has_enable_field<without_enable_field>);
+    STATIC_REQUIRE(interrupt::has_enable_field<with_enable_field>);
+    STATIC_REQUIRE(not interrupt::has_enable_field<without_enable_field>);
 }
 
 namespace {

--- a/test/interrupt/irq_impl.cpp
+++ b/test/interrupt/irq_impl.cpp
@@ -11,7 +11,7 @@ using no_flows_config_t = interrupt::irq<42_irq, 17, interrupt::policies<>>;
 }
 
 TEST_CASE("config models concept", "[irq_impl]") {
-    static_assert(interrupt::irq_config<no_flows_config_t>);
+    STATIC_REQUIRE(interrupt::irq_config<no_flows_config_t>);
 }
 
 TEST_CASE("config can enable/disable its irq", "[irq_impl]") {
@@ -29,21 +29,21 @@ TEST_CASE("config enables its irq with priority", "[irq_impl]") {
 }
 
 TEST_CASE("config default status policy is clear first", "[irq_impl]") {
-    static_assert(std::is_same_v<no_flows_config_t::status_policy_t,
-                                 interrupt::clear_status_first>);
+    STATIC_REQUIRE(std::is_same_v<no_flows_config_t::status_policy_t,
+                                  interrupt::clear_status_first>);
 }
 
 TEST_CASE("config status policy can be supplied", "[irq_impl]") {
     using config_t =
         interrupt::irq<42_irq, 17,
                        interrupt::policies<interrupt::clear_status_last>>;
-    static_assert(std::is_same_v<config_t::status_policy_t,
-                                 interrupt::clear_status_last>);
+    STATIC_REQUIRE(std::is_same_v<config_t::status_policy_t,
+                                  interrupt::clear_status_last>);
 }
 
 TEST_CASE("impl models concept", "[irq_impl]") {
     using impl_t = interrupt::irq_impl<no_flows_config_t, test_nexus>;
-    static_assert(interrupt::irq_interface<impl_t>);
+    STATIC_REQUIRE(interrupt::irq_interface<impl_t>);
 }
 
 namespace {
@@ -54,7 +54,7 @@ using flow_config_t = interrupt::irq<17_irq, 42, interrupt::policies<>, T>;
 TEST_CASE("impl runs a flow", "[irq_impl]") {
     using impl_t =
         interrupt::irq_impl<flow_config_t<std::true_type>, test_nexus>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
     flow_run<std::true_type> = false;
     impl_t::run();
     CHECK(flow_run<std::true_type>);
@@ -73,12 +73,12 @@ TEST_CASE("impl can init its interrupt", "[irq_impl]") {
 TEST_CASE("impl is inactive when flow is not active", "[irq_impl]") {
     using impl_t =
         interrupt::irq_impl<flow_config_t<std::false_type>, test_nexus>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl is inactive when there are no flows", "[irq_impl]") {
     using impl_t = interrupt::irq_impl<no_flows_config_t, test_nexus>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl has no enable fields", "[irq_impl]") {

--- a/test/interrupt/policies.cpp
+++ b/test/interrupt/policies.cpp
@@ -5,14 +5,15 @@
 TEST_CASE("policies get", "[policies]") {
     using policies_t = interrupt::policies<interrupt::clear_status_first>;
     using default_policy_t = interrupt::clear_status_last;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(policies_t::get<interrupt::status_clear_policy,
                                                 default_policy_t>()),
                        interrupt::clear_status_first>);
-    static_assert(std::is_same_v<
-                  decltype(policies_t::get<interrupt::required_resources_policy,
-                                           default_policy_t>()),
-                  default_policy_t>);
+    STATIC_REQUIRE(
+        std::is_same_v<
+            decltype(policies_t::get<interrupt::required_resources_policy,
+                                     default_policy_t>()),
+            default_policy_t>);
 }
 
 TEST_CASE("clear status first policy", "[policies]") {
@@ -40,7 +41,7 @@ TEST_CASE("policy with required resources", "[policies]") {
     using policies_t = interrupt::policies<interrupt::required_resources<int>>;
     using P =
         decltype(policies_t::get<interrupt::required_resources_policy, void>());
-    static_assert(interrupt::policy<P>);
-    static_assert(
+    STATIC_REQUIRE(interrupt::policy<P>);
+    STATIC_REQUIRE(
         std::is_same_v<typename P::resources, interrupt::resource_list<int>>);
 }

--- a/test/interrupt/shared_irq_impl.cpp
+++ b/test/interrupt/shared_irq_impl.cpp
@@ -12,7 +12,7 @@ using no_flows_config_t =
 }
 
 TEST_CASE("config models concept", "[shared_irq_impl]") {
-    static_assert(interrupt::irq_config<no_flows_config_t>);
+    STATIC_REQUIRE(interrupt::irq_config<no_flows_config_t>);
 }
 
 TEST_CASE("config can enable/disable its irq", "[shared_irq_impl]") {
@@ -30,20 +30,20 @@ TEST_CASE("config enables its irq with priority", "[shared_irq_impl]") {
 }
 
 TEST_CASE("config default status policy is clear first", "[shared_irq_impl]") {
-    static_assert(std::is_same_v<no_flows_config_t::status_policy_t,
-                                 interrupt::clear_status_first>);
+    STATIC_REQUIRE(std::is_same_v<no_flows_config_t::status_policy_t,
+                                  interrupt::clear_status_first>);
 }
 
 TEST_CASE("config status policy can be supplied", "[shared_irq_impl]") {
     using config_t = interrupt::shared_irq<
         42_irq, 17, interrupt::policies<interrupt::clear_status_last>>;
-    static_assert(std::is_same_v<config_t::status_policy_t,
-                                 interrupt::clear_status_last>);
+    STATIC_REQUIRE(std::is_same_v<config_t::status_policy_t,
+                                  interrupt::clear_status_last>);
 }
 
 TEST_CASE("impl models concept", "[shared_irq_impl]") {
     using impl_t = interrupt::shared_irq_impl<no_flows_config_t>;
-    static_assert(interrupt::irq_interface<impl_t>);
+    STATIC_REQUIRE(interrupt::irq_interface<impl_t>);
 }
 
 namespace {
@@ -61,7 +61,7 @@ TEST_CASE("impl runs a flow", "[shared_irq_impl]") {
         interrupt::sub_irq_impl<sub_config_t<std::true_type, 0>, test_nexus>;
     using impl_t =
         interrupt::shared_irq_impl<flow_config_t<std::true_type>, sub_impl_t>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 
     enable_field_t<0>::value = true;
     status_field_t<0>::value = true;
@@ -88,7 +88,7 @@ TEST_CASE("impl is inactive when all subs are inactive", "[shared_irq_impl]") {
         interrupt::sub_irq_impl<sub_config_t<std::false_type, 0>, test_nexus>;
     using impl_t =
         interrupt::shared_irq_impl<flow_config_t<std::true_type>, sub_impl_t>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl is active when any sub is active", "[shared_irq_impl]") {
@@ -99,12 +99,12 @@ TEST_CASE("impl is active when any sub is active", "[shared_irq_impl]") {
     using impl_t =
         interrupt::shared_irq_impl<flow_config_t<std::true_type>,
                                    active_sub_impl_t, inactive_sub_impl_t>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 }
 
 TEST_CASE("impl is inactive when there are no subs", "[shared_irq_impl]") {
     using impl_t = interrupt::shared_irq_impl<flow_config_t<std::true_type>>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl enable fields are active sub enable fields",

--- a/test/interrupt/shared_sub_irq_impl.cpp
+++ b/test/interrupt/shared_sub_irq_impl.cpp
@@ -13,26 +13,26 @@ using no_flows_config_t =
 } // namespace
 
 TEST_CASE("config models concept", "[shared_sub_irq_impl]") {
-    static_assert(interrupt::sub_irq_config<no_flows_config_t>);
+    STATIC_REQUIRE(interrupt::sub_irq_config<no_flows_config_t>);
 }
 
 TEST_CASE("config default status policy is clear first",
           "[shared_sub_irq_impl]") {
-    static_assert(std::is_same_v<no_flows_config_t::status_policy_t,
-                                 interrupt::clear_status_first>);
+    STATIC_REQUIRE(std::is_same_v<no_flows_config_t::status_policy_t,
+                                  interrupt::clear_status_first>);
 }
 
 TEST_CASE("config status policy can be supplied", "[shared_sub_irq_impl]") {
     using config_t = interrupt::shared_sub_irq<
         enable_field_t<0>, status_field_t<0>,
         interrupt::policies<interrupt::clear_status_last>>;
-    static_assert(std::is_same_v<config_t::status_policy_t,
-                                 interrupt::clear_status_last>);
+    STATIC_REQUIRE(std::is_same_v<config_t::status_policy_t,
+                                  interrupt::clear_status_last>);
 }
 
 TEST_CASE("impl models concept", "[shared_sub_irq_impl]") {
     using impl_t = interrupt::shared_sub_irq_impl<no_flows_config_t>;
-    static_assert(interrupt::sub_irq_interface<impl_t>);
+    STATIC_REQUIRE(interrupt::sub_irq_interface<impl_t>);
 }
 
 namespace {
@@ -51,7 +51,7 @@ TEST_CASE("impl runs a flow", "[shared_sub_irq_impl]") {
         interrupt::sub_irq_impl<sub_config_t<std::true_type, 1>, test_nexus>;
     using impl_t = interrupt::shared_sub_irq_impl<flow_config_t<std::true_type>,
                                                   sub_impl_t>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 
     enable_field_t<0>::value = true;
     enable_field_t<1>::value = true;
@@ -68,7 +68,7 @@ TEST_CASE("impl is inactive when all subs are inactive",
         interrupt::sub_irq_impl<sub_config_t<std::false_type, 1>, test_nexus>;
     using impl_t = interrupt::shared_sub_irq_impl<flow_config_t<std::true_type>,
                                                   sub_impl_t>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl is active when any sub is active", "[shared_sub_irq_impl]") {
@@ -79,13 +79,13 @@ TEST_CASE("impl is active when any sub is active", "[shared_sub_irq_impl]") {
     using impl_t =
         interrupt::shared_sub_irq_impl<flow_config_t<std::true_type>,
                                        active_sub_impl_t, inactive_sub_impl_t>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 }
 
 TEST_CASE("impl is inactive when there are no subs", "[shared_sub_irq_impl]") {
     using impl_t =
         interrupt::shared_sub_irq_impl<flow_config_t<std::true_type>>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE(

--- a/test/interrupt/sub_irq_impl.cpp
+++ b/test/interrupt/sub_irq_impl.cpp
@@ -13,25 +13,25 @@ using no_flows_config_t =
 } // namespace
 
 TEST_CASE("config models concept", "[sub_irq_impl]") {
-    static_assert(interrupt::sub_irq_config<no_flows_config_t>);
+    STATIC_REQUIRE(interrupt::sub_irq_config<no_flows_config_t>);
 }
 
 TEST_CASE("config default status policy is clear first", "[sub_irq_impl]") {
-    static_assert(std::is_same_v<no_flows_config_t::status_policy_t,
-                                 interrupt::clear_status_first>);
+    STATIC_REQUIRE(std::is_same_v<no_flows_config_t::status_policy_t,
+                                  interrupt::clear_status_first>);
 }
 
 TEST_CASE("config status policy can be supplied", "[sub_irq_impl]") {
     using config_t =
         interrupt::sub_irq<enable_field_t<0>, status_field_t<0>,
                            interrupt::policies<interrupt::clear_status_last>>;
-    static_assert(std::is_same_v<config_t::status_policy_t,
-                                 interrupt::clear_status_last>);
+    STATIC_REQUIRE(std::is_same_v<config_t::status_policy_t,
+                                  interrupt::clear_status_last>);
 }
 
 TEST_CASE("impl models concept", "[sub_irq_impl]") {
     using impl_t = interrupt::sub_irq_impl<no_flows_config_t, test_nexus>;
-    static_assert(interrupt::sub_irq_interface<impl_t>);
+    STATIC_REQUIRE(interrupt::sub_irq_interface<impl_t>);
 }
 
 namespace {
@@ -43,7 +43,7 @@ using flow_config_t = interrupt::sub_irq<enable_field_t<0>, status_field_t<0>,
 TEST_CASE("impl runs a flow when enabled and status", "[sub_irq_impl]") {
     using impl_t =
         interrupt::sub_irq_impl<flow_config_t<std::true_type>, test_nexus>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 
     enable_field_t<0>::value = true;
     status_field_t<0>::value = true;
@@ -55,7 +55,7 @@ TEST_CASE("impl runs a flow when enabled and status", "[sub_irq_impl]") {
 TEST_CASE("impl doesn't run a flow when not enabled", "[sub_irq_impl]") {
     using impl_t =
         interrupt::sub_irq_impl<flow_config_t<std::true_type>, test_nexus>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 
     enable_field_t<0>::value = false;
     status_field_t<0>::value = true;
@@ -67,7 +67,7 @@ TEST_CASE("impl doesn't run a flow when not enabled", "[sub_irq_impl]") {
 TEST_CASE("impl doesn't run a flow when not status", "[sub_irq_impl]") {
     using impl_t =
         interrupt::sub_irq_impl<flow_config_t<std::true_type>, test_nexus>;
-    static_assert(impl_t::active);
+    STATIC_REQUIRE(impl_t::active);
 
     enable_field_t<0>::value = true;
     status_field_t<0>::value = false;
@@ -79,12 +79,12 @@ TEST_CASE("impl doesn't run a flow when not status", "[sub_irq_impl]") {
 TEST_CASE("impl is inactive when flow is not active", "[sub_irq_impl]") {
     using impl_t =
         interrupt::sub_irq_impl<flow_config_t<std::false_type>, test_nexus>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl is inactive when there are no flows", "[sub_irq_impl]") {
     using impl_t = interrupt::sub_irq_impl<no_flows_config_t, test_nexus>;
-    static_assert(not impl_t::active);
+    STATIC_REQUIRE(not impl_t::active);
 }
 
 TEST_CASE("impl reports one enable field when active", "[sub_irq_impl]") {

--- a/test/log/encoder.cpp
+++ b/test/log/encoder.cpp
@@ -68,7 +68,7 @@ struct test_conc_policy {
 int num_log_args_calls{};
 
 constexpr auto check = [](auto value, auto expected) {
-    static_assert(std::is_same_v<decltype(value), decltype(expected)>);
+    STATIC_REQUIRE(std::is_same_v<decltype(value), decltype(expected)>);
     CHECK(value == expected);
 };
 
@@ -155,31 +155,31 @@ template <> inline auto conc::injected_policy<> = test_conc_policy{};
 
 TEST_CASE("argument packing", "[mipi]") {
     using P = logging::default_arg_packer;
-    static_assert(std::same_as<P::pack_as_t<std::int32_t>, std::int32_t>);
-    static_assert(std::same_as<P::pack_as_t<std::uint32_t>, std::uint32_t>);
-    static_assert(std::same_as<P::pack_as_t<std::int64_t>, std::int64_t>);
-    static_assert(std::same_as<P::pack_as_t<std::uint64_t>, std::uint64_t>);
-    static_assert(std::same_as<P::pack_as_t<char>, std::int32_t>);
-    static_assert(std::same_as<P::pack_as_t<unsigned char>, std::uint32_t>);
-    static_assert(std::same_as<P::pack_as_t<float>, std::uint32_t>);
-    static_assert(std::same_as<P::pack_as_t<double>, std::uint64_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<std::int32_t>, std::int32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<std::uint32_t>, std::uint32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<std::int64_t>, std::int64_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<std::uint64_t>, std::uint64_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<char>, std::int32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<unsigned char>, std::uint32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<float>, std::uint32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<double>, std::uint64_t>);
 }
 
 TEST_CASE("argument encoding", "[mipi]") {
     using P = logging::default_arg_packer;
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<P::encode_as_t<std::int32_t>, encode_32<std::int32_t>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<P::encode_as_t<std::uint32_t>, encode_u32<std::uint32_t>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<P::encode_as_t<std::int64_t>, encode_64<std::int64_t>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<P::encode_as_t<std::uint64_t>, encode_u64<std::uint64_t>>);
-    static_assert(std::same_as<P::encode_as_t<char>, encode_32<char>>);
-    static_assert(
+    STATIC_REQUIRE(std::same_as<P::encode_as_t<char>, encode_32<char>>);
+    STATIC_REQUIRE(
         std::same_as<P::encode_as_t<unsigned char>, encode_u32<unsigned char>>);
-    static_assert(std::same_as<P::encode_as_t<float>, encode_u32<float>>);
-    static_assert(std::same_as<P::encode_as_t<double>, encode_u64<double>>);
+    STATIC_REQUIRE(std::same_as<P::encode_as_t<float>, encode_u32<float>>);
+    STATIC_REQUIRE(std::same_as<P::encode_as_t<double>, encode_u64<double>>);
 }
 
 TEST_CASE("log zero arguments", "[mipi]") {
@@ -330,7 +330,7 @@ template <logging::level Level> struct test_catalog_args_destination {
             expected_catalog32_header(Level, test_module_id);
         CHECK(header == Header);
         CHECK(id == test_string_id);
-        static_assert(sizeof...(Args) == 0);
+        STATIC_REQUIRE(sizeof...(Args) == 0);
         ++num_catalog_args_calls;
     }
 };

--- a/test/log/env.cpp
+++ b/test/log/env.cpp
@@ -28,23 +28,23 @@ namespace {
 } // namespace
 
 TEST_CASE("override environment", "[log_env]") {
-    static_assert(custom(cib_log_env_t{}) == 42);
+    STATIC_REQUIRE(custom(cib_log_env_t{}) == 42);
     CIB_LOG_ENV(custom, 1);
-    static_assert(custom(cib_log_env_t{}) == 1);
+    STATIC_REQUIRE(custom(cib_log_env_t{}) == 1);
     {
         CIB_LOG_ENV(custom, 2);
-        static_assert(custom(cib_log_env_t{}) == 2);
+        STATIC_REQUIRE(custom(cib_log_env_t{}) == 2);
     }
 }
 
 TEST_CASE("supplement environment", "[log_env]") {
     CIB_LOG_ENV(custom, 1);
-    static_assert(custom(cib_log_env_t{}) == 1);
+    STATIC_REQUIRE(custom(cib_log_env_t{}) == 1);
     {
         using namespace stdx::literals;
         CIB_LOG_ENV(logging::get_module, "hello");
-        static_assert(custom(cib_log_env_t{}) == 1);
-        static_assert(logging::get_module(cib_log_env_t{}) == "hello"_cts);
+        STATIC_REQUIRE(custom(cib_log_env_t{}) == 1);
+        STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "hello"_cts);
     }
 }
 
@@ -52,8 +52,8 @@ TEST_CASE("multi-value environment", "[log_env]") {
     CIB_LOG_ENV(custom, 1, logging::get_module, "hello");
 
     using namespace stdx::literals;
-    static_assert(custom(cib_log_env_t{}) == 1);
-    static_assert(logging::get_module(cib_log_env_t{}) == "hello"_cts);
+    STATIC_REQUIRE(custom(cib_log_env_t{}) == 1);
+    STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "hello"_cts);
 }
 
 namespace {

--- a/test/log/level.cpp
+++ b/test/log/level.cpp
@@ -22,8 +22,8 @@ std::string buffer{};
 
 namespace logging {
 template <custom_level L>
-[[nodiscard]] constexpr auto format_as(level_wrapper<L>) -> std::string_view {
-    static_assert(L == custom_level::THE_ONE_LEVEL);
+[[nodiscard]] auto format_as(level_wrapper<L>) -> std::string_view {
+    STATIC_REQUIRE(L == custom_level::THE_ONE_LEVEL);
     return "THE_ONE_LEVEL";
 }
 } // namespace logging

--- a/test/log/module_id.cpp
+++ b/test/log/module_id.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("default log module id", "[module_id]") {
     using namespace stdx::literals;
-    static_assert(logging::get_module(cib_log_env_t{}) == "default"_cts);
+    STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "default"_cts);
 }
 
 namespace ns {
@@ -16,14 +16,14 @@ CIB_LOG_MODULE("ns");
 
 TEST_CASE("log module id overridden at namespace scope", "[module_id]") {
     using namespace stdx::literals;
-    static_assert(logging::get_module(cib_log_env_t{}) == "ns"_cts);
+    STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "ns"_cts);
 }
 } // namespace ns
 
 struct S {
-    template <typename = void> constexpr static auto test() {
+    template <typename = void> static auto test() {
         using namespace stdx::literals;
-        static_assert(logging::get_module(cib_log_env_t{}) == "S"_cts);
+        STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "S"_cts);
     }
 
     CIB_LOG_MODULE("S");
@@ -33,10 +33,10 @@ TEST_CASE("log module id overridden at class scope", "[module_id]") {
     S::test();
 }
 
-template <typename = void> constexpr static auto func_test() {
+template <typename = void> auto func_test() {
     CIB_LOG_MODULE("fn");
     using namespace stdx::literals;
-    static_assert(logging::get_module(cib_log_env_t{}) == "fn"_cts);
+    STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "fn"_cts);
 }
 
 TEST_CASE("log module id overridden at function scope", "[module_id]") {
@@ -49,6 +49,6 @@ TEST_CASE("log module id overridden at statement scope", "[module_id]") {
     {
         CIB_LOG_MODULE("statement");
         using namespace stdx::literals;
-        static_assert(logging::get_module(cib_log_env_t{}) == "statement"_cts);
+        STATIC_REQUIRE(logging::get_module(cib_log_env_t{}) == "statement"_cts);
     }
 }

--- a/test/lookup/input.cpp
+++ b/test/lookup/input.cpp
@@ -8,7 +8,7 @@
 TEST_CASE("an input with no entries (type deduced)", "[input]") {
     constexpr auto input = lookup::input{1};
     CHECK(input.default_value == 1);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(input), lookup::input<int, int, 0> const>);
     CHECK(std::size(input) == 0);
 }
@@ -16,7 +16,7 @@ TEST_CASE("an input with no entries (type deduced)", "[input]") {
 TEST_CASE("an input with no entries (explicit types)", "[input]") {
     constexpr auto input = lookup::input<float, int>{1};
     CHECK(input.default_value == 1);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(input), lookup::input<float, int, 0> const>);
     CHECK(std::size(input) == 0);
 }
@@ -24,7 +24,7 @@ TEST_CASE("an input with no entries (explicit types)", "[input]") {
 TEST_CASE("an input with some entries (type deduced)", "[input]") {
     constexpr auto input = lookup::input(1, std::array{lookup::entry{1.0f, 2}});
     CHECK(input.default_value == 1);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(input), lookup::input<float, int, 1> const>);
     CHECK(std::size(input) == 1);
 }

--- a/test/lookup/linear_search.cpp
+++ b/test/lookup/linear_search.cpp
@@ -13,7 +13,7 @@ TEST_CASE("a lookup with more entries than allowed", "[linear search]") {
     constexpr auto lookup = LS::make(CX_VALUE(lookup::input<int, int, 3>{
         0, std::array{lookup::entry{1, 1}, lookup::entry{2, 2},
                       lookup::entry{3, 3}}}));
-    static_assert(lookup::strategy_failed(lookup));
+    STATIC_REQUIRE(lookup::strategy_failed(lookup));
 }
 
 TEST_CASE("a lookup with no entries", "[linear search]") {

--- a/test/lookup/lookup.cpp
+++ b/test/lookup/lookup.cpp
@@ -13,15 +13,15 @@
 TEST_CASE("a lookup with no entries", "[lookup]") {
     constexpr auto lookup =
         lookup::make(CX_VALUE(lookup::input<std::uint32_t>{}));
-    static_assert(lookup[0u] == 0u);
-    static_assert(lookup[42u] == 0u);
+    STATIC_REQUIRE(lookup[0u] == 0u);
+    STATIC_REQUIRE(lookup[42u] == 0u);
 }
 
 TEST_CASE("a lookup with no entries and non-zero default", "[lookup]") {
     constexpr auto lookup =
         lookup::make(CX_VALUE(lookup::input<std::uint32_t>{5u}));
-    static_assert(lookup[0u] == 5u);
-    static_assert(lookup[42u] == 5u);
+    STATIC_REQUIRE(lookup[0u] == 5u);
+    STATIC_REQUIRE(lookup[42u] == 5u);
 }
 
 namespace {
@@ -36,37 +36,37 @@ TEST_CASE("a linear lookup with non-integer values", "[lookup]") {
                 lookup::entry{42, bitset<32>{stdx::place_bits, 0}},
                 lookup::entry{89, bitset<32>{stdx::place_bits, 12, 3}}}}));
 
-    static_assert(lookup[0] == bitset<32>{});
-    static_assert(lookup[42] == bitset<32>{stdx::place_bits, 0});
-    static_assert(lookup[89] == bitset<32>{stdx::place_bits, 12, 3});
+    STATIC_REQUIRE(lookup[0] == bitset<32>{});
+    STATIC_REQUIRE(lookup[42] == bitset<32>{stdx::place_bits, 0});
+    STATIC_REQUIRE(lookup[89] == bitset<32>{stdx::place_bits, 12, 3});
 }
 
 TEST_CASE("a lookup with some entries", "[lookup]") {
     constexpr auto lookup = lookup::make(CX_VALUE(lookup::input<int, int, 3>{
         0, std::array{lookup::entry{0, 13}, lookup::entry{6, 42},
                       lookup::entry{89, 10}}}));
-    static_assert(lookup[0] == 13);
-    static_assert(lookup[1] == 0);
-    static_assert(lookup[5] == 0);
-    static_assert(lookup[6] == 42);
-    static_assert(lookup[7] == 0);
-    static_assert(lookup[88] == 0);
-    static_assert(lookup[89] == 10);
-    static_assert(lookup[90] == 0);
+    STATIC_REQUIRE(lookup[0] == 13);
+    STATIC_REQUIRE(lookup[1] == 0);
+    STATIC_REQUIRE(lookup[5] == 0);
+    STATIC_REQUIRE(lookup[6] == 42);
+    STATIC_REQUIRE(lookup[7] == 0);
+    STATIC_REQUIRE(lookup[88] == 0);
+    STATIC_REQUIRE(lookup[89] == 10);
+    STATIC_REQUIRE(lookup[90] == 0);
 }
 
 TEST_CASE("a lookup with some entries and non-zero default", "[lookup]") {
     constexpr auto lookup = lookup::make(CX_VALUE(lookup::input<int, int, 3>{
         5, std::array{lookup::entry{1, 13}, lookup::entry{6, 42},
                       lookup::entry{89, 10}}}));
-    static_assert(lookup[0] == 5);
-    static_assert(lookup[1] == 13);
-    static_assert(lookup[5] == 5);
-    static_assert(lookup[6] == 42);
-    static_assert(lookup[7] == 5);
-    static_assert(lookup[88] == 5);
-    static_assert(lookup[89] == 10);
-    static_assert(lookup[90] == 5);
+    STATIC_REQUIRE(lookup[0] == 5);
+    STATIC_REQUIRE(lookup[1] == 13);
+    STATIC_REQUIRE(lookup[5] == 5);
+    STATIC_REQUIRE(lookup[6] == 42);
+    STATIC_REQUIRE(lookup[7] == 5);
+    STATIC_REQUIRE(lookup[88] == 5);
+    STATIC_REQUIRE(lookup[89] == 10);
+    STATIC_REQUIRE(lookup[90] == 5);
 }
 
 TEST_CASE("a lookup with some sequential entries", "[lookup]") {
@@ -77,21 +77,21 @@ TEST_CASE("a lookup with some sequential entries", "[lookup]") {
                            lookup::entry{4u, 25u}, lookup::entry{5u, 82u},
                            lookup::entry{6u, 18u}, lookup::entry{7u, 87u},
                            lookup::entry{8u, 55u}, lookup::entry{9u, 11u}}}));
-    static_assert(lookup[0] == 13);
-    static_assert(lookup[1] == 42);
-    static_assert(lookup[2] == 10);
-    static_assert(lookup[3] == 76);
-    static_assert(lookup[4] == 25);
-    static_assert(lookup[5] == 82);
-    static_assert(lookup[6] == 18);
-    static_assert(lookup[7] == 87);
-    static_assert(lookup[8] == 55);
-    static_assert(lookup[9] == 11);
-    static_assert(lookup[10] == 1);
-    static_assert(lookup[11] == 1);
-    static_assert(lookup[12] == 1);
-    static_assert(lookup[13] == 1);
-    static_assert(lookup[14] == 1);
-    static_assert(lookup[15] == 1);
-    static_assert(lookup[4'000'000'000u] == 1);
+    STATIC_REQUIRE(lookup[0] == 13);
+    STATIC_REQUIRE(lookup[1] == 42);
+    STATIC_REQUIRE(lookup[2] == 10);
+    STATIC_REQUIRE(lookup[3] == 76);
+    STATIC_REQUIRE(lookup[4] == 25);
+    STATIC_REQUIRE(lookup[5] == 82);
+    STATIC_REQUIRE(lookup[6] == 18);
+    STATIC_REQUIRE(lookup[7] == 87);
+    STATIC_REQUIRE(lookup[8] == 55);
+    STATIC_REQUIRE(lookup[9] == 11);
+    STATIC_REQUIRE(lookup[10] == 1);
+    STATIC_REQUIRE(lookup[11] == 1);
+    STATIC_REQUIRE(lookup[12] == 1);
+    STATIC_REQUIRE(lookup[13] == 1);
+    STATIC_REQUIRE(lookup[14] == 1);
+    STATIC_REQUIRE(lookup[15] == 1);
+    STATIC_REQUIRE(lookup[4'000'000'000u] == 1);
 }

--- a/test/match/and.cpp
+++ b/test/match/and.cpp
@@ -10,56 +10,56 @@
 
 TEST_CASE("AND fulfils matcher concept", "[match and]") {
     using T = match::and_t<test_matcher, test_matcher>;
-    static_assert(match::matcher<T>);
-    static_assert(match::matcher_for<T, int>);
+    STATIC_REQUIRE(match::matcher<T>);
+    STATIC_REQUIRE(match::matcher_for<T, int>);
 }
 
 TEST_CASE("AND describes itself", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    static_assert(e.describe() ==
-                  stdx::ct_format<"({}) and ({})">(test_m<0>{}.describe(),
-                                                   test_m<1>{}.describe()));
+    STATIC_REQUIRE(e.describe() ==
+                   stdx::ct_format<"({}) and ({})">(test_m<0>{}.describe(),
+                                                    test_m<1>{}.describe()));
 }
 
 TEST_CASE("AND description flattens", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    static_assert(e.describe() == stdx::ct_format<"({}) and ({}) and ({})">(
-                                      test_m<0>{}.describe(),
-                                      test_m<1>{}.describe(),
-                                      test_m<2>{}.describe()));
+    STATIC_REQUIRE(e.describe() == stdx::ct_format<"({}) and ({}) and ({})">(
+                                       test_m<0>{}.describe(),
+                                       test_m<1>{}.describe(),
+                                       test_m<2>{}.describe()));
 }
 
 TEST_CASE("AND describes a match", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    static_assert(e.describe_match(1) == stdx::ct_format<"({}) and ({})">(
-                                             test_m<0>{}.describe_match(1),
-                                             test_m<1>{}.describe_match(1)));
+    STATIC_REQUIRE(e.describe_match(1) == stdx::ct_format<"({}) and ({})">(
+                                              test_m<0>{}.describe_match(1),
+                                              test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("AND match description flattens", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    static_assert(e.describe_match(1) ==
-                  stdx::ct_format<"({}) and ({}) and ({})">(
-                      test_m<0>{}.describe_match(1),
-                      test_m<1>{}.describe_match(1),
-                      test_m<2>{}.describe_match(1)));
+    STATIC_REQUIRE(e.describe_match(1) ==
+                   stdx::ct_format<"({}) and ({}) and ({})">(
+                       test_m<0>{}.describe_match(1),
+                       test_m<1>{}.describe_match(1),
+                       test_m<2>{}.describe_match(1)));
 }
 
 TEST_CASE("AND matches correctly", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(e), match::and_t<test_m<0>, test_m<1>> const>);
-    static_assert(e(1));
-    static_assert(not e(0));
+    STATIC_REQUIRE(e(1));
+    STATIC_REQUIRE(not e(0));
 }
 
 TEST_CASE("AND simplifies correctly", "[match and]") {
     constexpr auto e = test_matcher{} and test_matcher{};
-    static_assert(std::is_same_v<decltype(e), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), test_matcher const>);
 }
 
 TEST_CASE("all expression simplifies", "[match and]") {
     constexpr auto m = match::all(test_m<0>{}, test_m<1>{}, match::always);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(m), match::and_t<test_m<0>, test_m<1>> const>);
 }

--- a/test/match/constant.cpp
+++ b/test/match/constant.cpp
@@ -7,29 +7,29 @@
 TEST_CASE("constant fulfils matcher concepts", "[match constant]") {
     using A = decltype(match::always);
     using N = decltype(match::never);
-    static_assert(match::matcher<A>);
-    static_assert(match::matcher<N>);
-    static_assert(match::matcher_for<A, int>);
-    static_assert(match::matcher_for<N, int>);
+    STATIC_REQUIRE(match::matcher<A>);
+    STATIC_REQUIRE(match::matcher<N>);
+    STATIC_REQUIRE(match::matcher_for<A, int>);
+    STATIC_REQUIRE(match::matcher_for<N, int>);
 }
 
 TEST_CASE("constant describes itself", "[match constant]") {
     using namespace stdx::literals;
     using A = decltype(match::always);
     using N = decltype(match::never);
-    static_assert(A{}.describe() == "true"_ctst);
-    static_assert(N{}.describe() == "false"_ctst);
+    STATIC_REQUIRE(A{}.describe() == "true"_ctst);
+    STATIC_REQUIRE(N{}.describe() == "false"_ctst);
 }
 
 TEST_CASE("constant describes a match", "[match not]") {
     using namespace stdx::literals;
     using A = decltype(match::always);
     using N = decltype(match::never);
-    static_assert(A{}.describe_match(0) == "true"_ctst);
-    static_assert(N{}.describe_match(0) == "false"_ctst);
+    STATIC_REQUIRE(A{}.describe_match(0) == "true"_ctst);
+    STATIC_REQUIRE(N{}.describe_match(0) == "false"_ctst);
 }
 
 TEST_CASE("constant matches correctly", "[match constant]") {
-    static_assert(match::always(0));
-    static_assert(not match::never(0));
+    STATIC_REQUIRE(match::always(0));
+    STATIC_REQUIRE(not match::never(0));
 }

--- a/test/match/equivalence.cpp
+++ b/test/match/equivalence.cpp
@@ -11,27 +11,27 @@ TEST_CASE("less than", "[match equivalence]") {
     using T = match::and_t<test_m<0>, test_m<1>>;
     using U = test_m<0>;
     constexpr auto result = T{} <=> U{};
-    static_assert(result == std::partial_ordering::less);
-    static_assert(T{} < U{});
+    STATIC_REQUIRE(result == std::partial_ordering::less);
+    STATIC_REQUIRE(T{} < U{});
 }
 
 TEST_CASE("greater than", "[match equivalence]") {
     using T = match::or_t<test_m<0>, test_m<1>>;
     using U = test_m<0>;
     constexpr auto result = T{} <=> U{};
-    static_assert(result == std::partial_ordering::greater);
-    static_assert(T{} > U{});
+    STATIC_REQUIRE(result == std::partial_ordering::greater);
+    STATIC_REQUIRE(T{} > U{});
 }
 
 TEST_CASE("equivalent", "[match equivalence]") {
     using T = test_m<0>;
     constexpr auto result = T{} <=> T{};
-    static_assert(result == std::partial_ordering::equivalent);
+    STATIC_REQUIRE(result == std::partial_ordering::equivalent);
 }
 
 TEST_CASE("unorderable", "[match equivalence]") {
     using T = test_m<0>;
     using U = test_m<1>;
     constexpr auto result = T{} <=> U{};
-    static_assert(result == std::partial_ordering::unordered);
+    STATIC_REQUIRE(result == std::partial_ordering::unordered);
 }

--- a/test/match/implies.cpp
+++ b/test/match/implies.cpp
@@ -5,39 +5,39 @@
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("X => X", "[match implies]") {
-    static_assert(match::implies(test_matcher{}, test_matcher{}));
+    STATIC_REQUIRE(match::implies(test_matcher{}, test_matcher{}));
 }
 
 TEST_CASE("false => X", "[match implies]") {
-    static_assert(match::implies(match::never, test_matcher{}));
+    STATIC_REQUIRE(match::implies(match::never, test_matcher{}));
 }
 
 TEST_CASE("X => true", "[match implies]") {
-    static_assert(match::implies(test_matcher{}, match::always));
+    STATIC_REQUIRE(match::implies(test_matcher{}, match::always));
 }
 
 TEST_CASE("disambiguate: false => true", "[match implies]") {
-    static_assert(match::implies(match::never, match::always));
+    STATIC_REQUIRE(match::implies(match::never, match::always));
 }
 
 TEST_CASE("X => (X ∨ Y)", "[match implies]") {
-    static_assert(
+    STATIC_REQUIRE(
         match::implies(test_matcher{}, match::or_t<test_matcher, test_m<0>>{}));
 }
 
 TEST_CASE("recursive: X => (Y ∨ (X ∨ Z))", "[match implies]") {
-    static_assert(match::implies(
+    STATIC_REQUIRE(match::implies(
         test_matcher{},
         match::or_t<test_m<0>, match::or_t<test_matcher, test_m<1>>>{}));
 }
 
 TEST_CASE("(X ∧ Y) => X", "[match implies]") {
-    static_assert(match::implies(match::and_t<test_matcher, test_m<0>>{},
-                                 test_matcher{}));
+    STATIC_REQUIRE(match::implies(match::and_t<test_matcher, test_m<0>>{},
+                                  test_matcher{}));
 }
 
 TEST_CASE("recursive: (Y ∧ (X ∧ Z)) => X", "[match implies]") {
-    static_assert(match::implies(
+    STATIC_REQUIRE(match::implies(
         match::and_t<test_m<0>, match::and_t<test_matcher, test_m<1>>>{},
         test_matcher{}));
 }
@@ -45,5 +45,5 @@ TEST_CASE("recursive: (Y ∧ (X ∧ Z)) => X", "[match implies]") {
 TEST_CASE("ambiguity between X => or, and => X", "[match implies]") {
     using T1 = match::and_t<test_m<0>, test_m<1>>;
     using T2 = match::or_t<test_m<0>, test_m<1>>;
-    static_assert(match::implies(T1{}, T2{}));
+    STATIC_REQUIRE(match::implies(T1{}, T2{}));
 }

--- a/test/match/not.cpp
+++ b/test/match/not.cpp
@@ -10,28 +10,29 @@
 
 TEST_CASE("NOT fulfils matcher concept", "[match not]") {
     using T = decltype(not test_matcher{});
-    static_assert(match::matcher<T>);
-    static_assert(match::matcher_for<T, int>);
+    STATIC_REQUIRE(match::matcher<T>);
+    STATIC_REQUIRE(match::matcher_for<T, int>);
 }
 
 TEST_CASE("NOT describes itself", "[match not]") {
     constexpr auto e = not test_matcher{};
-    static_assert(e.describe() ==
-                  stdx::ct_format<"not ({})">(test_m<0>{}.describe()));
+    STATIC_REQUIRE(e.describe() ==
+                   stdx::ct_format<"not ({})">(test_m<0>{}.describe()));
 }
 
 TEST_CASE("NOT describes a match", "[match not]") {
     constexpr auto e = not test_matcher{};
-    static_assert(e.describe_match(1) == stdx::ct_format<"not ({})">(
-                                             test_matcher{}.describe_match(1)));
+    STATIC_REQUIRE(
+        e.describe_match(1) ==
+        stdx::ct_format<"not ({})">(test_matcher{}.describe_match(1)));
 }
 
 TEST_CASE("NOT matches correctly", "[match not]") {
-    static_assert((not test_matcher{})(0));
-    static_assert(not(not test_matcher{})(1));
+    STATIC_REQUIRE((not test_matcher{})(0));
+    STATIC_REQUIRE(not(not test_matcher{})(1));
 }
 
 TEST_CASE("NOT simplifies correctly", "[match not]") {
     constexpr auto e = not not test_matcher{};
-    static_assert(std::is_same_v<decltype(e), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), test_matcher const>);
 }

--- a/test/match/or.cpp
+++ b/test/match/or.cpp
@@ -10,35 +10,35 @@
 
 TEST_CASE("OR fulfils matcher concept", "[match or]") {
     using T = match::or_t<test_matcher, test_matcher>;
-    static_assert(match::matcher<T>);
-    static_assert(match::matcher_for<T, int>);
+    STATIC_REQUIRE(match::matcher<T>);
+    STATIC_REQUIRE(match::matcher_for<T, int>);
 }
 
 TEST_CASE("OR describes itself", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    static_assert(e.describe() ==
-                  stdx::ct_format<"({}) or ({})">(test_m<0>{}.describe(),
-                                                  test_m<1>{}.describe()));
+    STATIC_REQUIRE(e.describe() ==
+                   stdx::ct_format<"({}) or ({})">(test_m<0>{}.describe(),
+                                                   test_m<1>{}.describe()));
 }
 
 TEST_CASE("OR description flattens", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    static_assert(e.describe() == stdx::ct_format<"({}) or ({}) or ({})">(
-                                      test_m<0>{}.describe(),
-                                      test_m<1>{}.describe(),
-                                      test_m<2>{}.describe()));
+    STATIC_REQUIRE(e.describe() == stdx::ct_format<"({}) or ({}) or ({})">(
+                                       test_m<0>{}.describe(),
+                                       test_m<1>{}.describe(),
+                                       test_m<2>{}.describe()));
 }
 
 TEST_CASE("OR describes a match", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    static_assert(e.describe_match(1) == stdx::ct_format<"({}) or ({})">(
-                                             test_m<0>{}.describe_match(1),
-                                             test_m<1>{}.describe_match(1)));
+    STATIC_REQUIRE(e.describe_match(1) == stdx::ct_format<"({}) or ({})">(
+                                              test_m<0>{}.describe_match(1),
+                                              test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("OR match description flattens", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    static_assert(
+    STATIC_REQUIRE(
         e.describe_match(1) ==
         stdx::ct_format<"({}) or ({}) or ({})">(test_m<0>{}.describe_match(1),
                                                 test_m<1>{}.describe_match(1),
@@ -47,19 +47,19 @@ TEST_CASE("OR match description flattens", "[match or]") {
 
 TEST_CASE("OR matches correctly", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(e), match::or_t<test_m<0>, test_m<1>> const>);
-    static_assert(e(1));
-    static_assert(not e(0));
+    STATIC_REQUIRE(e(1));
+    STATIC_REQUIRE(not e(0));
 }
 
 TEST_CASE("OR simplifies correctly", "[match or]") {
     constexpr auto e = test_matcher{} and test_matcher{};
-    static_assert(std::is_same_v<decltype(e), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), test_matcher const>);
 }
 
 TEST_CASE("any expression simplifies", "[match or]") {
     constexpr auto m = match::any(test_m<0>{}, test_m<1>{}, match::never);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(m), match::or_t<test_m<0>, test_m<1>> const>);
 }

--- a/test/match/predicate.cpp
+++ b/test/match/predicate.cpp
@@ -8,27 +8,27 @@
 TEST_CASE("predicate fulfils matcher concepts", "[match predicate]") {
     [[maybe_unused]] constexpr auto p =
         match::predicate<"P">([](int) { return true; });
-    static_assert(match::matcher<decltype(p)>);
-    static_assert(match::matcher_for<decltype(p), int>);
-    static_assert(not match::matcher_for<decltype(p), decltype([] {})>);
+    STATIC_REQUIRE(match::matcher<decltype(p)>);
+    STATIC_REQUIRE(match::matcher_for<decltype(p), int>);
+    STATIC_REQUIRE(not match::matcher_for<decltype(p), decltype([] {})>);
 }
 
 TEST_CASE("predicate describes itself", "[match predicate]") {
     using namespace stdx::literals;
     [[maybe_unused]] constexpr auto p =
         match::predicate<"P">([](int) { return true; });
-    static_assert(p.describe() == "P"_ctst);
+    STATIC_REQUIRE(p.describe() == "P"_ctst);
 }
 
 TEST_CASE("unnamed predicate", "[match predicate]") {
     using namespace stdx::literals;
     [[maybe_unused]] constexpr auto p =
         match::predicate([](int) { return true; });
-    static_assert(p.describe() == "<predicate>"_ctst);
+    STATIC_REQUIRE(p.describe() == "<predicate>"_ctst);
 }
 
 TEST_CASE("predicate matches correctly", "[match predicate]") {
     constexpr auto p = match::predicate([](int i) { return i % 2 == 0; });
-    static_assert(p(0));
-    static_assert(not p(1));
+    STATIC_REQUIRE(p(0));
+    STATIC_REQUIRE(not p(1));
 }

--- a/test/match/simplify_and.cpp
+++ b/test/match/simplify_and.cpp
@@ -11,66 +11,66 @@ using namespace match;
 TEST_CASE("Idempotence: X ∧ X -> X", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Right complementation: X ∧ ¬X -> F", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, not_t<test_matcher>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), never_t const>);
 }
 
 TEST_CASE("Left complementation: ¬X ∧ X -> F", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, not_t<test_matcher>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), never_t const>);
 }
 
 TEST_CASE("Right identity: X ∧ T -> X", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, always_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Left identity: T ∧ X -> X", "[match simplify and]") {
     constexpr auto e = and_t<always_t, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Right annihilation: X ∧ F -> F", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, never_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), never_t const>);
 }
 
 TEST_CASE("Left annihilation: F ∧ X -> F", "[match simplify and]") {
     constexpr auto e = and_t<never_t, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), never_t const>);
 }
 
 TEST_CASE("Left absorption: X ∧ (X ∨ Y) -> X", "[match simplify and]") {
     constexpr auto e = and_t<test_m<0>, or_t<test_m<0>, test_m<1>>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_m<0> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_m<0> const>);
 }
 
 TEST_CASE("Right absorption: (X ∨ Y) ∧ X -> X", "[match simplify and]") {
     constexpr auto e = and_t<or_t<test_m<0>, test_m<1>>, test_m<0>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_m<0> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_m<0> const>);
 }
 
 TEST_CASE("De Morgan's Law: ¬X ∧ ¬Y -> ¬(X ∨ Y)", "[match simplify and]") {
     constexpr auto e = and_t<not_t<test_m<0>>, not_t<test_m<1>>>{};
     constexpr auto s = simplify(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s), not_t<or_t<test_m<0>, test_m<1>>> const>);
 }
 
 TEST_CASE("AND simplifies recursively", "[match simplify and]") {
     constexpr auto e = and_t<test_matcher, and_t<test_matcher, always_t>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }

--- a/test/match/simplify_custom.cpp
+++ b/test/match/simplify_custom.cpp
@@ -11,22 +11,22 @@ using namespace match;
 
 TEST_CASE("custom matcher simplifies (NOT)", "[match simplify]") {
     constexpr auto e = not rel_matcher<std::less<>, 5>{};
-    static_assert(std::is_same_v<decltype(e),
-                                 rel_matcher<std::greater_equal<>, 5> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e),
+                                  rel_matcher<std::greater_equal<>, 5> const>);
 }
 
 TEST_CASE("custom matcher simplifies (AND negative terms)",
           "[match simplify]") {
     constexpr auto e = rel_matcher<std::less<>, 5>{} and
                        rel_matcher<std::greater_equal<>, 5>{};
-    static_assert(std::is_same_v<decltype(e), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), never_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (AND subsumptive terms)",
           "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} and rel_matcher<std::less<>, 3>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(e), rel_matcher<std::less<>, 3> const>);
 }
 
@@ -34,7 +34,7 @@ TEST_CASE("custom matcher simplifies (AND exclusive terms)",
           "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} and rel_matcher<std::greater<>, 4>{};
-    static_assert(std::is_same_v<decltype(e), match::never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), match::never_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (exclusive terms inside AND)",
@@ -42,26 +42,26 @@ TEST_CASE("custom matcher simplifies (exclusive terms inside AND)",
     constexpr auto e = rel_matcher<std::less<>, 5>{} and
                        rel_matcher<std::less<>, 10>{} and
                        rel_matcher<std::greater<>, 4>{};
-    static_assert(std::is_same_v<decltype(e), match::never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), match::never_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (OR)", "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} or rel_matcher<std::greater_equal<>, 5>{};
-    static_assert(std::is_same_v<decltype(e), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), always_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (OR negative terms)", "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} or rel_matcher<std::greater_equal<>, 5>{};
-    static_assert(std::is_same_v<decltype(e), match::always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), match::always_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (OR subsumptive terms)",
           "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} or rel_matcher<std::less<>, 3>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(e), rel_matcher<std::less<>, 5> const>);
 }
 
@@ -69,7 +69,7 @@ TEST_CASE("custom matcher simplifies (OR overlapping terms)",
           "[match simplify]") {
     constexpr auto e =
         rel_matcher<std::less<>, 5>{} or rel_matcher<std::greater<>, 4>{};
-    static_assert(std::is_same_v<decltype(e), match::always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), match::always_t const>);
 }
 
 TEST_CASE("custom matcher simplifies (overlapping terms inside OR)",
@@ -77,5 +77,5 @@ TEST_CASE("custom matcher simplifies (overlapping terms inside OR)",
     constexpr auto e = rel_matcher<std::less<>, 5>{} or
                        rel_matcher<std::less<>, 10>{} or
                        rel_matcher<std::greater<>, 4>{};
-    static_assert(std::is_same_v<decltype(e), match::always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(e), match::always_t const>);
 }

--- a/test/match/simplify_not.cpp
+++ b/test/match/simplify_not.cpp
@@ -11,17 +11,17 @@ using namespace match;
 TEST_CASE("Negate true: ¬T -> F", "[match simplify not]") {
     constexpr auto e = not_t<always_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), never_t const>);
 }
 
 TEST_CASE("Negate false: ¬F -> T", "[match simplify not]") {
     constexpr auto e = not_t<never_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), always_t const>);
 }
 
 TEST_CASE("Double negation: ¬¬X -> X", "[match simplify not]") {
     constexpr auto e = not_t<not_t<test_matcher>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }

--- a/test/match/simplify_or.cpp
+++ b/test/match/simplify_or.cpp
@@ -11,66 +11,66 @@ using namespace match;
 TEST_CASE("Idempotence: X ∨ X -> X", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Right complementation: X ∨ ¬X -> T", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, not_t<test_matcher>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), always_t const>);
 }
 
 TEST_CASE("Left complementation: ¬X ∨ X -> F", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, not_t<test_matcher>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), always_t const>);
 }
 
 TEST_CASE("Right annihilation: X ∨ T -> T", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, always_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), always_t const>);
 }
 
 TEST_CASE("Left annihilation: T ∨ X -> T", "[match simplify or]") {
     constexpr auto e = or_t<always_t, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), always_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), always_t const>);
 }
 
 TEST_CASE("Right identity: X ∨ F -> X", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, never_t>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Left identity: F ∨ X -> X", "[match simplify or]") {
     constexpr auto e = or_t<never_t, test_matcher>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Left absorption: X ∨ (X ∧ Y) -> X", "[match simplify or]") {
     constexpr auto e = or_t<test_m<0>, and_t<test_m<0>, test_m<1>>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_m<0> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_m<0> const>);
 }
 
 TEST_CASE("Right absorption: (X ∧ Y) ∨ X -> X", "[match simplify or]") {
     constexpr auto e = or_t<and_t<test_m<0>, test_m<1>>, test_m<0>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_m<0> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_m<0> const>);
 }
 
 TEST_CASE("De Morgan's Law: ¬X ∨ ¬Y -> ¬(X ∧ Y)", "[match simplify or]") {
     constexpr auto e = or_t<not_t<test_m<0>>, not_t<test_m<1>>>{};
     constexpr auto s = simplify(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s), not_t<and_t<test_m<0>, test_m<1>>> const>);
 }
 
 TEST_CASE("OR simplifies recursively", "[match simplify or]") {
     constexpr auto e = or_t<test_matcher, or_t<test_matcher, never_t>>{};
     constexpr auto s = simplify(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }

--- a/test/match/sum_of_products.cpp
+++ b/test/match/sum_of_products.cpp
@@ -12,19 +12,19 @@ using namespace match;
 TEST_CASE("Single term: X -> X", "[match sum of products]") {
     constexpr auto e = test_matcher{};
     constexpr auto s = sum_of_products(e);
-    static_assert(std::is_same_v<decltype(s), test_matcher const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), test_matcher const>);
 }
 
 TEST_CASE("Negation: ¬X -> ¬X", "[match sum of products]") {
     constexpr auto e = not_t<test_matcher>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(std::is_same_v<decltype(s), not_t<test_matcher> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), not_t<test_matcher> const>);
 }
 
 TEST_CASE("Disjunction: X ∨ Y -> X ∨ Y", "[match sum of products]") {
     constexpr auto e = or_t<test_m<0>, test_m<1>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s), or_t<test_m<0>, test_m<1>> const>);
 }
 
@@ -32,7 +32,7 @@ TEST_CASE("Left distributive law: X ∧ (Y ∨ Z) -> (X ∧ Y) ∨ (X ∧ Z)",
           "[match sum of products]") {
     constexpr auto e = and_t<test_m<0>, or_t<test_m<1>, test_m<2>>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s), or_t<and_t<test_m<0>, test_m<1>>,
                                          and_t<test_m<0>, test_m<2>>> const>);
 }
@@ -41,7 +41,7 @@ TEST_CASE("Right distributive law: (X ∨ Y) ∧ Z -> (X ∧ Z) ∨ (Y ∧ Z)",
           "[match sum of products]") {
     constexpr auto e = and_t<or_t<test_m<0>, test_m<1>>, test_m<2>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s), or_t<and_t<test_m<0>, test_m<2>>,
                                          and_t<test_m<1>, test_m<2>>> const>);
 }
@@ -52,7 +52,7 @@ TEST_CASE("Binary distributive law: (A ∨ B) ∧ (X ∨ Y) -> (A ∧ X) ∨ (A 
     constexpr auto e =
         and_t<or_t<test_m<0>, test_m<1>>, or_t<test_m<2>, test_m<3>>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(s),
             or_t<or_t<and_t<test_m<0>, test_m<2>>, and_t<test_m<0>, test_m<3>>>,
@@ -66,17 +66,17 @@ TEST_CASE(
     constexpr auto e =
         or_t<test_m<0>, and_t<test_m<1>, or_t<test_m<2>, test_m<3>>>>{};
     constexpr auto s = sum_of_products(simplify(e));
-    static_assert(std::is_same_v<
-                  decltype(s),
-                  or_t<test_m<0>, or_t<and_t<test_m<1>, test_m<2>>,
-                                       and_t<test_m<1>, test_m<3>>>> const>);
+    STATIC_REQUIRE(std::is_same_v<
+                   decltype(s),
+                   or_t<test_m<0>, or_t<and_t<test_m<1>, test_m<2>>,
+                                        and_t<test_m<1>, test_m<3>>>> const>);
 }
 
 TEST_CASE("Push negation inside conjunction: ¬(X ∧ Y) -> ¬X ∨ ¬Y",
           "[match sum of products]") {
     constexpr auto e = not_t<and_t<test_m<0>, test_m<1>>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s),
                        or_t<not_t<test_m<0>>, not_t<test_m<1>>> const>);
 }
@@ -85,7 +85,7 @@ TEST_CASE("Push negation inside disjunction: ¬(X ∨ Y) -> ¬X ∧ ¬Y",
           "[match sum of products]") {
     constexpr auto e = not_t<or_t<test_m<0>, test_m<1>>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s),
                        and_t<not_t<test_m<0>>, not_t<test_m<1>>> const>);
 }
@@ -94,7 +94,7 @@ TEST_CASE("Recursive inside NOT: ¬(X ∧ (Y ∨ Z)) -> ¬X ∨ (¬Y ∧ ¬Z)",
           "[match sum of products]") {
     constexpr auto e = not_t<and_t<test_m<0>, or_t<test_m<1>, test_m<2>>>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s),
                        or_t<not_t<test_m<0>>,
                             and_t<not_t<test_m<1>>, not_t<test_m<2>>>> const>);
@@ -104,7 +104,7 @@ TEST_CASE("Recursive inside AND: ¬(X ∨ Y) ∧ Z -> ¬X ∧ ¬Y ∧ ¬Z",
           "[match sum of products]") {
     constexpr auto e = and_t<not_t<or_t<test_m<0>, test_m<1>>>, test_m<2>>{};
     constexpr auto s = sum_of_products(e);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(s),
             and_t<and_t<not_t<test_m<0>>, not_t<test_m<1>>>, test_m<2>> const>);

--- a/test/msg/callback.cpp
+++ b/test/msg/callback.cpp
@@ -230,42 +230,42 @@ constexpr auto expect_matcher = expect_matcher_t<RelOp, V>{};
 TEST_CASE("alternative matcher syntax (inequality)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field != msg::constant<0x80>, [] {});
-    static_assert(expect_matcher<std::not_equal_to<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::not_equal_to<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
 TEST_CASE("alternative matcher syntax (less)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field < msg::constant<0x80>, [] {});
-    static_assert(expect_matcher<std::less<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::less<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
 TEST_CASE("alternative matcher syntax (less than or equal)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field <= msg::constant<0x80>, [] {});
-    static_assert(expect_matcher<std::less_equal<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::less_equal<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
 TEST_CASE("alternative matcher syntax (greater)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field > msg::constant<0x80>, [] {});
-    static_assert(expect_matcher<std::greater<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::greater<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
 TEST_CASE("alternative matcher syntax (greater than or equal)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field >= msg::constant<0x80>, [] {});
-    static_assert(expect_matcher<std::greater_equal<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::greater_equal<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
 TEST_CASE("alternative matcher syntax (not)", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
         not("id"_field < msg::constant<0x80>), [] {});
-    static_assert(expect_matcher<std::greater_equal<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::greater_equal<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
@@ -273,7 +273,7 @@ TEST_CASE("alternative matcher syntax (and)", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
         "id"_field > msg::constant<0x80> and "id"_field > msg::constant<0x90>,
         [] {});
-    static_assert(expect_matcher<std::greater<>, 0x90>(
+    STATIC_REQUIRE(expect_matcher<std::greater<>, 0x90>(
         typename decltype(callback)::matcher_t{}));
 }
 
@@ -281,7 +281,7 @@ TEST_CASE("alternative matcher syntax (or)", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
         "id"_field > msg::constant<0x80> or "id"_field > msg::constant<0x90>,
         [] {});
-    static_assert(expect_matcher<std::greater<>, 0x80>(
+    STATIC_REQUIRE(expect_matcher<std::greater<>, 0x80>(
         typename decltype(callback)::matcher_t{}));
 }
 
@@ -289,23 +289,23 @@ TEST_CASE("alternative matcher syntax (multi-field)", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>(
         "id"_field == msg::constant<0x80> and "f1"_field == msg::constant<1>,
         [] {});
-    static_assert(std::same_as<typename decltype(callback)::matcher_t,
-                               match::and_t<msg::equal_to_t<id_field, 0x80>,
-                                            msg::equal_to_t<field1, 1>>>);
+    STATIC_REQUIRE(std::same_as<typename decltype(callback)::matcher_t,
+                                match::and_t<msg::equal_to_t<id_field, 0x80>,
+                                             msg::equal_to_t<field1, 1>>>);
 }
 
 TEST_CASE("alternative matcher syntax (value in set)", "[callback]") {
     auto callback =
         msg::callback<"cb", msg_defn>("id"_field.in<0x80, 0x90>, [] {});
-    static_assert(std::same_as<typename decltype(callback)::matcher_t,
-                               match::or_t<msg::equal_to_t<id_field, 0x80>,
-                                           msg::equal_to_t<id_field, 0x90>>>);
+    STATIC_REQUIRE(std::same_as<typename decltype(callback)::matcher_t,
+                                match::or_t<msg::equal_to_t<id_field, 0x80>,
+                                            msg::equal_to_t<id_field, 0x90>>>);
 }
 
 TEST_CASE("alternative matcher syntax (value in singleton)", "[callback]") {
     auto callback = msg::callback<"cb", msg_defn>("id"_field.in<0x80>, [] {});
-    static_assert(std::same_as<typename decltype(callback)::matcher_t,
-                               msg::equal_to_t<id_field, 0x80>>);
+    STATIC_REQUIRE(std::same_as<typename decltype(callback)::matcher_t,
+                                msg::equal_to_t<id_field, 0x80>>);
 }
 
 TEST_CASE("alternative matcher syntax (and-combine matcher with matcher maker)",

--- a/test/msg/fail/message_dangling_view.cpp
+++ b/test/msg/fail/message_dangling_view.cpp
@@ -15,6 +15,6 @@ auto main() -> int {
 #if defined(__clang__)
     [[maybe_unused]] auto v = msg::owning<msg_defn>{}.as_const_view();
 #else
-    static_assert(false, "-Wdangling");
+    STATIC_REQUIRE(false, "-Wdangling");
 #endif
 }

--- a/test/msg/field_insert.cpp
+++ b/test/msg/field_insert.cpp
@@ -152,7 +152,7 @@ TEST_CASE("trivially_copyable field type ", "[field insert]") {
 
 TEST_CASE("value fits in field", "[field insert]") {
     using F = field<"", std::uint32_t>::located<at{0_dw, 3_msb, 0_lsb}>;
-    static_assert(F::can_hold(15));
+    STATIC_REQUIRE(F::can_hold(15));
     CHECK(F::can_hold(15));
     CHECK(not F::can_hold(16));
 }
@@ -160,7 +160,7 @@ TEST_CASE("value fits in field", "[field insert]") {
 TEST_CASE("value fits in split field", "[field insert]") {
     using F = field<"", std::uint32_t>::located<at{0_dw, 1_msb, 0_lsb},
                                                 at{0_dw, 7_msb, 6_lsb}>;
-    static_assert(F::can_hold(15));
+    STATIC_REQUIRE(F::can_hold(15));
     CHECK(F::can_hold(15));
     CHECK(not F::can_hold(16));
 }

--- a/test/msg/field_matchers.cpp
+++ b/test/msg/field_matchers.cpp
@@ -22,7 +22,7 @@ TEST_CASE("matcher description", "[field matchers]") {
     using namespace stdx::literals;
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto desc = m.describe();
-    static_assert(desc.str == "test_field < 0x5"_ctst);
+    STATIC_REQUIRE(desc.str == "test_field < 0x5"_ctst);
 }
 
 TEST_CASE("matcher description of match", "[field matchers]") {
@@ -31,15 +31,15 @@ TEST_CASE("matcher description of match", "[field matchers]") {
 
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
-    static_assert(desc.str == "test_field (0x{:x}) < 0x5"_ctst);
-    static_assert(desc.args == stdx::tuple{1});
+    STATIC_REQUIRE(desc.str == "test_field (0x{:x}) < 0x5"_ctst);
+    STATIC_REQUIRE(desc.args == stdx::tuple{1});
 }
 
 TEST_CASE("matcher description (enum field)", "[field matchers]") {
     using namespace stdx::literals;
     constexpr auto m = msg::less_than_t<test_enum_field, E::C>{};
     constexpr auto desc = m.describe();
-    static_assert(desc.str == "enum_field < C"_ctst);
+    STATIC_REQUIRE(desc.str == "enum_field < C"_ctst);
 }
 
 TEST_CASE("matcher description of match (enum field)", "[field matchers]") {
@@ -48,14 +48,14 @@ TEST_CASE("matcher description of match (enum field)", "[field matchers]") {
 
     constexpr auto m = msg::less_than_t<test_enum_field, E::C>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
-    static_assert(desc.str == "enum_field ({}) < C"_ctst);
-    static_assert(desc.args == stdx::tuple{E::B});
+    STATIC_REQUIRE(desc.str == "enum_field ({}) < C"_ctst);
+    STATIC_REQUIRE(desc.args == stdx::tuple{E::B});
 }
 
 TEST_CASE("negate less_than", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n),
                        msg::greater_than_or_equal_to_t<test_field, 5> const>);
 }
@@ -63,7 +63,7 @@ TEST_CASE("negate less_than", "[field matchers]") {
 TEST_CASE("negate greater_than", "[field matchers]") {
     constexpr auto m = msg::greater_than_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n),
                        msg::less_than_or_equal_to_t<test_field, 5> const>);
 }
@@ -71,168 +71,168 @@ TEST_CASE("negate greater_than", "[field matchers]") {
 TEST_CASE("negate less_than_or_equal_to", "[field matchers]") {
     constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n), msg::greater_than_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate greater_than_or_equal_to", "[field matchers]") {
     constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n), msg::less_than_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate equal_to", "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n), msg::not_equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("negate not_equal_to", "[field matchers]") {
     constexpr auto m = msg::not_equal_to_t<test_field, 5>{};
     constexpr auto n = match::negate(m);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(n), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("less_than X implies less_than Y (X == Y)", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto n = msg::less_than_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("less_than X implies less_than Y (X <= Y)", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto n = msg::less_than_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies greater_than Y (X >= Y)",
           "[field matchers]") {
     constexpr auto m = msg::greater_than_t<test_field, 6>{};
     constexpr auto n = msg::greater_than_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("less_than_or_equal_to X implies less_than Y (X < Y)",
           "[field matchers]") {
     constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = msg::less_than_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("less_than X implies less_than_or_equal_to Y (X <= Y + 1)",
           "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 6>{};
     constexpr auto n = msg::less_than_or_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("greater_than_or_equal_to X implies greater_than Y (X > Y)",
           "[field matchers]") {
     constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 6>{};
     constexpr auto n = msg::greater_than_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies greater_than_or_equal_to Y (X + 1 >= Y)",
           "[field matchers]") {
     constexpr auto m = msg::greater_than_t<test_field, 5>{};
     constexpr auto n = msg::greater_than_or_equal_to_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies less_than Y (X < Y)", "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = msg::less_than_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies less_than_or_equal_to Y (X <= Y)",
           "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = msg::less_than_or_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies greater_than Y (X > Y)", "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 6>{};
     constexpr auto n = msg::greater_than_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies greater_than_or_equal_to Y (X >= Y)",
           "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = msg::greater_than_or_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X implies not equal_to Y (X != Y)", "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{};
     constexpr auto n = not msg::equal_to_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("equal_to X and equal_to Y is false (X != Y)", "[field matchers]") {
     constexpr auto m =
         msg::equal_to_t<test_field, 5>{} and msg::equal_to_t<test_field, 6>{};
-    static_assert(std::is_same_v<decltype(m), match::never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), match::never_t const>);
 }
 
 TEST_CASE("equal_to X and not equal_to Y is equal_to X (X != Y)",
           "[field matchers]") {
     constexpr auto m = msg::equal_to_t<test_field, 5>{} and
                        not msg::equal_to_t<test_field, 6>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(m), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("equal_to X and less_than X is false (X != Y)", "[field matchers]") {
     constexpr auto m =
         msg::equal_to_t<test_field, 5>{} and msg::less_than_t<test_field, 5>{};
-    static_assert(std::is_same_v<decltype(m), match::never_t const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), match::never_t const>);
 }
 
 TEST_CASE("equal_to X and less_than Y is equal_to X (X < Y)",
           "[field matchers]") {
     constexpr auto m =
         msg::equal_to_t<test_field, 5>{} and msg::less_than_t<test_field, 6>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(m), msg::equal_to_t<test_field, 5> const>);
 }
 
 TEST_CASE("less_than X implies not_equal_to X", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("greater_than X implies not_equal_to X", "[field matchers]") {
     constexpr auto m = msg::greater_than_t<test_field, 5>{};
     constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("less_than_or_equal_to X implies not_equal_to X",
           "[field matchers]") {
     constexpr auto m = msg::less_than_or_equal_to_t<test_field, 5>{};
     constexpr auto n = msg::not_equal_to_t<test_field, 6>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("greater_than_or_equal_to X implies not_equal_to X",
           "[field matchers]") {
     constexpr auto m = msg::greater_than_or_equal_to_t<test_field, 6>{};
     constexpr auto n = msg::not_equal_to_t<test_field, 5>{};
-    static_assert(match::implies(m, n));
+    STATIC_REQUIRE(match::implies(m, n));
 }
 
 TEST_CASE("not_equal_to X and less_than Y is less_than Y (X >= Y)",
           "[field matchers]") {
     constexpr auto m = msg::not_equal_to_t<test_field, 6>{} and
                        msg::less_than_t<test_field, 6>{};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(m), msg::less_than_t<test_field, 6> const>);
 }

--- a/test/msg/indexed_callback.cpp
+++ b/test/msg/indexed_callback.cpp
@@ -45,7 +45,7 @@ TEST_CASE("callback with compound match", "[indexed_callback]") {
 TEST_CASE("callback is sum of products", "[indexed_callback]") {
     constexpr auto cb = msg::callback<"", msg_defn>(
         msg::equal_to<int_f, 0> and msg::in<char_f, 'a', 'b'>, [](auto) {});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(cb.matcher),
             match::or_t<
@@ -108,7 +108,7 @@ TEST_CASE("remove an indexed term from a callback", "[indexed_callback]") {
         msg::equal_to<int_f, 0> and msg::in<char_f, 'a', 'b'>, [](auto) {});
 
     constexpr auto sut = msg::remove_match_terms<int_f>(cb);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(sut.matcher),
             match::or_t<equal_to_t<char_f, 'a'>, equal_to_t<char_f, 'b'>>>);
@@ -120,7 +120,7 @@ TEST_CASE("remove multiple indexed terms from a callback",
         msg::equal_to<int_f, 0> and msg::in<char_f, 'a', 'b'>, [](auto) {});
 
     constexpr auto sut = msg::remove_match_terms<int_f, char_f>(cb);
-    static_assert(std::is_same_v<decltype(sut.matcher), match::always_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(sut.matcher), match::always_t>);
 }
 
 namespace {
@@ -134,8 +134,8 @@ TEST_CASE("separate sum terms in a callback", "[indexed_callback]") {
     CHECK(cb.matcher(msg_defn::owner_t{}));
 
     auto sut = msg::separate_sum_terms(cb);
-    static_assert(stdx::is_specialization_of_v<decltype(sut), stdx::tuple>);
-    static_assert(sut.size() == 2);
+    STATIC_REQUIRE(stdx::is_specialization_of_v<decltype(sut), stdx::tuple>);
+    STATIC_REQUIRE(sut.size() == 2);
 
     auto const &cb1 = stdx::get<0>(sut);
     auto const &cb2 = stdx::get<1>(sut);

--- a/test/msg/relaxed_message.cpp
+++ b/test/msg/relaxed_message.cpp
@@ -17,7 +17,7 @@ TEST_CASE("message with automatically packed fields", "[relaxed_message]") {
     using expected_defn =
         msg::message<"msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>,
                      auto_f2::located<at{1_dw, 7_msb, 0_lsb}>>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("automatically packed fields are sorted by size",
@@ -26,7 +26,7 @@ TEST_CASE("automatically packed fields are sorted by size",
     using expected_defn =
         msg::message<"msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>,
                      auto_f2::located<at{1_dw, 7_msb, 0_lsb}>>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("message with mixed fixed and automatically packed fields",
@@ -35,20 +35,20 @@ TEST_CASE("message with mixed fixed and automatically packed fields",
     using expected_defn =
         msg::message<"msg", fixed_f, auto_f1::located<at{1_dw, 31_msb, 0_lsb}>,
                      auto_f2::located<at{2_dw, 7_msb, 0_lsb}>>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("message with no automatically packed fields", "[relaxed_message]") {
     using defn = relaxed_message<"msg", fixed_f>;
     using expected_defn = msg::message<"msg", fixed_f>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("auto field with default value", "[relaxed_message]") {
     using defn = relaxed_message<"msg", auto_f1::with_default<42>>;
     using expected_defn = msg::message<
         "msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>::with_default<42>>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("auto field with const default value", "[relaxed_message]") {
@@ -56,14 +56,14 @@ TEST_CASE("auto field with const default value", "[relaxed_message]") {
     using expected_defn =
         msg::message<"msg", auto_f1::located<at{
                                 0_dw, 31_msb, 0_lsb}>::with_const_default<42>>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 TEST_CASE("auto field without default value", "[relaxed_message]") {
     using defn = relaxed_message<"msg", auto_f1::without_default>;
     using expected_defn = msg::message<
         "msg", auto_f1::located<at{0_dw, 31_msb, 0_lsb}>::without_default>;
-    static_assert(std::is_same_v<defn, expected_defn>);
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
 namespace {
@@ -82,11 +82,11 @@ namespace {
 
 TEST_CASE("message with default empty environment", "[relaxed_message]") {
     using defn = relaxed_message<"msg", auto_f1, auto_f2>;
-    static_assert(custom(defn::env_t{}) == 42);
+    STATIC_REQUIRE(custom(defn::env_t{}) == 42);
 }
 
 TEST_CASE("message with defined environment", "[message]") {
     using env_t = stdx::make_env_t<custom, 17>;
     using defn = relaxed_message<"msg", env_t, auto_f1, auto_f2>;
-    static_assert(custom(defn::env_t{}) == 17);
+    STATIC_REQUIRE(custom(defn::env_t{}) == 17);
 }


### PR DESCRIPTION
Problem:
- Using static_assert does not report the check in Catch2.

Solution:
- Use STATIC_REQUIRE so that the check is reported.