### PR TITLE
:sparkles: Allow field insert/extract on integral types

### DIFF
--- a/test/msg/fail/CMakeLists.txt
+++ b/test/msg/fail/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_compile_fail_test(callback_bad_field_name.cpp LIBRARIES warnings cib_msg)
+add_compile_fail_test(field_insert_space.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(field_location.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(field_size.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(impossible_match_callback.cpp LIBRARIES warnings cib_msg)

--- a/test/msg/fail/field_insert_space.cpp
+++ b/test/msg/fail/field_insert_space.cpp
@@ -1,0 +1,13 @@
+#include <msg/field.hpp>
+
+#include <cstdint>
+
+// EXPECT: Field location is outside the range of argument
+
+using namespace msg;
+using F = field<"", std::uint8_t>::located<at{32_msb, 31_lsb}>;
+
+auto main() -> int {
+    std::uint32_t data{};
+    F::insert(data, 1u);
+}

--- a/test/msg/field_extract.cpp
+++ b/test/msg/field_extract.cpp
@@ -16,6 +16,12 @@ TEST_CASE("single bit", "[field extract]") {
     CHECK(0b1u == F::extract(data));
 }
 
+TEST_CASE("from integral type", "[field extract]") {
+    using F = field<"", std::uint32_t>::located<at{0_dw, 1_msb, 1_lsb}>;
+    std::uint32_t data{0b010};
+    CHECK(0b1u == F::extract(data));
+}
+
 TEST_CASE("within one storage element", "[field extract]") {
     using F = field<"", std::uint32_t>::located<at{0_dw, 16_msb, 5_lsb}>;
     std::array<std::uint32_t, 1> data{0b11'1010'1010'1110'0000};

--- a/test/msg/field_insert.cpp
+++ b/test/msg/field_insert.cpp
@@ -16,6 +16,13 @@ TEST_CASE("single bit", "[field insert]") {
     CHECK(0b010u == data[0]);
 }
 
+TEST_CASE("into integral type", "[field insert]") {
+    using F = field<"", std::uint32_t>::located<at{0_dw, 1_msb, 1_lsb}>;
+    std::uint32_t data{};
+    F::insert(data, 1u);
+    CHECK(0b010u == data);
+}
+
 TEST_CASE("within one storage element", "[field insert]") {
     using F = field<"", std::uint32_t>::located<at{0_dw, 16_msb, 5_lsb}>;
     std::array<std::uint32_t, 1> data{0b10'0000'0000'0001'0000};


### PR DESCRIPTION
Problem:
- With small messages, it's frequently useful to insert and extract fields directly into (unsigned) integral types without having to construct a span over the data.

Solution:
- Overloads of `insert` and `extract` on `field` which work on unsigned integral types.