### PR TITLE
:sparkles: Allow parts of flow graphs to be shown during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ target_sources(
               include
               FILES
               include/flow/builder.hpp
+              include/flow/debug_builder.hpp
               include/flow/dsl/par.hpp
               include/flow/dsl/seq.hpp
               include/flow/dsl/subgraph_identity.hpp
@@ -248,6 +249,7 @@ target_sources(
               include/flow/flow.hpp
               include/flow/func_list.hpp
               include/flow/graph_builder.hpp
+              include/flow/graph_common.hpp
               include/flow/log.hpp
               include/flow/run.hpp
               include/flow/service.hpp

--- a/include/flow/debug_builder.hpp
+++ b/include/flow/debug_builder.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <flow/dsl/walk.hpp>
+#include <flow/graph_common.hpp>
+#include <flow/viz_builder.hpp>
+
+#include <stdx/ct_string.hpp>
+#include <stdx/static_assert.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+
+#include <boost/mp11/set.hpp>
+
+#include <type_traits>
+
+namespace flow {
+template <stdx::ct_string Start, stdx::ct_string End,
+          typename Renderer = graphviz>
+struct debug_builder {
+    template <typename Graph>
+    [[nodiscard]] static auto build(Graph const &input) {
+        auto const nodes = stdx::to_unsorted_set(flow::dsl::get_nodes(input));
+        auto const edges = stdx::to_unsorted_set(flow::dsl::get_edges(input));
+        auto const named_nodes = stdx::apply_indices<name_for>(nodes);
+
+        using nodes_t = std::remove_cvref_t<decltype(nodes)>;
+        using edges_t = std::remove_cvref_t<decltype(edges)>;
+
+        auto const start = stdx::get<stdx::cts_t<Start>>(named_nodes);
+        using start_t = std::remove_cvref_t<decltype(start)>;
+
+        auto const end = stdx::get<stdx::cts_t<End>>(named_nodes);
+        using end_t = std::remove_cvref_t<decltype(end)>;
+
+        using downstream_t = boost::mp11::mp_copy_if_q<
+            nodes_t, detail::descendant_of_q<start_t, edges_t>>;
+        using upstream_t =
+            boost::mp11::mp_copy_if_q<nodes_t,
+                                      detail::ancestor_of_q<end_t, edges_t>>;
+
+        using subgraph_nodes_t =
+            boost::mp11::mp_set_intersection<downstream_t, upstream_t>;
+        using subgraph_edges_t = boost::mp11::mp_copy_if_q<
+            edges_t, detail::contained_edge_q<subgraph_nodes_t>>;
+
+        using viz_t = viz_builder<name, Renderer>;
+        STATIC_ASSERT(
+            false, "subgraph debug\n\n{}",
+            (viz_t::template visualize<subgraph_nodes_t, subgraph_edges_t>()));
+    }
+
+    constexpr static auto name = Start + stdx::ct_string{" -> "} + End;
+    using interface_t = auto (*)() -> void;
+
+    template <typename Initialized> class built_flow {
+        static auto run() -> void {
+            auto const v = Initialized::value;
+            build(v);
+        }
+
+      public:
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        constexpr explicit(false) operator interface_t() const { return run; }
+        auto operator()() const { run(); }
+        constexpr static bool active = true;
+    };
+
+    template <typename Initialized>
+    [[nodiscard]] constexpr static auto render() -> built_flow<Initialized> {
+        return {};
+    }
+};
+} // namespace flow

--- a/include/flow/graph_builder.hpp
+++ b/include/flow/graph_builder.hpp
@@ -2,6 +2,7 @@
 
 #include <flow/dsl/walk.hpp>
 #include <flow/func_list.hpp>
+#include <flow/graph_common.hpp>
 
 #include <stdx/ct_string.hpp>
 #include <stdx/cx_multimap.hpp>
@@ -38,31 +39,6 @@ constexpr static auto error_steps =
         return x + ", "_ctst + y;
     });
 } // namespace detail
