### PR TITLE
:art: Autodetect scoped enums in generated `.cpp` catalog file

### DIFF
--- a/include/log/catalog/arguments.hpp
+++ b/include/log/catalog/arguments.hpp
@@ -10,46 +10,65 @@ template <typename> struct encode_32;
 template <typename> struct encode_64;
 template <typename> struct encode_u32;
 template <typename> struct encode_u64;
+template <typename...> struct encode_enum;
 
 namespace logging {
 template <typename T>
-concept signed_packable = std::signed_integral<stdx::underlying_type_t<T>> and
-                          sizeof(T) <= sizeof(std::int64_t);
+concept signed_packable =
+    std::signed_integral<T> and sizeof(T) <= sizeof(std::int64_t);
 
 template <typename T>
 concept unsigned_packable =
-    std::unsigned_integral<stdx::underlying_type_t<T>> and
-    sizeof(T) <= sizeof(std::int64_t);
+    std::unsigned_integral<T> and sizeof(T) <= sizeof(std::int64_t);
 
 template <typename T>
-concept float_packable = std::floating_point<stdx::underlying_type_t<T>> and
-                         sizeof(T) <= sizeof(std::int64_t);
+concept float_packable =
+    std::floating_point<T> and sizeof(T) <= sizeof(std::int64_t);
 
 template <typename T>
-concept packable =
-    signed_packable<T> or unsigned_packable<T> or float_packable<T>;
+concept enum_packable = std::is_enum_v<T> and sizeof(T) <= sizeof(std::int64_t);
+
+template <typename T>
+concept packable = signed_packable<T> or unsigned_packable<T> or
+                   float_packable<T> or enum_packable<T>;
 
 template <typename T> struct encoding;
 
+namespace detail {
+template <typename T>
+using signed_encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::int32_t),
+                                            encode_32<T>, encode_64<T>>;
+template <typename T>
+using unsigned_encode_t =
+    stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t), encode_u32<T>,
+                        encode_u64<T>>;
+} // namespace detail
+
 template <signed_packable T> struct encoding<T> {
-    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::int32_t),
-                                         encode_32<T>, encode_64<T>>;
+    using encode_t = detail::signed_encode_t<T>;
     using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::int32_t),
                                        std::int32_t, std::int64_t>;
 };
 
 template <unsigned_packable T> struct encoding<T> {
-    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
-                                         encode_u32<T>, encode_u64<T>>;
+    using encode_t = detail::unsigned_encode_t<T>;
     using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
                                        std::uint32_t, std::uint64_t>;
 };
 
 template <float_packable T> struct encoding<T> {
-    using encode_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
-                                         encode_u32<T>, encode_u64<T>>;
+    using encode_t = detail::unsigned_encode_t<T>;
     using pack_t = stdx::conditional_t<sizeof(T) <= sizeof(std::uint32_t),
                                        std::uint32_t, std::uint64_t>;
+};
+
+template <enum_packable T>
+struct encoding<T> : encoding<stdx::underlying_type_t<T>> {
+    using encode_t = stdx::conditional_t<
+        stdx::is_scoped_enum_v<T>, encode_enum<T, stdx::underlying_type_t<T>>,
+        stdx::conditional_t<std::signed_integral<stdx::underlying_type_t<T>>,
+                            detail::signed_encode_t<T>,
+                            detail::unsigned_encode_t<T>>>;
 };
 
 struct default_arg_packer {

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -26,6 +26,7 @@ using log_env2b = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
 auto log_rt_enum_arg() -> void;
+auto log_rt_auto_scoped_enum_arg() -> void;
 auto log_rt_float_arg() -> void;
 auto log_rt_double_arg() -> void;
 
@@ -33,7 +34,18 @@ auto log_rt_enum_arg() -> void {
     auto cfg = logging::binary::config{test_log_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
-        stdx::ct_format<"E string with {} placeholder">(E::value));
+        stdx::ct_format<"E string with {} placeholder">(VAL));
+}
+
+namespace some_ns {
+enum struct E { A, B, C };
+}
+
+auto log_rt_auto_scoped_enum_arg() -> void {
+    auto cfg = logging::binary::config{test_log_destination{}};
+    using namespace some_ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"E (scoped) string with {} placeholder">(E::A));
 }
 
 auto log_rt_float_arg() -> void {

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -17,6 +17,7 @@ extern auto log_one_64bit_rt_arg() -> void;
 extern auto log_one_formatted_rt_arg() -> void;
 extern auto log_two_rt_args() -> void;
 extern auto log_rt_enum_arg() -> void;
+extern auto log_rt_auto_scoped_enum_arg() -> void;
 extern auto log_with_non_default_module() -> void;
 extern auto log_with_fixed_module() -> void;
 extern auto log_with_fixed_string_id() -> void;
@@ -96,6 +97,15 @@ TEST_CASE("log runtime enum argument", "[catalog]") {
     log_calls = 0;
     test_critical_section::count = 0;
     log_rt_enum_arg();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+}
+
+TEST_CASE("log runtime scoped enum argument outside included header",
+          "[catalog]") {
+    log_calls = 0;
+    test_critical_section::count = 0;
+    log_rt_auto_scoped_enum_arg();
     CHECK(test_critical_section::count == 2);
     CHECK(log_calls == 1);
 }

--- a/test/log/catalog_enums.hpp
+++ b/test/log/catalog_enums.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
 namespace ns {
-enum struct E { value = 42 };
-}
+enum E { VAL = 42 };
+} // namespace ns

