### PR TITLE
:sparkles: Rename a field in a message

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -536,6 +536,11 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
         field_t<Name, U, detail::with_default<U>, match::always_t, Ats...>;
 
     // ======================================================================
+    // rename field
+    template <stdx::ct_string NewName>
+    using with_new_name = field_t<NewName, T, Default, M, Ats...>;
+
+    // ======================================================================
     // shift a field
     template <auto N, typename Unit = bit_unit>
     using shifted_by =

--- a/test/msg/fail/CMakeLists.txt
+++ b/test/msg/fail/CMakeLists.txt
@@ -21,4 +21,6 @@ add_compile_fail_test(message_set_nonexistent_field.cpp LIBRARIES warnings
                       cib_msg)
 add_compile_fail_test(message_uninitialized_field.cpp LIBRARIES warnings
                       cib_msg)
+add_compile_fail_test(rename_field_duplicate.cpp LIBRARIES warnings cib_msg)
+add_compile_fail_test(rename_field_not_found.cpp LIBRARIES warnings cib_msg)
 add_compile_fail_test(view_upsize.cpp LIBRARIES warnings cib_msg)

--- a/test/msg/fail/rename_field_duplicate.cpp
+++ b/test/msg/fail/rename_field_duplicate.cpp
@@ -1,0 +1,15 @@
+#include <msg/message.hpp>
+
+// EXPECT: New field name already exists in message
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"f1", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+using test_field2 =
+    field<"f2", std::uint32_t>::located<at{0_dw, 23_msb, 16_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1, test_field2>;
+} // namespace
+
+auto main() -> int { using M = rename_field<msg_defn, "f1", "f2">; }

--- a/test/msg/fail/rename_field_not_found.cpp
+++ b/test/msg/fail/rename_field_not_found.cpp
@@ -1,0 +1,13 @@
+#include <msg/message.hpp>
+
+// EXPECT: Old field name not found in message
+namespace {
+using namespace msg;
+
+using test_field1 =
+    field<"f1", std::uint32_t>::located<at{0_dw, 31_msb, 24_lsb}>;
+
+using msg_defn = message<"test_msg", test_field1>;
+} // namespace
+
+auto main() -> int { using M = rename_field<msg_defn, "f", "F">; }

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -505,6 +505,15 @@ TEST_CASE("extend message with retyped field", "[message]") {
     STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
 }
 
+TEST_CASE("rename field in message", "[message]") {
+    using base_defn = message<"msg_base", id_field, field1>;
+    using defn = rename_field<base_defn, "f1", "f1_new">;
+    using expected_f =
+        field<"f1_new", std::uint32_t>::located<at{0_dw, 15_msb, 0_lsb}>;
+    using expected_defn = message<"msg_base", id_field, expected_f>;
+    STATIC_REQUIRE(std::is_same_v<defn, expected_defn>);
+}
+
 TEST_CASE("message equivalence (owning)", "[message]") {
     test_msg m1{"f1"_field = 0xba11, "f2"_field = 0x42, "f3"_field = 0xd00d};
     test_msg m2{"f1"_field = 0xba11, "f2"_field = 0x42, "f3"_field = 0xd00d};


### PR DESCRIPTION
Problem:
- It is sometimes useful to rename a field in a message. Since fields are identified by name, this cannot be done with the existing `extend` mechanism.

Solution:
- Introduce `rename_field<Msg, OldName, NewName>` for this purpose.