### PR TITLE
:sparkles: Generate flow diagram from code non-invasively

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -139,6 +139,17 @@ jobs:
           ${{ matrix.install }}
           sudo apt install -y ninja-build python3-venv python3-pip
 
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 22
+
+      - name: Install Asciidoctor & Mermaid
+        run: |
+          npm install -g @mermaid-js/mermaid-cli@11.12.0
+          npx puppeteer browsers install chrome-headless-shell
+          sudo gem install asciidoctor asciidoctor-diagram rouge
+
       - name: Restore CPM cache
         env:
           cache-name: cpm-cache-0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(
     COMPONENTS Interpreter
     REQUIRED)
 
+include(cmake/debug_flow.cmake)
 include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")

--- a/cmake/debug_flow.cmake
+++ b/cmake/debug_flow.cmake
@@ -1,0 +1,108 @@
+if(COMMAND generate_flow_graph)
+    return()
+endif()
+
+function(generate_flow_graph)
+    cmake_parse_arguments(FG "" "TARGET" "" ${ARGN})
+    message(
+        STATUS
+            "generate_flow_graph(${FG_TARGET}) is disabled because mmdc was not found."
+    )
+endfunction()
+
+find_program(MMDC_PROGRAM "mmdc")
+if(MMDC_PROGRAM)
+    message(STATUS "mmdc found at ${MMDC_PROGRAM}.")
+else()
+    message(STATUS "mmdc not found. generate_flow_graph will not be available.")
+    return()
+endif()
+
+function(copy_target_property OLD NEW PROP)
+    get_target_property(val ${OLD} ${PROP})
+    if(NOT "${val}" STREQUAL "val-NOTFOUND")
+        set_target_properties(${NEW} PROPERTIES "${PROP}" "${val}")
+    endif()
+endfunction(copy_target_property)
+
+function(copy_target_properties OLD NEW)
+    foreach(prop ${ARGN})
+        copy_target_property(${OLD} ${NEW} ${prop})
+        copy_target_property(${OLD} ${NEW} INTERFACE_${prop})
+    endforeach(prop)
+endfunction(copy_target_properties)
+
+function(make_flow_debug_target OLD NEW)
+    add_library(${NEW} STATIC EXCLUDE_FROM_ALL
+                $<TARGET_PROPERTY:${FG_TARGET},SOURCES>)
+    copy_target_properties(
+        ${OLD}
+        ${NEW}
+        COMPILE_DEFINITIONS
+        COMPILE_FEATURES
+        COMPILE_OPTIONS
+        INCLUDE_DIRECTORIES
+        LINK_LIBRARIES
+        PRECOMPILE_HEADERS)
+endfunction()
+
+function(generate_flow_graph)
+    set(oneValueArgs TARGET FLOW_NAME START_NODE END_NODE)
+    cmake_parse_arguments(FG "" "${oneValueArgs}" "" ${ARGN})
+    set(target_stem "${FG_TARGET}.${FG_FLOW_NAME}")
+
+    # generate a header that overrides the flow service
+    get_filename_component(header "${target_stem}.debug.hpp" ABSOLUTE BASE_DIR
+                           ${CMAKE_CURRENT_BINARY_DIR})
+    set(FLOW_NAME ${FG_FLOW_NAME})
+    set(START_NODE ${FG_START_NODE})
+    set(END_NODE ${FG_END_NODE})
+    set(RENDERER "mermaid")
+    configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/debug_flow.hpp.in"
+                   ${header} @ONLY)
+
+    # set up a library that injects the header
+    set(injection_lib "${target_stem}.lib")
+    add_library(${injection_lib} INTERFACE)
+    target_compile_options(${injection_lib} INTERFACE -include ${header})
+
+    # set up a new target from the existing one
+    set(debug_target "${target_stem}.bin")
+    make_flow_debug_target(${FG_TARGET} ${debug_target})
+    target_link_libraries(${debug_target} PRIVATE ${injection_lib})
+
+    # generate the graph source
+    set(graph_stem "${target_stem}.graph")
+    set(graph_source "${graph_stem}.mmd")
+    set(graph "${graph_stem}.svg")
+    set(awk_gcc_cmd "awk '{gsub(\"\\\\\\\\012\",\"\\n\")}\;1'")
+    set(awk_clang_cmd "awk '{gsub(\"\\\\\\\\n\",\"\\n\")}\;1'")
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${graph_source}
+        DEPENDS $<TARGET_PROPERTY:${debug_target},SOURCES>
+        DEPENDS ${header}
+        COMMAND
+            ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target
+            ${debug_target} | bash -c ${awk_gcc_cmd} | bash -c ${awk_clang_cmd}
+            | tac | sed -n "/^~~~~END/,/^~~~~START/{p;/^~~~~START/q}" | tac |
+            tail -n +2 | head -n -1 >
+            "${CMAKE_CURRENT_BINARY_DIR}/${graph_source}"
+        VERBATIM)
+
+    # build the graph from the source
+    if(EXISTS "${CMAKE_SOURCE_DIR}/docs/mermaid.conf")
+        set(mm_conf "-c;${CMAKE_SOURCE_DIR}/docs/mermaid.conf")
+    endif()
+    if(EXISTS "${CMAKE_SOURCE_DIR}/docs/puppeteer_config.json")
+        set(puppeteer_conf "-p;${CMAKE_SOURCE_DIR}/docs/puppeteer_config.json")
+    endif()
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${graph}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${graph_source}
+        COMMAND
+            ${MMDC_PROGRAM} -i "${CMAKE_CURRENT_BINARY_DIR}/${graph_source}" -o
+            "${CMAKE_CURRENT_BINARY_DIR}/${graph}" ${mm_conf} ${puppeteer_conf}
+        COMMAND_EXPAND_LISTS)
+    add_custom_target("${graph_stem}"
+                      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${graph})
+endfunction()

