### PR TITLE
:books: :arrow_up: Update mermaid config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 /mull.yml
 /requirements.txt
 /docs/puppeteer_config.json
+/docs/mermaid.conf

--- a/docs/flows.adoc
+++ b/docs/flows.adoc
@@ -72,7 +72,7 @@ to the flow.
 If we only use the `morning` component in our project, the `MorningRoutine` flow
 graph would look like the following:
 
-mermaid::morning_flow1.mmd[format="svg"]
+mermaid::morning_flow1.mmd[format="svg" config="mermaid.conf"]
 
 The power of `flow` services comes when more than one component adds actions to
 the flow. Flows can be extended by inserting additional actions with new
@@ -102,7 +102,7 @@ struct childcare {
 
 The new steps are inserted into the existing `flow`​'s dependency graph:
 
-mermaid::morning_flow2.mmd[format="svg"]
+mermaid::morning_flow2.mmd[format="svg" config="mermaid.conf"]
 
 Multiple independent components can add actions to the same `flow`. This is the
 power of `flow` services, they can be extended by multiple independent
@@ -128,7 +128,7 @@ all without the `MorningRoutine` source code having known about the new
 functionality. We can mix and match new components without modifying the
 original source code.
 
-mermaid::morning_flow3.mmd[format="svg"]
+mermaid::morning_flow3.mmd[format="svg" config="mermaid.conf"]
 
 The `cib` library will take care of initializing and building all services,
 including `flow` services. For `flow`​s, this means the dependency graph will be

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -55,7 +55,7 @@ _cib_ contains several parts that work together:
 Various sub-libraries within CIB form a dependency graph. `cib` is an omnibus
 library that contains all the functionality.
 
-mermaid::library_deps.mmd[format="svg"]
+mermaid::library_deps.mmd[format="svg" config="mermaid.conf"]
 
 === Getting Started
 

--- a/docs/logging.adoc
+++ b/docs/logging.adoc
@@ -199,7 +199,7 @@ begin with. It is specialized as follows:
 - Link-time optimization inlines the `catalog` function template
   specializations, each of which is a one-line function that returns an ID.
 
-mermaid::log_build_process.mmd[format="svg"]
+mermaid::log_build_process.mmd[format="svg" config="mermaid.conf"]
 
 NOTE: No logging exists in `main.cpp`: it's just a stub providing `main` that
 calls into the application's library code.


### PR DESCRIPTION
Problem:
- The default mermaid config causes truncated font rendering.

Solution:
- Use the CICD mermaid config file.