### PR TITLE
:sparkles: Allow a field's type to be changed

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -530,6 +530,12 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
                                   msg::equal_to_t<field_t, V>, Ats...>;
 
     // ======================================================================
+    // retype field
+    template <typename U>
+    using with_new_type =
+        field_t<Name, U, detail::with_default<U>, match::always_t, Ats...>;
+
+    // ======================================================================
     // shift a field
     template <auto N, typename Unit = bit_unit>
     using shifted_by =

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -497,6 +497,14 @@ TEST_CASE("extend message with new field constraint", "[message]") {
     STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
+TEST_CASE("extend message with retyped field", "[message]") {
+    using base_defn = message<"msg_base", id_field, field1>;
+    using defn = extend<base_defn, "msg", field1::with_new_type<std::uint16_t>>;
+    using expected_defn =
+        message<"msg", id_field, field1::with_new_type<std::uint16_t>>;
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
+}
+
 TEST_CASE("message equivalence (owning)", "[message]") {
     test_msg m1{"f1"_field = 0xba11, "f2"_field = 0x42, "f3"_field = 0xd00d};
     test_msg m2{"f1"_field = 0xba11, "f2"_field = 0x42, "f3"_field = 0xd00d};


### PR DESCRIPTION
Problem:
- It is sometimes useful to change the type of a message field. When specifying a "base message" we may know the storage constraints only but not necessarily the desired "leaf" type. e.g. A header with an N-bit field that is extended when more type information is known to give the field has a certain enumeration type.

Solution:
- Allow extending a message to change the type of a field.

Note:
- Changing a field's type resets its default/required value (if any) and its matcher. These can be updated to conform with the new type using existing mechanisms.