-
-template <typename T> using name_for = typename T::name_t;
-
-[[nodiscard]] constexpr auto edge_size(auto const &nodes, auto const &edges)
-    -> std::size_t {
-    auto const edge_capacities = transform(
-        [&]<typename N>(N const &) {
-            return edges.fold_left(
-                std::size_t{}, []<typename E>(auto acc, E const &) {
-                    if constexpr (std::is_same_v<name_for<typename E::source_t>,
-                                                 name_for<N>> or
-                                  std::is_same_v<name_for<typename E::dest_t>,
-                                                 name_for<N>>) {
-                        return ++acc;
-                    } else {
-                        return acc;
-                    }
-                });
-        },
-        nodes);
-
-    return edge_capacities.fold_left(std::size_t{1}, [](auto acc, auto next) {
-        return std::max(acc, next);
-    });
-}
 
 template <stdx::ct_string Name, typename LogPolicy = log_policy_t<Name>,
           template <stdx::ct_string, typename, std::size_t> typename Impl =

--- a/include/flow/graph_common.hpp
+++ b/include/flow/graph_common.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <stdx/ct_string.hpp>
+
+#include <boost/mp11/algorithm.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+
+namespace flow {
+template <typename T> using name_for = typename T::name_t;
+
+[[nodiscard]] constexpr auto edge_size(auto const &nodes, auto const &edges)
+    -> std::size_t {
+    auto const edge_capacities = transform(
+        [&]<typename N>(N const &) {
+            return edges.fold_left(
+                std::size_t{}, []<typename E>(auto acc, E const &) {
+                    if constexpr (std::is_same_v<name_for<typename E::source_t>,
+                                                 name_for<N>> or
+                                  std::is_same_v<name_for<typename E::dest_t>,
+                                                 name_for<N>>) {
+                        return ++acc;
+                    } else {
+                        return acc;
+                    }
+                });
+        },
+        nodes);
+
+    return edge_capacities.fold_left(std::size_t{1}, [](auto acc, auto next) {
+        return std::max(acc, next);
+    });
+}
+
+namespace detail {
+template <typename N> struct matching_source {
+    template <typename Edge>
+    using fn = std::is_same<name_for<N>, name_for<typename Edge::source_t>>;
+};
+
+template <typename N> struct matching_dest {
+    template <typename Edge>
+    using fn = std::is_same<name_for<N>, name_for<typename Edge::dest_t>>;
+};
+
+template <typename T> struct matching_name {
+    template <typename U> using fn = std::is_same<name_for<T>, name_for<U>>;
+};
+
+template <typename Nodes> struct contained_edge_q {
+    template <typename Edge>
+    using fn = std::bool_constant<
+        not boost::mp11::mp_empty<boost::mp11::mp_copy_if_q<
+            Nodes, matching_name<typename Edge::source_t>>>::value and
+        not boost::mp11::mp_empty<boost::mp11::mp_copy_if_q<
+            Nodes, matching_name<typename Edge::dest_t>>>::value>;
+};
+
+template <template <typename> typename Matcher, typename Edges>
+struct has_no_edge_q {
+    template <typename Node>
+    using fn =
+        boost::mp11::mp_empty<boost::mp11::mp_copy_if_q<Edges, Matcher<Node>>>;
+};
+
+template <typename E> using parent_of = typename E::source_t;
+template <typename E> using child_of = typename E::dest_t;
+
+template <typename Node, typename Edges>
+using parents_of = boost::mp11::mp_transform<
+    parent_of, boost::mp11::mp_copy_if_q<Edges, matching_dest<Node>>>;
+
+template <typename Node, typename Edges>
+using children_of = boost::mp11::mp_transform<
+    child_of, boost::mp11::mp_copy_if_q<Edges, matching_source<Node>>>;
+
+template <typename...> struct descendant_of_q;
+
+template <typename L, typename Start, typename Edges>
+using any_descendants =
+    boost::mp11::mp_any_of_q<L, descendant_of_q<Start, Edges>>;
+
+template <typename Start, typename Edges> struct descendant_of_q<Start, Edges> {
+    template <typename Node>
+    using fn = boost::mp11::mp_eval_if_c<
+        std::is_same_v<name_for<Node>, name_for<Start>>, std::true_type,
+        any_descendants, parents_of<Node, Edges>, Start, Edges>;
+};
+
+template <typename...> struct ancestor_of_q;
+
+template <typename L, typename Start, typename Edges>
+using any_ancestors = boost::mp11::mp_any_of_q<L, ancestor_of_q<Start, Edges>>;
+
+template <typename Start, typename Edges> struct ancestor_of_q<Start, Edges> {
+    template <typename Node>
+    using fn = boost::mp11::mp_eval_if_c<
+        std::is_same_v<name_for<Node>, name_for<Start>>, std::true_type,
+        any_ancestors, children_of<Node, Edges>, Start, Edges>;
+};
+} // namespace detail
+} // namespace flow

