### PR TITLE
:sparkles: Support tuple protocol on messages

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -356,6 +356,9 @@ template <stdx::ct_string Name, typename Access, typename T> struct msg_base {
 template <stdx::ct_string Name, typename Env, typename... Fields>
 struct message {
     using fields_t = stdx::type_list<Fields...>;
+    using num_fields_t = std::integral_constant<std::size_t, sizeof...(Fields)>;
+    template <std::size_t I> using nth_field_t = stdx::nth_t<I, Fields...>;
+
     using env_t = Env;
     using access_t = msg_access<Name, Fields...>;
     using default_storage_t = typename access_t::default_storage_t;

--- a/include/msg/message_destructure.hpp
+++ b/include/msg/message_destructure.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <msg/message.hpp>
+
+#include <stdx/type_traits.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+template <msg::messagelike M>
+struct std::tuple_size<M> : M::definition_t::num_fields_t {};
+
+template <std::size_t I, msg::messagelike M>
+struct std::tuple_element<I, M>
+    : std::type_identity<
+          typename M::definition_t::template nth_field_t<I>::value_type> {};
+
+namespace msg::detail {
+template <std::size_t I, msg::messagelike M>
+constexpr auto get(M &&m) -> decltype(auto) {
+    return std::forward<M>(m).get(typename std::remove_cvref_t<
+                                  M>::definition_t::template nth_field_t<I>{});
+}
+} // namespace msg::detail


### PR DESCRIPTION
Problem:
- It's sometimes useful to destructure messages.

Solution:
- Support the tuple protocol on (owning or view) messages.

Note:
- The field order is the canonical ordering of fields by lsb; this is not necessarily the declaration order in the message alias.