--- a/test/log/encoder.cpp
+++ b/test/log/encoder.cpp
@@ -155,6 +155,11 @@ using log_env = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 
 template <> inline auto conc::injected_policy<> = test_conc_policy{};
 
+namespace {
+enum UnscopedE { A, B, C };
+enum struct ScopedE { A, B, C };
+} // namespace
+
 TEST_CASE("argument packing", "[mipi]") {
     using P = logging::default_arg_packer;
     STATIC_REQUIRE(std::same_as<P::pack_as_t<std::int32_t>, std::int32_t>);
@@ -165,6 +170,8 @@ TEST_CASE("argument packing", "[mipi]") {
     STATIC_REQUIRE(std::same_as<P::pack_as_t<unsigned char>, std::uint32_t>);
     STATIC_REQUIRE(std::same_as<P::pack_as_t<float>, std::uint32_t>);
     STATIC_REQUIRE(std::same_as<P::pack_as_t<double>, std::uint64_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<UnscopedE>, std::uint32_t>);
+    STATIC_REQUIRE(std::same_as<P::pack_as_t<ScopedE>, std::int32_t>);
 }
 
 TEST_CASE("argument encoding", "[mipi]") {
@@ -182,6 +189,10 @@ TEST_CASE("argument encoding", "[mipi]") {
         std::same_as<P::encode_as_t<unsigned char>, encode_u32<unsigned char>>);
     STATIC_REQUIRE(std::same_as<P::encode_as_t<float>, encode_u32<float>>);
     STATIC_REQUIRE(std::same_as<P::encode_as_t<double>, encode_u64<double>>);
+    STATIC_REQUIRE(
+        std::same_as<P::encode_as_t<UnscopedE>, encode_u32<UnscopedE>>);
+    STATIC_REQUIRE(
+        std::same_as<P::encode_as_t<ScopedE>, encode_enum<ScopedE, int>>);
 }
 
 TEST_CASE("log zero arguments", "[mipi]") {


### PR DESCRIPTION
Problem:
- The `.cpp` file generated by `gen_str_catalog` requires headers to be supplied in order to define the enums used. If the headers are not supplied, it does not compile.

Solution:
- Export scoped enum information sufficient to forward declare enumerations. If headers are not supplied, the `.cpp` file should still compile.

Note:
- Unscoped enums cannot be forward declared.
- Enums inside anonymous namespaces cannot be forward declared.