### PR TITLE
:art: Logging: allow writer in env, remove `log_by_{args,buf}`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#09c043b")
-add_versioned_package("gh:intel/cpp-std-extensions#8e2f948")
+add_versioned_package("gh:intel/cpp-std-extensions#ca9e67a")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#27db6e1")
 
 set(GEN_STR_CATALOG

--- a/include/log/catalog/mipi_builder.hpp
+++ b/include/log/catalog/mipi_builder.hpp
@@ -69,23 +69,13 @@ template <packer P> struct builder<defn::catalog_msg_t, P> {
         using namespace msg;
         constexpr auto payload_size =
             (sizeof(id) + ... + sizeof(typename P::template pack_as_t<Ts>));
-        if constexpr (payload_size <= sizeof(uint32_t) * 3) {
-            constexpr auto header_size =
-                defn::catalog_msg_t::size<std::uint32_t>::value;
-            using storage_t =
-                std::array<std::uint32_t,
-                           header_size +
-                               stdx::sized8{payload_size}.in<std::uint32_t>()>;
-            return catalog_builder<storage_t, P>{}.template build<Level>(
-                id, m, args...);
-        } else {
-            constexpr auto header_size =
-                defn::catalog_msg_t::size<std::uint8_t>::value;
-            using storage_t =
-                std::array<std::uint8_t, header_size + payload_size>;
-            return catalog_builder<storage_t, P>{}.template build<Level>(
-                id, m, args...);
-        }
+        constexpr auto header_size =
+            defn::catalog_msg_t::size<std::uint32_t>::value;
+        using storage_t =
+            std::array<std::uint32_t, header_size + stdx::sized8{payload_size}
+                                                        .in<std::uint32_t>()>;
+        return catalog_builder<storage_t, P>{}.template build<Level>(id, m,
+                                                                     args...);
     }
 };
 

--- a/include/log/catalog/writer.hpp
+++ b/include/log/catalog/writer.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <log/catalog/mipi_builder.hpp>
+
+#include <stdx/compiler.hpp>
+#include <stdx/span.hpp>
+
+#include <cstdint>
+#include <utility>
+
+namespace logging::binary {
+template <typename T>
+concept writer_like =
+    requires(T &t, stdx::span<std::uint32_t const, 1> data) { t(data); };
+
+[[maybe_unused]] constexpr inline struct get_writer_t {
+    template <typename T>
+    CONSTEVAL auto operator()(T &&t) const noexcept(
+        noexcept(std::forward<T>(t).query(std::declval<get_writer_t>())))
+        -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
+    }
+} get_writer;
+} // namespace logging::binary

--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -4,6 +4,7 @@
 
 #include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/span.hpp>
 
 #include <conc/concurrency.hpp>
 
@@ -15,10 +16,11 @@ int log_calls{};
 std::uint32_t last_header{};
 
 namespace {
-struct test_log_args_destination {
-    auto log_by_args(std::uint32_t hdr, auto...) -> void {
+struct test_log_destination {
+    template <std::size_t N>
+    auto operator()(stdx::span<std::uint32_t const, N> pkt) const {
         ++log_calls;
-        last_header = hdr;
+        last_header = pkt[0];
     }
 };
 
@@ -36,32 +38,32 @@ auto log_with_fixed_string_id() -> void;
 auto log_with_fixed_module_id() -> void;
 
 auto log_zero_args() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"A string with no placeholders">());
 }
 
 auto log_one_ct_arg() -> void {
     using namespace stdx::literals;
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"B string with {} placeholder">("one"_ctst));
 }
 
 auto log_one_32bit_rt_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"C1 string with {} placeholder">(std::int32_t{1}));
 }
 
 auto log_one_64bit_rt_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"C2 string with {} placeholder">(std::int64_t{1}));
 }
 
 auto log_one_formatted_rt_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env1>(
         stdx::ct_format<"C3 string with {:08x} placeholder">(std::int32_t{1}));
 }
@@ -69,7 +71,7 @@ auto log_one_formatted_rt_arg() -> void {
 auto log_with_non_default_module() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_module, "not default") {
-        auto cfg = logging::binary::config{test_log_args_destination{}};
+        auto cfg = logging::binary::config{test_log_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"ModuleID string with {} placeholder">(1));
     }
