### PR TITLE
:arrow_up: Update dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
-add_versioned_package("gh:intel/cpp-std-extensions#73e1d48")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#22c8006")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#09c043b")
+add_versioned_package("gh:intel/cpp-std-extensions#8e2f948")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#27db6e1")
 
 set(GEN_STR_CATALOG
     ${CMAKE_CURRENT_LIST_DIR}/tools/gen_str_catalog.py


### PR DESCRIPTION
Problem:
- `stdx` has fixes that affect CIB logging.

Solution:
- Update dependencies.