### PR TITLE
:art: Refactor flow builder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,15 +241,17 @@ target_sources(
               include
               FILES
               include/flow/builder.hpp
-              include/flow/common.hpp
-              include/flow/detail/par.hpp
-              include/flow/detail/seq.hpp
-              include/flow/detail/walk.hpp
+              include/flow/dsl/par.hpp
+              include/flow/dsl/seq.hpp
+              include/flow/dsl/subgraph_identity.hpp
+              include/flow/dsl/walk.hpp
               include/flow/flow.hpp
+              include/flow/func_list.hpp
               include/flow/graph_builder.hpp
               include/flow/graphviz_builder.hpp
-              include/flow/impl.hpp
+              include/flow/log.hpp
               include/flow/run.hpp
+              include/flow/service.hpp
               include/flow/step.hpp)
 
 add_library(cib_seq INTERFACE)

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -1,30 +1,47 @@
 #pragma once
 
-#include <flow/common.hpp>
+#include <flow/dsl/walk.hpp>
 #include <flow/graph_builder.hpp>
-#include <flow/impl.hpp>
 #include <flow/log.hpp>
 
-#include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
-#include <stdx/panic.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+#include <stdx/type_traits.hpp>
+
+#include <utility>
 
 namespace flow {
-template <stdx::ct_string Name = "",
-          typename LogPolicy = flow::log_policy_t<Name>>
-using builder = graph<Name, LogPolicy>;
+template <typename Renderer, flow::dsl::subgraph... Fragments>
+class builder_for {
+    template <typename Tag>
+    friend constexpr auto tag_invoke(Tag, builder_for const &b) {
+        return b.fragments.apply([](auto const &...frags) {
+            return stdx::tuple_cat(Tag{}(frags)...);
+        });
+    }
+
+  public:
+    using interface_t = typename Renderer::interface_t;
+    constexpr static auto name = Renderer::name;
+
+    template <flow::dsl::subgraph... Ns>
+    [[nodiscard]] constexpr auto add(Ns &&...ns) {
+        return fragments.apply([&](auto &...frags) {
+            return builder_for<Renderer, Fragments...,
+                               stdx::remove_cvref_t<Ns>...>{
+                {frags..., std::forward<Ns>(ns)...}};
+        });
+    }
+
+    template <typename BuilderValue>
+    [[nodiscard]] constexpr static auto build() {
+        return Renderer::template render<BuilderValue>();
+    }
+
+    stdx::tuple<Fragments...> fragments;
+};
 
 template <stdx::ct_string Name = "", typename LogPolicy = log_policy_t<Name>>
-struct service {
-    using builder_t = builder<Name, LogPolicy>;
-    using interface_t = FunctionPtr;
-
-    CONSTEVAL static auto uninitialized() -> interface_t {
-        return [] {
-            using namespace stdx::literals;
-            stdx::panic<"Attempting to run flow ("_cts + Name +
-                        ") before it is initialized"_cts>();
-        };
-    }
-};
+using builder = builder_for<graph_builder<Name, LogPolicy>>;
 } // namespace flow

--- a/include/flow/common.hpp
+++ b/include/flow/common.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace flow {
-using FunctionPtr = auto (*)() -> void;
-} // namespace flow

--- a/include/flow/dsl/par.hpp
+++ b/include/flow/dsl/par.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <flow/detail/walk.hpp>
-#include <flow/subgraph_identity.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
+#include <flow/dsl/walk.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
 
@@ -59,7 +59,7 @@ template <flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs>
 }
 
 template <typename Cond, flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs,
-          flow::subgraph_identity Identity>
+          flow::dsl::subgraph_identity Identity>
 constexpr auto make_runtime_conditional(Cond,
                                         flow::dsl::par<Lhs, Rhs, Identity>) {
     auto lhs = make_runtime_conditional(Cond{}, Lhs{});

--- a/include/flow/dsl/seq.hpp
+++ b/include/flow/dsl/seq.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cib/detail/runtime_conditional.hpp>
-#include <flow/detail/walk.hpp>
-#include <flow/subgraph_identity.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
+#include <flow/dsl/walk.hpp>
 
 #include <stdx/tuple_algorithms.hpp>
 
@@ -72,7 +72,7 @@ template <flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs>
 }
 
 template <typename Cond, flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs,
