### PR TITLE
:bug: Fix mipi catalog payload size calculation

### DIFF
--- a/test/log/encoder.cpp
+++ b/test/log/encoder.cpp
@@ -259,6 +259,17 @@ TEST_CASE("log more than two arguments", "[mipi]") {
     }
 }
 
+TEST_CASE("log more than two arguments whose size fits in two uint32_ts",
+          "[mipi]") {
+    CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
+    test_critical_section::count = 0;
+    auto cfg = logging::binary::config{
+        test_log_buf_destination<logging::level::TRACE, log_env, 42u, 'a', 'b',
+                                 'c'>{}};
+    cfg.logger.log_msg<log_env>(stdx::ct_format<"{} {} {}">('a', 'b', 'c'));
+    CHECK(test_critical_section::count == 2);
+}
+
 TEST_CASE("log to multiple destinations", "[mipi]") {
     CIB_LOG_ENV(logging::get_level, logging::level::TRACE);
     test_critical_section::count = 0;


### PR DESCRIPTION
Problem:
- When logging runtime arguments whose total size is less than 2 `std::uint32_t`s, the mipi builder uses the `log_by_args` path, despite the fact that packing the arguments according to the mipi spec means they could use much more space.

Solution:
- Calculate the size based on the packed space, not the original argument size.