### PR TITLE
:sparkles: Add target for string collateral

### DIFF
--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -10,7 +10,8 @@ function(gen_str_catalog)
         VERSION
         GUID_ID
         GUID_MASK
-        MODULE_ID_MAX)
+        MODULE_ID_MAX
+        OUTPUTS_TARGET)
     set(multiValueArgs INPUT_JSON INPUT_LIBS INPUT_HEADERS STABLE_JSON)
     cmake_parse_arguments(SC "${options}" "${oneValueArgs}" "${multiValueArgs}"
                           ${ARGN})
@@ -86,5 +87,10 @@ function(gen_str_catalog)
     if(SC_OUTPUT_LIB)
         add_library(${SC_OUTPUT_LIB} STATIC ${SC_OUTPUT_CPP})
         target_link_libraries(${SC_OUTPUT_LIB} PUBLIC cib)
+    endif()
+    if(SC_OUTPUTS_TARGET)
+        add_custom_target(
+            ${SC_OUTPUTS_TARGET} DEPENDS ${SC_OUTPUT_CPP} ${SC_OUTPUT_XML}
+                                         ${SC_OUTPUT_JSON})
     endif()
 endfunction()

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -38,7 +38,9 @@ gen_str_catalog(
     GUID_ID
     "01234567-89ab-cdef-0123-456789abcdef"
     GUID_MASK
-    "ffffffff-ffff-ffff-ffff-ffffffffffff")
+    "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    OUTPUTS_TARGET
+    test_catalog_json)
 
 add_library(catalog_strings STATIC ${CMAKE_CURRENT_BINARY_DIR}/strings.cpp)
 target_link_libraries(catalog_strings PUBLIC cib)


### PR DESCRIPTION
Problem:
- The outputs produced by `gen_str_catalog` are built by a custom command but do not have an associated target, which means other targets can't depend on them.

Solution:
- Add an optional target for the `.cpp`, `.xml` and `.json` files produced by `gen_str_datalog`.