### PR TITLE
:children_crossing: Add `operator[]` to messages

### DIFF
--- a/test/msg/fail/CMakeLists.txt
+++ b/test/msg/fail/CMakeLists.txt
@@ -13,7 +13,11 @@ add_compile_fail_test(message_cmp_view.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(message_const_field_write.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(message_dangling_view.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(message_dup_fieldnames.cpp LIBRARIES warnings cib_msg)
+add_compile_fail_test(message_get_nonexistent_field.cpp LIBRARIES warnings
+                      cib_msg)
 add_compile_fail_test(message_incompatible_matcher.cpp LIBRARIES warnings
+                      cib_msg)
+add_compile_fail_test(message_set_nonexistent_field.cpp LIBRARIES warnings
                       cib_msg)
 add_compile_fail_test(message_uninitialized_field.cpp LIBRARIES warnings
                       cib_msg)

--- a/test/msg/fail/message_get_nonexistent_field.cpp
+++ b/test/msg/fail/message_get_nonexistent_field.cpp
@@ -1,0 +1,17 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: Field does not belong to this message
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"test_field", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1>;
+} // namespace
+
+auto main() -> int {
+    owning<msg_defn> m{};
+    [[maybe_unused]] auto f = m.get("no"_field);
+}

--- a/test/msg/fail/message_set_nonexistent_field.cpp
+++ b/test/msg/fail/message_set_nonexistent_field.cpp
@@ -1,0 +1,17 @@
+#include <msg/field.hpp>
+#include <msg/message.hpp>
+
+// EXPECT: Field does not belong to this message
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"test_field", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1>;
+} // namespace
+
+auto main() -> int {
+    owning<msg_defn> m{};
+    m.set("no"_field = 1);
+}

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -792,3 +792,18 @@ TEST_CASE("pack appends environments", "[message]") {
     using defn = pack<"defn", std::uint8_t, m1, m2>;
     STATIC_REQUIRE(custom(defn::env_t{}) == 18);
 }
+
+TEST_CASE("read indexing operator on message", "[message]") {
+    test_msg const msg{};
+    CHECK(0x80 == msg["id"_field]);
+}
+
+// This test causes clang-14 with libc++ to crash...
+#if not __clang__ or __clang_major__ > 14
+TEST_CASE("write indexing operator on message", "[message]") {
+    test_msg msg{};
+    CHECK((0 == msg["f1"_field]));
+    msg["f1"_field] = 0xba11;
+    CHECK((0xba11 == msg["f1"_field]));
+}
+#endif


### PR DESCRIPTION
Problem:
- Messages support `get` and `set` but not a natural indexing syntax.

Solution:
- Add `operator[]` to message, so that the follow work:

```c+++
msg["a"_field] = 42;
auto x = msg["a"_field];
```