### PR TITLE
:sparkles: Allow string ID ranges to be reserved on the command line

### DIFF
--- a/cmake/string_catalog.cmake
+++ b/cmake/string_catalog.cmake
@@ -11,6 +11,7 @@ function(gen_str_catalog)
         GUID_ID
         GUID_MASK
         MODULE_ID_MAX
+        RESERVED_IDS
         OUTPUTS_TARGET)
     set(multiValueArgs INPUT_JSON INPUT_LIBS INPUT_HEADERS STABLE_JSON)
     cmake_parse_arguments(SC "${options}" "${oneValueArgs}" "${multiValueArgs}"
@@ -68,6 +69,9 @@ function(gen_str_catalog)
     if(SC_MODULE_ID_MAX)
         set(MODULE_ID_MAX_ARG --module_id_max ${SC_MODULE_ID_MAX})
     endif()
+    if(SC_RESERVED_IDS)
+        set(RESERVED_IDS_ARG --reserved_ids ${SC_RESERVED_IDS})
+    endif()
     if(NOT SC_GEN_STR_CATALOG)
         set(SC_GEN_STR_CATALOG ${GEN_STR_CATALOG})
     endif()
@@ -80,7 +84,7 @@ function(gen_str_catalog)
             --cpp_output ${SC_OUTPUT_CPP} --json_output ${SC_OUTPUT_JSON}
             --xml_output ${SC_OUTPUT_XML} --stable_json ${STABLE_JSON}
             ${FORGET_ARG} ${CLIENT_NAME_ARG} ${VERSION_ARG} ${GUID_ID_ARG}
-            ${GUID_MASK_ARG} ${MODULE_ID_MAX_ARG}
+            ${GUID_MASK_ARG} ${MODULE_ID_MAX_ARG} ${RESERVED_IDS_ARG}
         DEPENDS ${UNDEFS} ${INPUT_JSON} ${SC_GEN_STR_CATALOG} ${STABLE_JSON}
         COMMAND_EXPAND_LISTS)
 

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -40,6 +40,8 @@ gen_str_catalog(
     "01234567-89ab-cdef-0123-456789abcdef"
     GUID_MASK
     "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    RESERVED_IDS
+    "1,1000-1005,1010"
     OUTPUTS_TARGET
     test_catalog_json)
 

--- a/tools/gen_str_catalog_test.py
+++ b/tools/gen_str_catalog_test.py
@@ -70,3 +70,27 @@ def test_module_cpp_type():
 def test_module_json():
     m = gen.Module("abc", 42)
     assert m.to_json() == {"string": "abc", "id": 42}
+
+
+test_ints = "1-5,8-10,15"
+
+
+def test_intervals():
+    m = gen.Intervals(test_ints)
+    assert m.contains(1)
+    assert m.contains(5)
+    assert not m.contains(6)
+    assert m.contains(8)
+    assert m.contains(10)
+    assert m.contains(15)
+
+
+def test_empty_intervals():
+    m = gen.Intervals("")
+    assert not m.contains(1)
+
+
+def test_intervals_repr():
+    m = gen.Intervals(test_ints)
+    assert f"{m}" == "1-5,8-10,15"
+    assert repr(m) == 'Intervals("1-5,8-10,15")'


### PR DESCRIPTION
Problem:
- When generating a string catalog, it can be useful to reserve string IDs cheaply without having to incur the overhead of keeping "stable strings" around.

Solution:
- Allow reserved string ID ranges to be passed on the command line to `gen_str_catalog.py`.