### PR TITLE
:rotating_light: Fix warnings arising from `-Wnrvo`

### DIFF
--- a/include/log/catalog/mipi_builder.hpp
+++ b/include/log/catalog/mipi_builder.hpp
@@ -32,7 +32,8 @@ template <packer P> struct builder<defn::short32_msg_t, P> {
 
 template <typename Storage, packer P> struct catalog_builder {
     template <auto Level, packable... Ts>
-    static auto build(string_id id, module_id m, unit_t u, Ts... args) {
+    static auto build(string_id id, module_id m, unit_t u, Ts... args)
+        -> defn::catalog_msg_t::owner_t<Storage> {
         using namespace msg;
         defn::catalog_msg_t::owner_t<Storage> message{
             "severity"_field = Level, "module_id"_field = m, "unit"_field = u};

--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -170,7 +170,8 @@ constexpr auto with_mask(T const mask, std::array<T, S> const &keys)
 }
 
 template <typename T, typename V, std::size_t S>
-constexpr auto get_keys(std::array<entry<T, V>, S> const &entries) {
+constexpr auto get_keys(std::array<entry<T, V>, S> const &entries)
+    -> std::array<detail::raw_integral_t<T>, S> {
     using raw_t = detail::raw_integral_t<T>;
     std::array<raw_t, S> new_keys{};
 
@@ -373,7 +374,8 @@ struct pseudo_pext_lookup {
             return empty_impl<key_type, value_type, default_value>{};
 
         } else if constexpr (use_indirect_strategy) {
-            constexpr auto storage = [&]() {
+            constexpr auto storage =
+                [&]() -> std::remove_const_t<decltype(input.entries)> {
                 auto s = input.entries;
 
                 // sort by the hashed key to group all the buckets together
@@ -416,8 +418,9 @@ struct pseudo_pext_lookup {
                 return s;
             }();
 
-            constexpr auto lookup_table = [&]() {
-                using lookup_idx_t = detail::uint_for_<storage.size()>;
+            using lookup_idx_t = detail::uint_for_<storage.size()>;
+            constexpr auto lookup_table =
+                [&]() -> std::array<lookup_idx_t, lookup_table_size> {
                 std::array<lookup_idx_t, lookup_table_size> t{};
 
                 t.fill(0);
@@ -442,7 +445,9 @@ struct pseudo_pext_lookup {
                 p, lookup_table, storage};
 
         } else {
-            constexpr auto storage = [&]() {
+            constexpr auto storage =
+                [&]() -> std::array<entry<raw_key_type, value_type>,
+                                    lookup_table_size> {
                 std::array<entry<raw_key_type, value_type>, lookup_table_size>
                     s{};
 

--- a/include/match/and.hpp
+++ b/include/match/and.hpp
@@ -25,9 +25,9 @@ template <matcher L, matcher R> struct and_t : bin_op_t<and_t, "and", L, R> {
         auto r = simplify(m.rhs);
 
         if constexpr (implies(l, r)) {
-            return l;
+            return [&] { return l; }();
         } else if constexpr (implies(r, l)) {
-            return r;
+            return [&] { return r; }();
         } else if constexpr (implies(l, negate(r)) or implies(r, negate(l))) {
             return never;
         } else {

--- a/include/match/or.hpp
+++ b/include/match/or.hpp
@@ -24,9 +24,9 @@ template <matcher L, matcher R> struct or_t : bin_op_t<or_t, "or", L, R> {
         auto r = simplify(m.rhs);
 
         if constexpr (implies(l, r)) {
-            return r;
+            return [&] { return r; }();
         } else if constexpr (implies(r, l)) {
-            return l;
+            return [&] { return l; }();
         } else if constexpr (implies(negate(l), r) or implies(negate(r), l)) {
             return always;
         } else {


### PR DESCRIPTION
Problem:
- CIB is not warning free with respect to -Wnrvo.

Solution:
- Add some trailing return types etc to fix warnings.