### PR TITLE
:sparkles: Add `uninitialized` state for fields

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -497,7 +497,7 @@ struct message {
         constexpr owner_t() {
             using uninit_fields =
                 boost::mp11::mp_remove_if<boost::mp11::mp_list<Fields...>,
-                                          has_default_value_t>;
+                                          initializable_t>;
             static_assert(boost::mp11::mp_empty<uninit_fields>::value,
                           "All fields must be initialized or defaulted");
             this->set(Fields{}...);
@@ -507,7 +507,7 @@ struct message {
             using defaulted_fields = boost::mp11::mp_transform<
                 name_for,
                 boost::mp11::mp_copy_if<boost::mp11::mp_list<Fields...>,
-                                        has_default_value_t>>;
+                                        initializable_t>>;
             using initialized_fields =
                 boost::mp11::mp_transform<name_for,
                                           boost::mp11::mp_list<Vs...>>;

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -824,3 +824,19 @@ TEST_CASE("write indexing operator on message", "[message]") {
     CHECK((0xba11 == msg["f1"_field]));
 }
 #endif
+
+namespace {
+using bit_field1 =
+    field<"f1",
+          std::uint32_t>::located<at{0_dw, 0_msb, 0_lsb}>::with_required<1>;
+using all_fields =
+    field<"all", std::uint32_t>::located<at{0_dw, 31_msb, 0_lsb}>;
+
+using overlap_msg_defn = message<"msg", bit_field1, all_fields::uninitialized>;
+} // namespace
+
+TEST_CASE("message with uninitialized field", "[message]") {
+    owning<overlap_msg_defn> msg{};
+    auto data = msg.data();
+    CHECK(data[0] == 1);
+}


### PR DESCRIPTION
Problem:
- Sometimes it is useful to use fields that overlap: for instance to be able to inspect individual bits _and_ have an overlapping field that represents the set of bits as a whole. In these cases it is useful at construction time to leave such an overlapping field uninitialized so that we don't have a scenario where one initialization overwrites another.

Solution:
- Allow a field to be marked as `uninitialized` so that on construction it won't potentially clobber other fields.

Note:
- The difference between `without_default` and `uninitialized` is that a field marked `without_default` must still be given a value at construction time.