@@ -78,7 +80,7 @@ auto log_with_non_default_module() -> void {
 auto log_with_fixed_module() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_module, "fixed") {
-        auto cfg = logging::binary::config{test_log_args_destination{}};
+        auto cfg = logging::binary::config{test_log_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
     }
@@ -87,7 +89,7 @@ auto log_with_fixed_module() -> void {
 auto log_with_fixed_string_id() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_string_id, 1337) {
-        auto cfg = logging::binary::config{test_log_args_destination{}};
+        auto cfg = logging::binary::config{test_log_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed StringID string">());
     }
@@ -97,7 +99,7 @@ auto log_with_fixed_module_id() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
                      logging::get_module_id, 7, logging::get_module,
                      "fixed_id") {
-        auto cfg = logging::binary::config{test_log_args_destination{}};
+        auto cfg = logging::binary::config{test_log_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
     }

--- a/test/log/catalog2a_lib.cpp
+++ b/test/log/catalog2a_lib.cpp
@@ -4,6 +4,7 @@
 #include <log/catalog/encoder.hpp>
 
 #include <stdx/ct_format.hpp>
+#include <stdx/span.hpp>
 
 #include <conc/concurrency.hpp>
 
@@ -14,10 +15,9 @@ template <> inline auto conc::injected_policy<> = test_conc_policy{};
 extern int log_calls;
 
 namespace {
-struct test_log_args_destination {
-    auto log_by_args(std::uint32_t, auto...) -> void { ++log_calls; }
+struct test_log_destination {
     template <std::size_t N>
-    auto log_by_buf(stdx::span<std::uint8_t const, N>) const {
+    auto operator()(stdx::span<std::uint32_t const, N>) const {
         ++log_calls;
     }
 };
@@ -28,7 +28,7 @@ using log_env2a = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 auto log_two_rt_args() -> void;
 
 auto log_two_rt_args() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     cfg.logger.log_msg<log_env2a>(
         stdx::ct_format<"D string with {} and {} placeholder">(
             std::uint32_t{1}, std::int64_t{2}));

--- a/test/log/catalog2b_lib.cpp
+++ b/test/log/catalog2b_lib.cpp
@@ -4,6 +4,7 @@
 #include <log/catalog/encoder.hpp>
 
 #include <stdx/ct_format.hpp>
+#include <stdx/span.hpp>
 
 #include <conc/concurrency.hpp>
 
@@ -14,8 +15,11 @@ template <> inline auto conc::injected_policy<> = test_conc_policy{};
 extern int log_calls;
 
 namespace {
-struct test_log_args_destination {
-    auto log_by_args(std::uint32_t, auto...) -> void { ++log_calls; }
+struct test_log_destination {
+    template <std::size_t N>
+    auto operator()(stdx::span<std::uint32_t const, N>) const {
+        ++log_calls;
+    }
 };
 
 using log_env2b = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
@@ -26,21 +30,21 @@ auto log_rt_float_arg() -> void;
 auto log_rt_double_arg() -> void;
 
 auto log_rt_enum_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
         stdx::ct_format<"E string with {} placeholder">(E::value));
 }
 
 auto log_rt_float_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
         stdx::ct_format<"Float string with {} placeholder">(3.14f));
 }
 
 auto log_rt_double_arg() -> void {
-    auto cfg = logging::binary::config{test_log_args_destination{}};
+    auto cfg = logging::binary::config{test_log_destination{}};
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
         stdx::ct_format<"Double string with {} placeholder">(3.14));

--- a/test/log/level.cpp
+++ b/test/log/level.cpp
@@ -5,6 +5,7 @@
 #include <stdx/ct_conversions.hpp>
 #include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/span.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -47,9 +48,13 @@ namespace {
 int log_calls{};
 
 struct test_destination {
-    auto log_by_args(std::uint32_t header, auto id, auto &&...) {
-        CHECK(header == 0x01'5a'00'53);
-        CHECK(id == 0xdeadbeef);
+    template <std::size_t N>
+    auto operator()(stdx::span<std::uint32_t const, N> pkt) const {
+        using namespace msg;
+        auto const msg =
+            msg::const_view<logging::mipi::defn::catalog_msg_t>{pkt};
+        CHECK(msg.get("severity"_f) ==
+              stdx::to_underlying(custom_level::THE_ONE_LEVEL));
         ++log_calls;
     }
 };

--- a/test/log/mipi_logger.cpp
+++ b/test/log/mipi_logger.cpp
@@ -1,6 +1,7 @@
 #include <log/catalog/encoder.hpp>
 
 #include <stdx/ct_string.hpp>
+#include <stdx/span.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -17,10 +18,11 @@ template <> inline auto version::config<> = version_config{};
 namespace {
 template <auto Header, auto... ExpectedArgs>
 struct test_log_version_destination {
-    template <typename... Args>
-    auto log_by_args(std::uint32_t header, Args... args) {
-        CHECK(header == Header);
-        (check(args, ExpectedArgs), ...);
+    template <std::size_t N>
+    auto operator()(stdx::span<std::uint32_t const, N> pkt) const {
+        std::uint32_t const *p = pkt.data();
+        CHECK(*p++ == Header);
+        (check(*p++, ExpectedArgs), ...);
     }
 };
 } // namespace


### PR DESCRIPTION
Problem:
- The writer has to be supplied in the log config; there are use cases for changing the writer in the environment. For instance this would provide an alternative, more flexible way to do secure logging.
- The hardcoded dichotomy between `log_by_args` and `log_by_buf` is annoying and a relic of the original implementation.

Solution:
- Allow the log writer to be passed in the log environment.
- Instead of `log_by_args` and `log_by_buf`, a writer should provide a function that takes the span to write. Now the callee can choose whether to make that a function template and potentially unroll the write loop, or just a function taking a dynamic span with a runtime loop.