### PR TITLE
cmake: use ${PROJECT_NAME}_IS_TOP_LEVEL instead of PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(
     HOMEPAGE_URL "https://github.com/intel/compile-time-init-build")
 
 include(cmake/get_cpm.cmake)
-if(PROJECT_IS_TOP_LEVEL)
+if(${PROJECT_NAME}_IS_TOP_LEVEL)
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")
 else()
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
@@ -298,7 +298,7 @@ target_sources(
               include/cib/cib.hpp
               include/cib/top.hpp)
 
-if(PROJECT_IS_TOP_LEVEL)
+if(${PROJECT_NAME}_IS_TOP_LEVEL)
     add_docs(docs)
     clang_tidy_interface(cib)
     clang_tidy_interface(cib_flow)


### PR DESCRIPTION
I use FetchContent_Declare() and FetchContent_MakeAvailable() to pull in the cib dependency to an ESP-IDF project (among others). Strangely, at least with cmake version 3.28.3, PROJECT_IS_TOP_LEVEL evaluates to true in such scenarios. The outcome of the mixup is a completely broken build. Using ${PROJECT_NAME}_IS_TOP_LEVEL solves the problem, as it produces the expected behavior.