--- a/cmake/debug_flow.hpp.in
+++ b/cmake/debug_flow.hpp.in
@@ -1,0 +1,13 @@
+#include <flow/debug_builder.hpp>
+#include <flow/service.hpp>
+#include <flow/viz_builder.hpp>
+
+namespace flow {
+template <stdx::ct_string Start, stdx::ct_string End, typename Renderer>
+using debug_service
+    = service_for<builder_for<debug_builder<Start, End, Renderer>>>;
+
+template <typename LogPolicy>
+struct service<"@FLOW_NAME@", LogPolicy>
+    : debug_service<"@START_NODE@", "@END_NODE@", @RENDERER@> {};
+} // namespace flow

--- a/include/flow/debug_builder.hpp
+++ b/include/flow/debug_builder.hpp
@@ -45,7 +45,7 @@ struct debug_builder {
 
         using viz_t = viz_builder<name, Renderer>;
         STATIC_ASSERT(
-            false, "subgraph debug\n\n{}",
+            false, "subgraph debug\n~~~~START\n{}~~~~END",
             (viz_t::template visualize<subgraph_nodes_t, subgraph_edges_t>()));
     }
 

--- a/include/flow/service.hpp
+++ b/include/flow/service.hpp
@@ -22,5 +22,5 @@ template <typename Builder> struct service_for {
 };
 
 template <stdx::ct_string Name = "", typename LogPolicy = log_policy_t<Name>>
-using service = service_for<builder<Name, LogPolicy>>;
+struct service : service_for<builder<Name, LogPolicy>> {};
 } // namespace flow

--- a/test/flow/CMakeLists.txt
+++ b/test/flow/CMakeLists.txt
@@ -21,3 +21,45 @@ add_tests(
     cib)
 
 add_subdirectory(fail)
+
+function(add_debug_flow_test)
+    add_executable(debug_flow EXCLUDE_FROM_ALL debug_flow.cpp)
+    target_link_libraries(debug_flow PRIVATE cib)
+    generate_flow_graph(
+        TARGET
+        debug_flow
+        FLOW_NAME
+        test
+        START_NODE
+        b
+        END_NODE
+        c)
+
+    if(TARGET debug_flow.test.graph)
+        add_custom_target(run_debug_flow_test DEPENDS debug_flow_test.passed)
+        add_custom_command(
+            OUTPUT debug_flow_test.passed
+            COMMAND diff ${CMAKE_CURRENT_BINARY_DIR}/debug_flow.test.graph.mmd
+                    ${CMAKE_CURRENT_SOURCE_DIR}/debug_flow.test.graph.mmd
+            COMMAND ${CMAKE_COMMAND} "-E" "touch" "debug_flow_test.passed"
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/debug_flow.test.graph.mmd
+                    ${CMAKE_CURRENT_SOURCE_DIR}/debug_flow.test.graph.mmd)
+        add_dependencies(${INFRA_TARGET_NAMESPACE}build_unit_tests
+                         run_debug_flow_test)
+        add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_tests run_debug_flow_test)
+
+        add_test(
+            NAME debug_flow_test
+            COMMAND diff ${CMAKE_CURRENT_BINARY_DIR}/debug_flow.test.graph.mmd
+                    ${CMAKE_CURRENT_SOURCE_DIR}/debug_flow.test.graph.mmd)
+    endif()
+endfunction()
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                 VERSION_GREATER_EQUAL 15)
+    add_debug_flow_test()
+endif()
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                               VERSION_GREATER_EQUAL 13.2)
+    add_debug_flow_test()
+endif()

--- a/test/flow/debug_flow.cpp
+++ b/test/flow/debug_flow.cpp
@@ -1,0 +1,24 @@
+#include <cib/cib.hpp>
+#include <flow/flow.hpp>
+
+namespace {
+using namespace flow::literals;
+
+constexpr auto a = flow::action<"a">([] {});
+constexpr auto b = flow::action<"b">([] {});
+constexpr auto c = flow::action<"c">([] {});
+constexpr auto d = flow::action<"d">([] {});
+
+struct DebugFlow : public flow::service<"test"> {};
+struct DebugConfig {
+    constexpr static auto config = cib::config(
+        cib::exports<DebugFlow>, cib::extend<DebugFlow>(*a, *b, *c, *d),
+        cib::extend<DebugFlow>(a >> b >> c >> d));
+};
+} // namespace
+
+auto main() -> int {
+    using namespace std::string_view_literals;
+    cib::nexus<DebugConfig> nexus{};
+    nexus.service<DebugFlow>();
+}

--- a/test/flow/debug_flow.test.graph.mmd
+++ b/test/flow/debug_flow.test.graph.mmd
@@ -1,0 +1,7 @@
+---
+title: b -> c
+---
+flowchart TD
+  _b(b)
+  _c(c)
+  _b --> _c


### PR DESCRIPTION
Problem:
- In order to debug a flow, we can use an alternative renderer, but it requires changing code.

Solution:
- Add `generate_flow_graph` which injects the debug renderer for a particular named flow, to produce a compile-time error containing the appropriate part of the flow. Mermaid can then be used to render that output into an svg file.