### PR TITLE
🐛 gen_str_catalog.py should accept "unsigned (long|int)" catalog return type

### DIFF
--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -183,7 +183,7 @@ def assign_ids(messages, modules, stable_data):
 
 
 def read_input(filenames: list[str], stable_data):
-    line_re = re.compile(r"^.*unsigned int (catalog|module)<(.+?)>\(\)$")
+    line_re = re.compile(r"^.*unsigned (?:int|long) (catalog|module)<(.+?)>\(\)$")
 
     def read_file(filename):
         with open(filename, "r") as f:


### PR DESCRIPTION
Some processors define `uint32_t` as `int`, and others as `long`. The log catalog script should accept both.