### PR TITLE
:sparkles: Add `SOURCES` to string catalog target

### DIFF
--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -90,7 +90,8 @@ function(gen_str_catalog)
     endif()
     if(SC_OUTPUTS_TARGET)
         add_custom_target(
-            ${SC_OUTPUTS_TARGET} DEPENDS ${SC_OUTPUT_CPP} ${SC_OUTPUT_XML}
-                                         ${SC_OUTPUT_JSON})
+            ${SC_OUTPUTS_TARGET}
+            DEPENDS ${SC_OUTPUT_CPP} ${SC_OUTPUT_XML} ${SC_OUTPUT_JSON}
+            SOURCES ${SC_OUTPUT_CPP} ${SC_OUTPUT_XML} ${SC_OUTPUT_JSON})
     endif()
 endfunction()


### PR DESCRIPTION
Problem:
- The target for the string catalog files depends on the generated files, but it is difficult for calling code to recover those dependencies.

Solution:
- Add the generated files as sources so that calling code can look at the `SOURCES` property.