### PR TITLE
:sparkles: Add a predicate matcher to fields

### DIFF
--- a/include/match/and.hpp
+++ b/include/match/and.hpp
@@ -15,7 +15,8 @@ namespace match {
 template <matcher, matcher> struct or_t;
 
 template <matcher L, matcher R> struct and_t : bin_op_t<and_t, "and", L, R> {
-    [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
+    [[nodiscard]] constexpr auto operator()(auto const &event) const
+        -> decltype(this->lhs(event) and this->rhs(event)) {
         return this->lhs(event) and this->rhs(event);
     }
 

--- a/include/match/not.hpp
+++ b/include/match/not.hpp
@@ -20,7 +20,8 @@ template <matcher M> struct not_t {
     using is_matcher = void;
     [[no_unique_address]] M m;
 
-    [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
+    [[nodiscard]] constexpr auto operator()(auto const &event) const
+        -> decltype(not m(event)) {
         return not m(event);
     }
 

--- a/include/match/or.hpp
+++ b/include/match/or.hpp
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <match/bin_op.hpp>
@@ -14,7 +15,8 @@ namespace match {
 template <matcher, matcher> struct and_t;
 
 template <matcher L, matcher R> struct or_t : bin_op_t<or_t, "or", L, R> {
-    [[nodiscard]] constexpr auto operator()(auto const &event) const -> bool {
+    [[nodiscard]] constexpr auto operator()(auto const &event) const
+        -> decltype(this->lhs(event) or this->rhs(event)) {
         return this->lhs(event) or this->rhs(event);
     }
 

--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -86,6 +86,13 @@ template <stdx::ct_string Name, typename Msg> struct callback_construct_t {
                                 std::forward<F>(f));
     }
 
+    template <stdx::callable F>
+    [[nodiscard]] constexpr auto operator()(F &&f) const {
+        using matcher_t = typename Msg::matcher_t;
+        return callback<Name, Msg, matcher_t, std::remove_cvref_t<F>>{
+            matcher_t{}, std::forward<F>(f)};
+    }
+
   private:
     template <typename N> struct matching_name {
         template <typename Field>

--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -527,6 +527,10 @@ class field_t : public field_spec_t<Name, T, detail::field_size<Ats...>>,
         field_t<Name, T, Default, msg::less_than_or_equal_to_t<field_t, V>,
                 Ats...>;
 
+    template <auto P>
+    using with_predicate =
+        field_t<Name, T, Default, msg::pred_matcher_t<field_t, P>, Ats...>;
+
     // ======================================================================
     // "const value" for construction and matching
     template <T V>

--- a/test/msg/field_matchers.cpp
+++ b/test/msg/field_matchers.cpp
@@ -236,3 +236,34 @@ TEST_CASE("not_equal_to X and less_than Y is less_than Y (X >= Y)",
     STATIC_REQUIRE(
         std::is_same_v<decltype(m), msg::less_than_t<test_field, 6> const>);
 }
+
+TEST_CASE("predicate matcher description", "[field matchers]") {
+    using namespace stdx::literals;
+    constexpr auto m =
+        msg::pred_matcher_t<test_field, [](std::uint32_t) { return true; }>{};
+    constexpr auto desc = m.describe();
+    STATIC_REQUIRE(desc.str == "<predicate>(test_field)"_ctst);
+}
+
+TEST_CASE("predicate matcher description of match", "[field matchers]") {
+    using namespace stdx::literals;
+    using msg_data = std::array<std::uint32_t, 1>;
+
+    constexpr auto m =
+        msg::pred_matcher_t<test_field, [](std::uint32_t) { return true; }>{};
+    constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
+    STATIC_REQUIRE(desc.str == "<predicate>(test_field(0x{:x}))"_ctst);
+    STATIC_REQUIRE(desc.args == stdx::tuple{1});
+}
+
+TEST_CASE("predicate matcher description of match (enum field)",
+          "[field matchers]") {
+    using namespace stdx::literals;
+    using msg_data = std::array<std::uint32_t, 1>;
+
+    constexpr auto m =
+        msg::pred_matcher_t<test_enum_field, [](auto) { return true; }>{};
+    constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
+    STATIC_REQUIRE(desc.str == "<predicate>(enum_field({}))"_ctst);
+    STATIC_REQUIRE(desc.args == stdx::tuple{E::B});
+}


### PR DESCRIPTION
Problem:
- Custom predicates on fields can be difficult to apply.
- Match machinery is not SFINAE-friendly.
- Message callbacks require a user-supplied matcher which is often just `always`.

Solution:
- Allow `with_predicate` on fields which receives the field value, rather than needing to receive the message and extract the field.
- Apply SFINAE-friendly return types to `and`, `or` and `not` match combinators.
- Allow `msg::callback` to be constructed without an extra matcher, just using the message's built-in matcher.