### PR TITLE
:construction_worker: Add clang-21 to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
   DEFAULT_CXX_STANDARD: 20
-  DEFAULT_LLVM_VERSION: 20
+  DEFAULT_LLVM_VERSION: 21
   DEFAULT_GCC_VERSION: 14
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [12, 13, 14, 16, 17, 18, 19, 20]
+        version: [12, 13, 14, 16, 17, 18, 19, 20, 21]
         cxx_standard: [20]
         stdlib: [libstdc++, libc++]
         build_type: [Debug]
@@ -36,6 +36,15 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             cxx_flags: "-stdlib=libstdc++"
+          - version: 21
+            compiler: clang
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21
+            toolchain_root: "/usr/lib/llvm-21"
+          - version: 21
+            compiler: clang
+            stdlib: libc++
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21 && sudo apt install -y libc++-21-dev libc++abi-21-dev
+            cxx_flags: "-stdlib=libc++"
           - version: 20
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20 all
@@ -101,6 +110,8 @@ jobs:
             cxx: "g++-12"
             cxx_flags: ""
         exclude:
+          - compiler: gcc
+            version: 21
           - compiler: gcc
             version: 20
           - compiler: gcc

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -13,8 +13,8 @@ file for information.
 
 The following compilers are supported:
 
-* clang 14 thru 17
-* GCC 12 thru 13
+* clang 14 thru 21
+* GCC 12 thru 14
 
 C++20 is required.
 

--- a/include/flow/step.hpp
+++ b/include/flow/step.hpp
@@ -41,7 +41,7 @@ template <stdx::ct_string Type, stdx::ct_string Name, typename F>
                    cib::detail::always_condition_t, F>{};
 }
 
-constexpr auto empty_func = []() {};
+constexpr auto empty_func = []() -> void {};
 } // namespace detail
 
 template <stdx::ct_string Name, typename F>

--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -202,7 +202,7 @@ struct bits_locator_t {
     template <std::uint32_t NumBits>
     constexpr static auto fits_inside() -> bool {
         constexpr auto Msb = Lsb + BitSize - 1;
-        return Index * 32 + Msb <= NumBits;
+        return (Index * 32) + Msb <= NumBits;
     }
 
     template <typename T> constexpr static auto extent_in() -> std::size_t {

--- a/include/msg/indexed_builder.hpp
+++ b/include/msg/indexed_builder.hpp
@@ -65,11 +65,10 @@ struct indexed_builder
 
         constexpr auto baked_indices =
             temp_indices.apply([&]<typename... I>(I...) {
-                return indices {
+                return indices{
                     index{typename I::field_type{},
                           make_index_lookup.template operator()<I>(
-                              entry_index_seq.template operator()<I>())}...
-                };
+                              entry_index_seq.template operator()<I>())}...};
             });
 
         constexpr auto num_callbacks = BuilderValue::value.callbacks.size();


### PR DESCRIPTION
Problem:
- Clang 21 has been released and is not yet used by CI.

Solution:
- Add clang-21 to CI.