-          flow::subgraph_identity Identity, typename EdgeCond>
+          flow::dsl::subgraph_identity Identity, typename EdgeCond>
 constexpr auto
 make_runtime_conditional(Cond, flow::dsl::seq<Lhs, Rhs, Identity, EdgeCond>) {
     auto lhs = make_runtime_conditional(Cond{}, Lhs{});

--- a/include/flow/dsl/subgraph_identity.hpp
+++ b/include/flow/dsl/subgraph_identity.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace flow::dsl {
+enum struct subgraph_identity : bool { VALUE, REFERENCE };
+}

--- a/include/flow/dsl/walk.hpp
+++ b/include/flow/dsl/walk.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <flow/subgraph_identity.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
 
 #include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>

--- a/include/flow/flow.hpp
+++ b/include/flow/flow.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <flow/builder.hpp>
-#include <flow/common.hpp>
-#include <flow/detail/par.hpp>
-#include <flow/detail/seq.hpp>
-#include <flow/impl.hpp>
+#include <flow/dsl/par.hpp>
+#include <flow/dsl/seq.hpp>
 #include <flow/run.hpp>
+#include <flow/service.hpp>
 #include <flow/step.hpp>

--- a/include/flow/graphviz_builder.hpp
+++ b/include/flow/graphviz_builder.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <flow/detail/walk.hpp>
+#include <flow/dsl/walk.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/tuple_algorithms.hpp>
 
 #include <set>
@@ -9,9 +10,7 @@
 #include <string_view>
 
 namespace flow {
-using VizFunctionPtr = auto (*)() -> std::string;
-
-struct graphviz_builder {
+template <stdx::ct_string Name> struct graphviz_builder {
     template <typename Graph>
     [[nodiscard]] static auto build(Graph const &input) {
         auto const nodes = flow::dsl::get_nodes(input);
@@ -54,6 +53,9 @@ struct graphviz_builder {
         return output;
     }
 
+    constexpr static auto name = Name;
+    using interface_t = auto (*)() -> std::string;
+
     template <typename Initialized> class built_flow {
         static auto built() {
             auto const v = Initialized::value;
@@ -64,10 +66,8 @@ struct graphviz_builder {
 
       public:
         // NOLINTNEXTLINE(google-explicit-constructor)
-        constexpr explicit(false) operator VizFunctionPtr() const {
-            return run;
-        }
-        auto operator()() const -> std::string { return run(); }
+        constexpr explicit(false) operator interface_t() const { return run; }
+        auto operator()() const { return run(); }
         constexpr static bool active = true;
     };
 

--- a/include/flow/log.hpp
+++ b/include/flow/log.hpp
@@ -4,11 +4,14 @@
 #include <log/log.hpp>
 
 #include <stdx/compiler.hpp>
+#include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/env.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <concepts>
 #include <type_traits>
+#include <utility>
 
 namespace flow {
 using default_log_env =
@@ -52,4 +55,11 @@ struct normal {
 template <stdx::ct_string Name>
 using log_policy_t =
     stdx::conditional_t<Name.empty(), log_policies::none, log_policies::normal>;
+
+template <typename T>
+concept log_policy = requires {
+    {
+        T::template log<default_log_env>(stdx::ct_format<"">())
+    } -> std::same_as<void>;
+};
 } // namespace flow

--- a/include/flow/run.hpp
+++ b/include/flow/run.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cib/built.hpp>
-#include <flow/common.hpp>
 
 namespace flow {
 /**
@@ -10,5 +9,5 @@ namespace flow {
  * @tparam Tag Type of the flow to be ran. This is the name of the flow::builder
  * used to declare and build the flow.
  */
-template <typename Tag> FunctionPtr &run = cib::service<Tag>;
+template <typename Tag> auto &run = cib::service<Tag>;
 } // namespace flow

--- a/include/flow/service.hpp
+++ b/include/flow/service.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <flow/builder.hpp>
+#include <flow/log.hpp>
+
+#include <stdx/compiler.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/panic.hpp>
+
+namespace flow {
+template <typename Builder> struct service_for {
+    using builder_t = Builder;
+    using interface_t = typename builder_t::interface_t;
+
+    CONSTEVAL static auto uninitialized() -> interface_t {
+        return [] {
+            using namespace stdx::literals;
+            stdx::panic<"Attempting to run flow ("_cts + builder_t::name +
+                        ") before it is initialized"_cts>();
+        };
+    }
+};
+
+template <stdx::ct_string Name = "", typename LogPolicy = log_policy_t<Name>>
+using service = service_for<builder<Name, LogPolicy>>;
+} // namespace flow

--- a/include/flow/step.hpp
+++ b/include/flow/step.hpp
@@ -2,9 +2,8 @@
 
 #include <cib/detail/runtime_conditional.hpp>
 #include <cib/func_decl.hpp>
-#include <flow/common.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
 #include <flow/log.hpp>
-#include <flow/subgraph_identity.hpp>
 
 #include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
@@ -14,7 +13,7 @@
 
 namespace flow {
 template <stdx::ct_string Type, stdx::ct_string Name,
-          subgraph_identity Identity, typename Cond, typename F>
+          dsl::subgraph_identity Identity, typename Cond, typename F>
 struct ct_node {
     using is_subgraph = void;
     using name_t = stdx::cts_t<Name>;
@@ -26,8 +25,9 @@ struct ct_node {
     constexpr static auto condition = Cond{};
 
     constexpr auto operator*() const {
-        if constexpr (Identity == subgraph_identity::REFERENCE) {
-            return ct_node<Type, Name, subgraph_identity::VALUE, Cond, F>{};
+        if constexpr (Identity == dsl::subgraph_identity::REFERENCE) {
+            return ct_node<Type, Name, dsl::subgraph_identity::VALUE, Cond,
+                           F>{};
         } else {
             return ct_node{};
         }
@@ -37,7 +37,7 @@ struct ct_node {
 namespace detail {
 template <stdx::ct_string Type, stdx::ct_string Name, typename F>
 [[nodiscard]] constexpr auto make_node() {
-    return ct_node<Type, Name, subgraph_identity::REFERENCE,
+    return ct_node<Type, Name, dsl::subgraph_identity::REFERENCE,
                    cib::detail::always_condition_t, F>{};
 }
 
@@ -78,10 +78,10 @@ template <stdx::ct_string S>
 } // namespace literals
 
 template <typename Cond, stdx::ct_string Type, stdx::ct_string Name,
-          subgraph_identity Identity, typename NodeCond, typename F>
+          dsl::subgraph_identity Identity, typename NodeCond, typename F>
 constexpr auto
 make_runtime_conditional(Cond, ct_node<Type, Name, Identity, NodeCond, F>) {
-    if constexpr (Identity == subgraph_identity::VALUE) {
+    if constexpr (Identity == dsl::subgraph_identity::VALUE) {
         return ct_node<Type, Name, Identity, decltype(NodeCond{} and Cond{}),
                        F>{};
     } else {

--- a/include/flow/subgraph_identity.hpp
+++ b/include/flow/subgraph_identity.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace flow {
-enum class subgraph_identity { VALUE, REFERENCE };
-}

--- a/include/seq/builder.hpp
+++ b/include/seq/builder.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <flow/common.hpp>
-#include <flow/graph_builder.hpp>
+#include <flow/builder.hpp>
 #include <flow/log.hpp>
 #include <seq/impl.hpp>
 
@@ -10,13 +9,12 @@
 namespace seq {
 template <stdx::ct_string Name = "",
           typename LogPolicy = flow::log_policy_t<Name>>
-using builder =
-    flow::graph<Name, LogPolicy, flow::graph_builder<Name, impl, LogPolicy>>;
+using builder = flow::builder_for<flow::graph_builder<Name, LogPolicy, impl>>;
 
 template <stdx::ct_string Name = "",
           typename LogPolicy = flow::log_policy_t<Name>>
 struct service {
     using builder_t = builder<Name, LogPolicy>;
-    using interface_t = flow::FunctionPtr;
+    using interface_t = void (*)();
 };
 } // namespace seq

--- a/include/seq/step.hpp
+++ b/include/seq/step.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cib/detail/runtime_conditional.hpp>
-#include <flow/subgraph_identity.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
 #include <log/log.hpp>
 
 #include <stdx/ct_string.hpp>
@@ -32,7 +32,7 @@ struct ct_step : rt_step {
     using is_subgraph = void;
     using name_t = stdx::cts_t<Name>;
 
-    constexpr static auto identity = flow::subgraph_identity::VALUE;
+    constexpr static auto identity = flow::dsl::subgraph_identity::VALUE;
 
     constexpr static auto condition = cib::detail::always_condition;
 

--- a/test/flow/CMakeLists.txt
+++ b/test/flow/CMakeLists.txt
@@ -10,9 +10,9 @@ add_unit_test(
 
 add_tests(
     FILES
+    builder
     flow
     flow_uninit
-    graph
     graph_builder
     logging
     log_levels

--- a/test/flow/builder.cpp
+++ b/test/flow/builder.cpp
@@ -20,32 +20,32 @@ constexpr auto b = flow::action<"b">([] {});
 constexpr auto c = flow::action<"c">([] {});
 } // namespace
 
-TEST_CASE("node size (empty graph)", "[graph]") {
-    constexpr auto g = flow::graph<>{};
+TEST_CASE("node size (empty graph)", "[builder]") {
+    constexpr auto g = flow::builder<>{};
     STATIC_REQUIRE(node_size(g) == 0);
 }
 
-TEST_CASE("node size (single action)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(*a >> *b);
+TEST_CASE("node size (single action)", "[builder]") {
+    constexpr auto g = flow::builder<>{}.add(*a >> *b);
     STATIC_REQUIRE(node_size(g) == 2);
 }
 
-TEST_CASE("node size (overlapping actions)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(*a >> *b).add(b >> *c);
+TEST_CASE("node size (overlapping actions)", "[builder]") {
+    constexpr auto g = flow::builder<>{}.add(*a >> *b).add(b >> *c);
     STATIC_REQUIRE(node_size(g) == 3);
 }
 
-TEST_CASE("edge size (empty flow)", "[graph]") {
-    constexpr auto g = flow::graph<>{};
+TEST_CASE("edge size (empty flow)", "[builder]") {
+    constexpr auto g = flow::builder<>{};
     STATIC_REQUIRE(edge_size(g) == 1);
 }
 
-TEST_CASE("edge size (single action)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(*a >> *b);
+TEST_CASE("edge size (single action)", "[builder]") {
+    constexpr auto g = flow::builder<>{}.add(*a >> *b);
     STATIC_REQUIRE(edge_size(g) == 1);
 }
 
-TEST_CASE("edge size (overlapping actions)", "[graph]") {
-    constexpr auto g = flow::graph<>{}.add(*a >> *b).add(*b >> *c);
+TEST_CASE("edge size (overlapping actions)", "[builder]") {
+    constexpr auto g = flow::builder<>{}.add(*a >> *b).add(*b >> *c);
     STATIC_REQUIRE(edge_size(g) == 2);
 }

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -49,17 +49,10 @@ TEST_CASE("run empty flow through cib::nexus", "[flow]") {
 }
 
 namespace {
-template <stdx::ct_string Name, typename LogPolicy>
-using alt_builder = flow::graph<Name, LogPolicy, flow::graphviz_builder>;
-template <stdx::ct_string Name = "",
-          typename LogPolicy = flow::log_policy_t<Name>>
-struct alt_flow_service {
-    using builder_t = alt_builder<Name, LogPolicy>;
-    using interface_t = flow::VizFunctionPtr;
-    constexpr static auto uninitialized() -> interface_t { return {}; }
-};
+template <stdx::ct_string Name>
+using alt_builder = flow::builder_for<flow::graphviz_builder<Name>>;
 
-struct VizFlow : public alt_flow_service<"debug"> {};
+struct VizFlow : public flow::service_for<alt_builder<"debug">> {};
 struct VizConfig {
     constexpr static auto config =
         cib::config(cib::exports<VizFlow>, cib::extend<VizFlow>(*a));

--- a/test/flow/flow_uninit.cpp
+++ b/test/flow/flow_uninit.cpp
@@ -1,5 +1,5 @@
 #include <cib/built.hpp>
-#include <flow/builder.hpp>
+#include <flow/service.hpp>
 
 #include <stdx/panic.hpp>
 

--- a/test/flow/graph_builder.cpp
+++ b/test/flow/graph_builder.cpp
@@ -17,12 +17,12 @@ constexpr auto b = flow::action<"b">([] { actual += "b"; });
 constexpr auto c = flow::action<"c">([] { actual += "c"; });
 constexpr auto d = flow::action<"d">([] { actual += "d"; });
 
-using builder = flow::graph_builder<"test_flow", flow::impl>;
+using builder = flow::graph_builder<"test_flow">;
 } // namespace
 
 template <auto... Vs> struct run_flow_t {
     struct wrapper {
-        constexpr static auto value = flow::graph<>{}.add(Vs...);
+        constexpr static auto value = flow::builder<>{}.add(Vs...);
     };
 
     auto operator()() const -> void { builder::render<wrapper>()(); }
@@ -207,8 +207,8 @@ TEST_CASE("add dependency rhs", "[graph_builder]") {
 }
 
 TEST_CASE("reference vs non-reference", "[graph_builder]") {
-    STATIC_REQUIRE(a.identity == flow::subgraph_identity::REFERENCE);
-    STATIC_REQUIRE((*a).identity == flow::subgraph_identity::VALUE);
+    STATIC_REQUIRE(a.identity == flow::dsl::subgraph_identity::REFERENCE);
+    STATIC_REQUIRE((*a).identity == flow::dsl::subgraph_identity::VALUE);
 }
 
 TEST_CASE("reference in order with non-reference added twice",
@@ -219,8 +219,8 @@ TEST_CASE("reference in order with non-reference added twice",
 #endif
 
 TEST_CASE("alternate builder", "[graph_builder]") {
-    using alt_builder = flow::graphviz_builder;
-    auto g = flow::graph<"debug">{}.add(*a && (*b >> *c));
+    using alt_builder = flow::graphviz_builder<"debug">;
+    auto g = flow::builder_for<alt_builder>{}.add(*a && (*b >> *c));
     auto const flow = alt_builder::build(g);
     auto expected = std::string{
         R"__debug__(digraph debug {

--- a/test/seq/sequencer.cpp
+++ b/test/seq/sequencer.cpp
@@ -10,7 +10,8 @@ namespace {
 int attempt_count;
 std::string result{};
 
-using builder = flow::graph_builder<"test_seq", seq::impl>;
+using builder =
+    flow::graph_builder<"test_seq", flow::log_policies::normal, seq::impl>;
 } // namespace
 
 TEST_CASE("build and run empty seq", "[seq]") {

--- a/usage_test/main_flow.cpp
+++ b/usage_test/main_flow.cpp
@@ -1,13 +1,15 @@
 #include <flow/builder.hpp>
-#include <flow/common.hpp>
-#include <flow/detail/par.hpp>
-#include <flow/detail/seq.hpp>
-#include <flow/detail/walk.hpp>
+#include <flow/dsl/par.hpp>
+#include <flow/dsl/seq.hpp>
+#include <flow/dsl/subgraph_identity.hpp>
+#include <flow/dsl/walk.hpp>
 #include <flow/flow.hpp>
+#include <flow/func_list.hpp>
 #include <flow/graph_builder.hpp>
 #include <flow/graphviz_builder.hpp>
-#include <flow/impl.hpp>
+#include <flow/log.hpp>
 #include <flow/run.hpp>
+#include <flow/service.hpp>
 #include <flow/step.hpp>
 
 #if __STDC_HOSTED__ == 0


### PR DESCRIPTION
Problem:
- The flow `service`s and `builder`s are too coupled to their implementations, viz:
  - `flow::FunctionPtr` is used for both the interface function on the `service` and the node type for the inlined function list; these have nothing to do with each other.
  - The `service` needs to know about the builder's interface.
  - The `graph_builder` knows about details of inlining the function list.
  - The `impl` is poorly named (it was named for the first, but now not the only, implementation).

Solution:
- Inject the builders and implementations at the correct levels.
- Instead of passing through template arguments, expose names and interfaces from lower levels. This enables concepts (TBD).