### PR TITLE
:sparkles: Make flow logging a policy

### DIFF
--- a/docs/flows.adoc
+++ b/docs/flows.adoc
@@ -211,6 +211,18 @@ struct MyFlow : public flow::service<> {};
 struct MyFlowWithLogging : public flow::service<"MyFlowWithLogging"> {};
 ----
 
+Alternatively, a flow's logging can be silenced by giving it a different logging
+policy:
+
+[source,cpp]
+----
+// declare a named flow without logging
+struct EarlyInitFlow : public flow::service<"EarlyInit", flow::log_policies::none> {};
+----
+
+This can be useful for dealing with "early initialization" steps and flows which
+happen before logging is initialized.
+
 ==== `action`
 
 Defines a new `flow` action. All `flow` actions are created with a name and a

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -3,17 +3,20 @@
 #include <flow/common.hpp>
 #include <flow/graph_builder.hpp>
 #include <flow/impl.hpp>
+#include <flow/log.hpp>
 
 #include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/panic.hpp>
 
 namespace flow {
-template <stdx::ct_string Name = "">
-using builder = graph<Name, graph_builder<Name, impl>>;
+template <stdx::ct_string Name = "",
+          typename LogPolicy = flow::log_policy_t<Name>>
+using builder = graph<Name, LogPolicy>;
 
-template <stdx::ct_string Name = ""> struct service {
-    using builder_t = builder<Name>;
+template <stdx::ct_string Name = "", typename LogPolicy = log_policy_t<Name>>
+struct service {
+    using builder_t = builder<Name, LogPolicy>;
     using interface_t = FunctionPtr;
 
     CONSTEVAL static auto uninitialized() -> interface_t {

--- a/include/flow/log.hpp
+++ b/include/flow/log.hpp
@@ -3,7 +3,10 @@
 #include <log/env.hpp>
 #include <log/log.hpp>
 
+#include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/env.hpp>
+#include <stdx/type_traits.hpp>
 
 #include <type_traits>
 
@@ -32,4 +35,21 @@ constexpr static auto get_log_env() {
         return log_env_t{};
     }
 }
+
+namespace log_policies {
+struct none {
+    template <typename> ALWAYS_INLINE static auto log(auto &&...) -> void {}
+};
+
+struct normal {
+    template <typename Env, typename... Args>
+    ALWAYS_INLINE static auto log(Args &&...args) -> void {
+        logging::log<Env>(std::forward<Args>(args)...);
+    }
+};
+} // namespace log_policies
+
+template <stdx::ct_string Name>
+using log_policy_t =
+    stdx::conditional_t<Name.empty(), log_policies::none, log_policies::normal>;
 } // namespace flow

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -2,16 +2,21 @@
 
 #include <flow/common.hpp>
 #include <flow/graph_builder.hpp>
+#include <flow/log.hpp>
 #include <seq/impl.hpp>
 
 #include <stdx/ct_string.hpp>
 
 namespace seq {
-template <stdx::ct_string Name = "">
-using builder = flow::graph<Name, flow::graph_builder<Name, impl>>;
+template <stdx::ct_string Name = "",
+          typename LogPolicy = flow::log_policy_t<Name>>
+using builder =
+    flow::graph<Name, LogPolicy, flow::graph_builder<Name, impl, LogPolicy>>;
 
-template <stdx::ct_string Name = ""> struct service {
-    using builder_t = builder<Name>;
+template <stdx::ct_string Name = "",
+          typename LogPolicy = flow::log_policy_t<Name>>
+struct service {
+    using builder_t = builder<Name, LogPolicy>;
     using interface_t = flow::FunctionPtr;
 };
 } // namespace seq

--- a/include/seq/impl.hpp
+++ b/include/seq/impl.hpp
@@ -14,7 +14,8 @@
 namespace seq {
 enum struct direction : std::uint8_t { FORWARD, BACKWARD };
 
-template <stdx::ct_string, std::size_t NumSteps> struct impl {
+template <stdx::ct_string, typename LogPolicy, std::size_t NumSteps>
+struct impl {
     stdx::cx_vector<func_ptr, NumSteps> _forward_steps{};
     stdx::cx_vector<func_ptr, NumSteps> _backward_steps{};
     std::size_t next_step{};

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -49,10 +49,12 @@ TEST_CASE("run empty flow through cib::nexus", "[flow]") {
 }
 
 namespace {
-template <stdx::ct_string Name = "">
-using alt_builder = flow::graph<Name, flow::graphviz_builder>;
-template <stdx::ct_string Name = ""> struct alt_flow_service {
-    using builder_t = alt_builder<Name>;
+template <stdx::ct_string Name, typename LogPolicy>
+using alt_builder = flow::graph<Name, LogPolicy, flow::graphviz_builder>;
+template <stdx::ct_string Name = "",
+          typename LogPolicy = flow::log_policy_t<Name>>
+struct alt_flow_service {
+    using builder_t = alt_builder<Name, LogPolicy>;
     using interface_t = flow::VizFunctionPtr;
     constexpr static auto uninitialized() -> interface_t { return {}; }
 };

--- a/test/flow/logging.cpp
+++ b/test/flow/logging.cpp
@@ -31,6 +31,8 @@ constexpr auto run_flow = [] {
 
 struct TestFlowAlpha : public flow::service<> {};
 struct NamedTestFlow : public flow::service<"TestFlow"> {};
+struct NoLogTestFlow
+    : public flow::service<"TestFlow", flow::log_policies::none> {};
 
 constexpr auto a = flow::action<"a">([] {});
 } // namespace
@@ -38,6 +40,11 @@ constexpr auto a = flow::action<"a">([] {});
 template <>
 inline auto logging::config<> =
     logging::fmt::config{std::back_inserter(log_buffer)};
+
+TEST_CASE("log policies model concept", "[flow_logging]") {
+    STATIC_REQUIRE(flow::log_policy<flow::log_policies::none>);
+    STATIC_REQUIRE(flow::log_policy<flow::log_policies::normal>);
+}
 
 TEST_CASE("unnamed flow does not log start/end", "[flow_logging]") {
     run_flow<TestFlowAlpha, cib::exports<TestFlowAlpha>>();
@@ -71,4 +78,19 @@ TEST_CASE("named flow logs milestones", "[flow_logging]") {
              cib::extend<NamedTestFlow>(*"ms"_milestone)>();
 
     CHECK(log_buffer.find("flow.milestone(ms)") != std::string::npos);
+}
+
+TEST_CASE("named flow with logging policy none does not log flow start/end",
+          "[flow_logging]") {
+    run_flow<NoLogTestFlow, cib::exports<NoLogTestFlow>>();
+
+    CHECK(std::empty(log_buffer));
+}
+
+TEST_CASE("named flow with logging policy none does not log flow actions",
+          "[flow_logging]") {
+    run_flow<NoLogTestFlow, cib::exports<NoLogTestFlow>,
+             cib::extend<NoLogTestFlow>(*a)>();
+
+    CHECK(std::empty(log_buffer));
 }


### PR DESCRIPTION
Problem:
- Whether or not a flow and its steps are logged is dependent on whether or not the flow is named. This is brittle.

Solution:
- Configure flow logging with a policy.

Note:
- For backward compatibility, the default policy is chosen based on whether the flow name is empty.