### PR TITLE
:children_crossing: Guard all call options in `msg::call_with_message`

### DIFF
--- a/include/msg/message.hpp
+++ b/include/msg/message.hpp
@@ -700,9 +700,16 @@ call_with_message(F &&f, S &&s, Args &&...args) -> decltype(auto) {
                          }) {
         return std::forward<F>(f)(typename Msg::view_t{std::forward<S>(s)},
                                   std::forward<Args>(args)...);
-    } else {
+    } else if constexpr (requires {
+                             std::forward<F>(f)(
+                                 typename Msg::owner_t{std::forward<S>(s)},
+                                 std::forward<Args>(args)...);
+                         }) {
         return std::forward<F>(f)(typename Msg::owner_t{std::forward<S>(s)},
                                   std::forward<Args>(args)...);
+    } else {
+        static_assert(stdx::always_false_v<Msg, F, S>,
+                      "No call option for call_with_message");
     }
 }
 


### PR DESCRIPTION
Problem:
- Although the final `if constexpr` branch in `call_with_message` may not be taken, it can still cause a substitution failure in some cases.

Solution:
- Guard the last call option in `call_with_message`, and provide a hard error if none of the options succeeds.

Note:
- An example of such a substitution failure may occur in a predicate matcher whose predicate fails to have a `-> bool` trailing return type, and in forming the substitution the compiler tries to look at `decltype(pred(msg))` which instantiates the ill-formed function body.