### PR TITLE
:bug: Fix field extent

### DIFF
--- a/include/msg/field.hpp
+++ b/include/msg/field.hpp
@@ -206,8 +206,8 @@ struct bits_locator_t {
     }
 
     template <typename T> constexpr static auto extent_in() -> std::size_t {
-        constexpr auto msb = Lsb + BitSize - 1;
-        constexpr auto msb_extent = (msb + CHAR_BIT - 1) / CHAR_BIT;
+        constexpr auto msb_exclusive = Lsb + BitSize;
+        constexpr auto msb_extent = (msb_exclusive + CHAR_BIT - 1) / CHAR_BIT;
         constexpr auto base_extent = Index * sizeof(std::uint32_t);
         constexpr auto extent = base_extent + msb_extent;
         return (extent + sizeof(T) - 1) / sizeof(T);

--- a/test/msg/message.cpp
+++ b/test/msg/message.cpp
@@ -840,3 +840,12 @@ TEST_CASE("message with uninitialized field", "[message]") {
     auto data = msg.data();
     CHECK(data[0] == 1);
 }
+
+TEST_CASE("field extents", "[message]") {
+    using f1 = msg::detail::bits_locator_t<0, 1, 0>;
+    STATIC_CHECK(f1::extent_in<std::uint32_t>() == 1);
+    STATIC_CHECK(f1::extent_in<std::uint8_t>() == 1);
+    using f2 = msg::detail::bits_locator_t<0, 1, 31>;
+    STATIC_CHECK(f2::extent_in<std::uint32_t>() == 1);
+    STATIC_CHECK(f2::extent_in<std::uint8_t>() == 4);
+}


### PR DESCRIPTION
Problem:
- There is an off-by-one error in the field extent code such that a message whose "rightmost" field is a single bit on a data boundary computes its storage wrongly.

Solution:
- Fix off-by-one error.