### PR TITLE
:children_crossing: Work around clang bug with `consteval` UDLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
-add_versioned_package("gh:intel/cpp-std-extensions#7e1cbc7")
+add_versioned_package("gh:intel/cpp-std-extensions#effadd4")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#22c8006")
 
 set(GEN_STR_CATALOG

--- a/include/interrupt/fwd.hpp
+++ b/include/interrupt/fwd.hpp
@@ -11,7 +11,7 @@ using priority_t = std::size_t;
 
 inline namespace literals {
 // NOLINTNEXTLINE(google-runtime-int)
-CONSTEVAL auto operator""_irq(unsigned long long int v) -> irq_num_t {
+CONSTEVAL_UDL auto operator""_irq(unsigned long long int v) -> irq_num_t {
     return static_cast<irq_num_t>(v);
 }
 } // namespace literals

--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -279,21 +279,21 @@ enum struct lsb_t : std::uint32_t {};
 
 inline namespace literals {
 // NOLINTNEXTLINE(google-runtime-int)
-CONSTEVAL auto operator""_bi(unsigned long long int v) -> byte_index_t {
+CONSTEVAL_UDL auto operator""_bi(unsigned long long int v) -> byte_index_t {
     return static_cast<byte_index_t>(v);
 }
-CONSTEVAL auto operator""_dwi(unsigned long long int v) -> dword_index_t {
+CONSTEVAL_UDL auto operator""_dwi(unsigned long long int v) -> dword_index_t {
     return static_cast<dword_index_t>(v);
 }
-CONSTEVAL auto operator""_dw(unsigned long long int v) -> dword_index_t {
+CONSTEVAL_UDL auto operator""_dw(unsigned long long int v) -> dword_index_t {
     return static_cast<dword_index_t>(v);
 }
 // NOLINTNEXTLINE(google-runtime-int)
-CONSTEVAL auto operator""_lsb(unsigned long long int v) -> lsb_t {
+CONSTEVAL_UDL auto operator""_lsb(unsigned long long int v) -> lsb_t {
     return static_cast<lsb_t>(v);
 }
 // NOLINTNEXTLINE(google-runtime-int)
-CONSTEVAL auto operator""_msb(unsigned long long int v) -> msb_t {
+CONSTEVAL_UDL auto operator""_msb(unsigned long long int v) -> msb_t {
     return static_cast<msb_t>(v);
 }
 } // namespace literals


### PR DESCRIPTION
Problem:
- clang has a persistent regression where it ICEs with the error "trying to emit a call to an immediate function". This seems to be provoked by `consteval` UDLs.

Solution:
- When using clang, mark UDLs as `constexpr` rather than `consteval`.