### PR TITLE
:bug: Fix extending `callback::service` with a function

### DIFF
--- a/include/cib/config.hpp
+++ b/include/cib/config.hpp
@@ -9,6 +9,7 @@
 #include <cib/detail/runtime_conditional.hpp>
 
 #include <stdx/compiler.hpp>
+#include <stdx/type_traits.hpp>
 
 namespace cib {
 /**
@@ -46,6 +47,12 @@ constexpr static detail::components<Components...> components{};
 template <typename... Services>
 constexpr static detail::exports<Services...> exports{};
 
+namespace detail {
+template <typename T>
+using maybe_funcptr_t =
+    stdx::conditional_t<stdx::is_function_v<T>, std::decay_t<T>, T>;
+}
+
 /**
  * Extend a service with new functionality.
  *
@@ -57,7 +64,7 @@ constexpr static detail::exports<Services...> exports{};
  */
 template <typename Service, typename... Args>
 [[nodiscard]] CONSTEVAL auto extend(Args const &...args) {
-    return detail::extend<Service, Args...>{args...};
+    return detail::extend<Service, detail::maybe_funcptr_t<Args>...>{args...};
 }
 
 template <stdx::ct_string Name>

--- a/test/cib/nexus.cpp
+++ b/test/cib/nexus.cpp
@@ -46,10 +46,14 @@ struct Foo {
         cib::extend<TestCallback<2>>([]() { is_callback_invoked<2> = true; }));
 };
 
+namespace {
+auto test_cb_1() { is_callback_invoked<1> = true; }
+} // namespace
+
 struct Bar {
     constexpr static auto config = cib::config(
         cib::extend<TestCallback<0>>([]() { is_callback_invoked<0> = true; }),
-        cib::extend<TestCallback<1>>([]() { is_callback_invoked<1> = true; }));
+        cib::extend<TestCallback<1>>(test_cb_1));
 };
 
 struct Gorp {


### PR DESCRIPTION
Problem:
- `extend<callback::service>(f)` works fine when `f` is a lambda expression, but doesn't compile when `f` is a function.

Solution:
- Decay functions to function pointers to properly store them.