### PR TITLE
:art: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,20 @@
-build/
-/cmake-build-*
-/venv
-/.vscode
-/.idea
-/.cache
-/.DS_Store
+# ignore all directories that start with .
+**/.*/
+
+# ignore conventionally-named build directories
+**/build*/
+**/*build/
+# and some other build directories
+**/cmake-build-*/
+
+# ignore conventionally-named python virtual env directories
+# (this is only necessary before Python 3.13)
+**/venv*/
+**/*venv/
+# and __pycache__ directories
+**/__pycache__/
+
+# ignore files provided by CICD
 /.clang-format
 /.clang-tidy
 /.cmake-format.yaml


### PR DESCRIPTION
Problem:
- Cache directories made by various tools can be made in any directory, but are only ignored in the root directory.
- Conventional directory names containing "build" or "venv" should be ignored.

Solution:
- Alter .gitignore to properly ignore cache directories and conventionally-named venv/build directories.