--- a/include/flow/viz_builder.hpp
+++ b/include/flow/viz_builder.hpp
@@ -1,131 +1,130 @@
 #pragma once
 
 #include <flow/dsl/walk.hpp>
+#include <flow/graph_common.hpp>
 #include <flow/step.hpp>
 
+#include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/utility.hpp>
 
 #include <algorithm>
-#include <array>
-#include <iterator>
-#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
 
 namespace flow {
 struct graphviz {
-    template <typename Graph> static auto prologue() -> std::string {
-        std::string output{"digraph "};
-        output += std::string_view{Graph::name};
-        output += " {";
-        return output;
+    template <stdx::ct_string Name> CONSTEVAL static auto prologue() {
+        return +stdx::ct_format<"digraph {} {">(stdx::cts_t<Name>{});
     }
-    template <typename Graph> static auto epilogue() -> std::string {
-        return "}";
+    template <stdx::ct_string Name> CONSTEVAL static auto epilogue() {
+        using namespace stdx::literals;
+        return "}"_cts;
     }
-    template <typename Node> static auto render_node(Node) -> std::string {
-        std::string output{"  "};
-        output += std::string_view{Node::name_t::value};
-        return output;
+    template <typename Node> CONSTEVAL static auto render_node(Node) {
+        return +stdx::ct_format<"  {}">(typename Node::name_t{});
     }
-    template <typename Edge> static auto render_edge(Edge) -> std::string {
-        std::string output{"  "};
-        output += std::string_view{Edge::source_t::name_t::value};
-        output += " -> ";
-        output += std::string_view{Edge::dest_t::name_t::value};
-        return output;
+    template <typename Edge> CONSTEVAL static auto render_edge(Edge) {
+        return +stdx::ct_format<"  {} -> {}">(typename Edge::source_t::name_t{},
+                                              typename Edge::dest_t::name_t{});
     }
 };
 
 class mermaid {
-    static auto to_id(auto str) {
-        std::string s{"_"};
-        s += str;
-        std::replace(std::begin(s), std::end(s), ' ', '_');
-        return s;
+    template <stdx::ct_string Name> CONSTEVAL static auto to_id() {
+        using namespace stdx::literals;
+        return "_"_ctst + stdx::cts_t<[] {
+                   auto n = Name;
+                   std::replace(n.begin(), n.end(), ' ', '_');
+                   return n;
+               }()>{};
+    }
+
+    template <typename Node> CONSTEVAL static auto to_box() {
+        using namespace stdx::literals;
+        if constexpr (detail::is_milestone<Node>) {
+            return stdx::ct_format<"[{}]">(typename Node::name_t{});
+        } else {
+            return stdx::ct_format<"({})">(typename Node::name_t{});
+        }
     }
 
   public:
-    template <typename Graph> static auto prologue() -> std::string {
-        std::string output{"---\ntitle: "};
-        output += std::string_view{Graph::name};
-        output += "\n---\nflowchart TD";
-        return output;
+    template <stdx::ct_string Name> CONSTEVAL static auto prologue() {
+        return +stdx::ct_format<"---\ntitle: {}\n---\nflowchart TD">(
+            stdx::cts_t<Name>{});
     }
 
-    template <typename Graph> static auto epilogue() -> std::string {
-        return "";
+    template <stdx::ct_string Name> CONSTEVAL static auto epilogue() {
+        using namespace stdx::literals;
+        return ""_cts;
     }
 
-    template <typename Node> static auto render_node(Node) -> std::string {
-        using namespace std::string_view_literals;
-        std::string output{"  "};
-        constexpr auto node_opener = std::array{"("sv, "["sv};
-        constexpr auto node_closer = std::array{")"sv, "]"sv};
-        output += to_id(std::string_view{Node::name_t::value});
-        output += node_opener[detail::is_milestone<Node>];
-        output += std::string_view{Node::name_t::value};
-        output += node_closer[detail::is_milestone<Node>];
-        return output;
+    template <typename Node> CONSTEVAL static auto render_node(Node) {
+        return +stdx::ct_format<"  {}{}">(to_id<Node::name_t::value>(),
+                                          to_box<Node>());
     }
 
     template <typename Node>
         requires(Node::name_t::value == stdx::ct_string{"start"} or
                  Node::name_t::value == stdx::ct_string{"end"})
-    static auto render_node(Node) -> std::string {
-        using namespace std::string_view_literals;
-        std::string output{"  "};
-        output += to_id(std::string_view{Node::name_t::value});
-        output += "((";
-        output += std::string_view{Node::name_t::value};
-        output += "))";
-        return output;
+    CONSTEVAL static auto render_node(Node) {
+        return +stdx::ct_format<"  {}(({}))">(to_id<Node::name_t::value>(),
+                                              typename Node::name_t{});
     }
 
-    template <typename Edge> static auto render_edge(Edge) -> std::string {
-        std::string output{"  "};
-        output += to_id(std::string_view{Edge::source_t::name_t::value});
-        output += " --";
-        if constexpr (Edge::cond_t::ct_name != stdx::ct_string{"always"}) {
-            output += std::string_view{Edge::cond_t::ct_name};
-            output += "--";
+    template <typename Edge> CONSTEVAL static auto render_edge(Edge) {
+        using namespace stdx::literals;
+
+        if constexpr (Edge::cond_t::ct_name == "always"_cts) {
+            return +stdx::ct_format<"  {} --> {}">(
+                to_id<Edge::source_t::name_t::value>(),
+                to_id<Edge::dest_t::name_t::value>());
+        } else {
+            return +stdx::ct_format<"  {} --{}--> {}">(
+                to_id<Edge::source_t::name_t::value>(),
+                stdx::cts_t<Edge::cond_t::ct_name>{},
+                to_id<Edge::dest_t::name_t::value>());
         }
-        output += "> ";
-        output += to_id(std::string_view{Edge::dest_t::name_t::value});
-        return output;
     }
 };
-
-namespace detail {
-template <typename N> struct matching_source {
-    template <typename Edge>
-    using fn = std::is_same<N, typename Edge::source_t>;
-};
-template <typename N> struct matching_dest {
-    template <typename Edge> using fn = std::is_same<N, typename Edge::dest_t>;
-};
-
-template <template <typename> typename Matcher, typename Edges>
-struct has_no_edge_q {
-    template <typename Node>
-    using fn =
-        boost::mp11::mp_empty<boost::mp11::mp_copy_if_q<Edges, Matcher<Node>>>;
-};
-} // namespace detail
 
 template <stdx::ct_string Name, typename Renderer = graphviz>
 struct viz_builder {
+    template <typename Nodes, typename Edges>
+    [[nodiscard]] constexpr static auto visualize() {
+        using namespace stdx::literals;
+        auto prologue = Renderer::template prologue<Name>();
+        auto epilogue = Renderer::template epilogue<Name>();
+        auto rendered_nodes = stdx::transform(
+            [](auto n) { return Renderer::render_node(n); }, Nodes{});
+        auto rendered_edges = stdx::transform(
+            [](auto e) { return Renderer::render_edge(e); }, Edges{});
+
+        return prologue + "\n"_cts +
+               std::move(rendered_nodes)
+                   .join(""_cts,
+                         [](auto &&x, auto &&y) {
+                             return FWD(x) + "\n"_cts + FWD(y);
+                         }) +
+               "\n"_cts +
+               std::move(rendered_edges)
+                   .join(""_cts,
+                         [](auto &&x, auto &&y) {
+                             return FWD(x) + "\n"_cts + FWD(y);
+                         }) +
+               "\n"_cts + epilogue;
+    }
+
     template <typename Graph>
-    [[nodiscard]] static auto build(Graph const &input) {
+    [[nodiscard]] constexpr static auto build(Graph const &input) {
         using flow::operator""_milestone;
 
         auto const nodes = stdx::to_sorted_set(flow::dsl::get_nodes(input));
         auto const edges = stdx::to_sorted_set(flow::dsl::get_edges(input));
-        using nodes_t = std::remove_cvref_t<decltype(nodes)>;
         using edges_t = std::remove_cvref_t<decltype(edges)>;
 
         auto const sources = stdx::filter<
@@ -152,44 +151,32 @@ struct viz_builder {
         auto const renderable_edges =
             stdx::tuple_cat(edges, stdx::transform(edge_from_start, sources),
                             stdx::transform(edge_to_end, sinks));
+        using renderable_nodes_t =
+            std::remove_cvref_t<decltype(renderable_nodes)>;
+        using renderable_edges_t =
+            std::remove_cvref_t<decltype(renderable_edges)>;
 
-        auto prologue = Renderer::template prologue<Graph>();
-        auto epilogue = Renderer::template epilogue<Graph>();
-        auto rendered_nodes = stdx::transform(
-            [](auto n) { return Renderer::render_node(n); }, renderable_nodes);
-        auto rendered_edges = stdx::transform(
-            [](auto e) { return Renderer::render_edge(e); }, renderable_edges);
-
-        return prologue + '\n' +
-               std::move(rendered_nodes)
-                   .join(std::string{},
-                         [](auto &&x, auto &&y) {
-                             return FWD(x) + '\n' + FWD(y);
-                         }) +
-               '\n' +
-               std::move(rendered_edges)
-                   .join(std::string{},
-                         [](auto &&x, auto &&y) {
-                             return FWD(x) + '\n' + FWD(y);
-                         }) +
-               '\n' + epilogue;
+        return visualize<renderable_nodes_t, renderable_edges_t>();
     }
 
     constexpr static auto name = Name;
-    using interface_t = auto (*)() -> std::string;
+    using interface_t = auto (*)() -> std::string_view;
 
     template <typename Initialized> class built_flow {
-        static auto built() {
+        constexpr static auto built() {
             auto const v = Initialized::value;
             return build(v);
         }
+        constexpr static auto built_v = built();
 
-        static auto run() -> std::string { return built(); }
+        constexpr static auto run() -> std::string_view {
+            return std::string_view{built_v};
+        }
 
       public:
         // NOLINTNEXTLINE(google-explicit-constructor)
         constexpr explicit(false) operator interface_t() const { return run; }
-        auto operator()() const { return run(); }
+        constexpr auto operator()() const { return run(); }
         constexpr static bool active = true;
     };
 

--- a/test/flow/fail/CMakeLists.txt
+++ b/test/flow/fail/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_compile_fail_test(cyclic_flow.cpp LIBRARIES cib)
 
 function(add_formatted_errors_tests)
+    add_compile_fail_test(debug_subgraph.cpp LIBRARIES cib)
     add_compile_fail_test(only_reference_added.cpp LIBRARIES cib)
     add_compile_fail_test(mismatched_flow_runtime_conditional.cpp LIBRARIES cib)
     add_compile_fail_test(node_explicitly_added_twice.cpp LIBRARIES cib)

--- a/test/flow/fail/debug_subgraph.cpp
+++ b/test/flow/fail/debug_subgraph.cpp
@@ -1,0 +1,29 @@
+#include <cib/cib.hpp>
+#include <flow/debug_builder.hpp>
+#include <flow/flow.hpp>
+
+// EXPECT: _b --> _c
+
+namespace {
+using namespace flow::literals;
+
+constexpr auto a = flow::action<"a">([] {});
+constexpr auto b = flow::action<"b">([] {});
+constexpr auto c = flow::action<"c">([] {});
+constexpr auto d = flow::action<"d">([] {});
+
+struct DebugFlow
+    : public flow::service_for<
+          flow::builder_for<flow::debug_builder<"b", "c", flow::mermaid>>> {};
+struct DebugConfig {
+    constexpr static auto config = cib::config(
+        cib::exports<DebugFlow>, cib::extend<DebugFlow>(*a, *b, *c, *d),
+        cib::extend<DebugFlow>(a >> b >> c >> d));
+};
+} // namespace
+
+auto main() -> int {
+    using namespace std::string_view_literals;
+    cib::nexus<DebugConfig> nexus{};
+    nexus.service<DebugFlow>();
+}

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -49,10 +49,9 @@ TEST_CASE("run empty flow through cib::nexus", "[flow]") {
 }
 
 namespace {
-template <stdx::ct_string Name>
-using alt_builder = flow::builder_for<flow::viz_builder<Name, flow::mermaid>>;
-
-struct VizFlow : public flow::service_for<alt_builder<"debug">> {};
+struct VizFlow
+    : public flow::service_for<
+          flow::builder_for<flow::viz_builder<"debug", flow::mermaid>>> {};
 struct VizCondConfig {
     constexpr static auto config =
         cib::config(cib::exports<VizFlow>, cib::extend<VizFlow>(*a),
@@ -60,10 +59,11 @@ struct VizCondConfig {
 };
 } // namespace
 
-TEST_CASE("visualize flow", "[flow]") {
+TEST_CASE("visualize flow (mermaid)", "[flow]") {
+    using namespace std::string_view_literals;
     cib::nexus<VizCondConfig> nexus{};
-    auto viz = nexus.service<VizFlow>();
-    auto expected = std::string{
+    constexpr auto viz = nexus.service<VizFlow>();
+    constexpr auto expected =
         R"__debug__(---
 title: debug
 ---
@@ -74,10 +74,9 @@ flowchart TD
   _b(b)
   _a --when--> _b
   _start --> _a
-  _a --> _end
   _b --when--> _end
-)__debug__"};
-    CHECK(viz == expected);
+)__debug__"sv;
+    STATIC_REQUIRE(viz == expected);
 }
 
 TEST_CASE("add single action through cib::nexus", "[flow]") {

--- a/test/flow/graph_builder.cpp
+++ b/test/flow/graph_builder.cpp
@@ -219,10 +219,11 @@ TEST_CASE("reference in order with non-reference added twice",
 #endif
 
 TEST_CASE("alternate builder (graphviz)", "[graph_builder]") {
+    using namespace stdx::literals;
     using alt_builder = flow::viz_builder<"debug">;
-    auto g = flow::builder_for<alt_builder>{}.add(*a && (*b >> *c));
-    auto const flow = alt_builder::build(g);
-    auto expected = std::string{
+    constexpr auto g = flow::builder_for<alt_builder>{}.add(*a && (*b >> *c));
+    constexpr auto flow = alt_builder::build(g);
+    constexpr auto expected =
         R"__debug__(digraph debug {
   start
   end
@@ -234,15 +235,17 @@ TEST_CASE("alternate builder (graphviz)", "[graph_builder]") {
   start -> b
   a -> end
   c -> end
-})__debug__"};
-    CHECK(flow == expected);
+})__debug__"_cts;
+    STATIC_REQUIRE(flow == expected);
 }
 
 TEST_CASE("alternate builder (mermaid)", "[graph_builder]") {
+    using namespace stdx::literals;
     using alt_builder = flow::viz_builder<"debug", flow::mermaid>;
-    auto g = flow::builder_for<alt_builder>{}.add(*a && (*b >> *c));
-    auto const flow = alt_builder::build(g);
-    auto expected = std::string{
+    constexpr auto g = flow::builder_for<alt_builder>{}.add(*a && (*b >> *c));
+    constexpr auto flow = alt_builder::build(g);
+
+    constexpr auto expected =
         R"__debug__(---
 title: debug
 ---
@@ -257,6 +260,6 @@ flowchart TD
   _start --> _b
   _a --> _end
   _c --> _end
-)__debug__"};
-    CHECK(flow == expected);
+)__debug__"_cts;
+    STATIC_REQUIRE(flow == expected);
 }


### PR DESCRIPTION
Problem:
- Debugging a flow graph can be tricky. Compiling on platform, we don't necessarily have the ability to use the `viz_builder` that produces a string that can be printed at runtime.

Solution:
- Allow a `debug_builder` that will cause a compilation error, but show a message that is the visualization of the flow graph between two nodes.