### PR TITLE
:bug: Preserve C++ type in string/module ID specializations

### DIFF
--- a/test/log/catalog1_lib.cpp
+++ b/test/log/catalog1_lib.cpp
@@ -35,7 +35,9 @@ auto log_one_formatted_rt_arg() -> void;
 auto log_with_non_default_module() -> void;
 auto log_with_fixed_module() -> void;
 auto log_with_fixed_string_id() -> void;
+auto log_with_fixed_unsigned_string_id() -> void;
 auto log_with_fixed_module_id() -> void;
+auto log_with_fixed_unsigned_module_id() -> void;
 
 auto log_zero_args() -> void {
     auto cfg = logging::binary::config{test_log_destination{}};
@@ -95,12 +97,32 @@ auto log_with_fixed_string_id() -> void {
     }
 }
 
+auto log_with_fixed_unsigned_string_id() -> void {
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_string_id, 1338u) {
+        auto cfg = logging::binary::config{test_log_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            stdx::ct_format<"Fixed unsigned StringID string">());
+    }
+}
+
 auto log_with_fixed_module_id() -> void {
     CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
-                     logging::get_module_id, 7, logging::get_module,
-                     "fixed_id") {
+                     logging::get_module_id, 6, logging::get_module,
+                     "fixed_id6") {
         auto cfg = logging::binary::config{test_log_destination{}};
         cfg.logger.log_msg<cib_log_env_t>(
             stdx::ct_format<"Fixed ModuleID string with {} placeholder">(1));
+    }
+}
+
+auto log_with_fixed_unsigned_module_id() -> void {
+    CIB_WITH_LOG_ENV(logging::get_level, logging::level::TRACE,
+                     logging::get_module_id, 7ULL, logging::get_module,
+                     "fixed_id7") {
+        auto cfg = logging::binary::config{test_log_destination{}};
+        cfg.logger.log_msg<cib_log_env_t>(
+            stdx::ct_format<
+                "Fixed unsigned ModuleID string with {} placeholder">(1));
     }
 }

--- a/test/log/catalog_app.cpp
+++ b/test/log/catalog_app.cpp
@@ -21,7 +21,9 @@ extern auto log_rt_auto_scoped_enum_arg() -> void;
 extern auto log_with_non_default_module() -> void;
 extern auto log_with_fixed_module() -> void;
 extern auto log_with_fixed_string_id() -> void;
+extern auto log_with_fixed_unsigned_string_id() -> void;
 extern auto log_with_fixed_module_id() -> void;
+extern auto log_with_fixed_unsigned_module_id() -> void;
 extern auto log_rt_float_arg() -> void;
 extern auto log_rt_double_arg() -> void;
 
@@ -141,10 +143,29 @@ TEST_CASE("log with fixed string id", "[catalog]") {
     CHECK(last_header == ((1337u << 4u) | 1u));
 }
 
+TEST_CASE("log with fixed unsigned string id", "[catalog]") {
+    test_critical_section::count = 0;
+    log_calls = 0;
+    log_with_fixed_unsigned_string_id();
+    CHECK(test_critical_section::count == 2);
+    CHECK(log_calls == 1);
+    // string ID 1338 is fixed by environment
+    CHECK(last_header == ((1338u << 4u) | 1u));
+}
+
 TEST_CASE("log with fixed module id", "[catalog]") {
     std::uint32_t expected_static = (1u << 24u) | (7u << 4u) | 3u;
 
     log_with_fixed_module_id();
+    CHECK((last_header & expected_static) == expected_static);
+    // module ID 6 is fixed by environment
+    CHECK((last_header & ~expected_static) == (6u << 16u));
+}
+
+TEST_CASE("log with fixed unsigned module id", "[catalog]") {
+    std::uint32_t expected_static = (1u << 24u) | (7u << 4u) | 3u;
+
+    log_with_fixed_unsigned_module_id();
     CHECK((last_header & expected_static) == expected_static);
     // module ID 7 is fixed by environment
     CHECK((last_header & ~expected_static) == (7u << 16u));

--- a/tools/gen_str_catalog_test.py
+++ b/tools/gen_str_catalog_test.py
@@ -37,6 +37,14 @@ def test_message_cpp_type():
     )
 
 
+def test_message_cpp_type_unsigned():
+    m = gen.Message("abc", ["int"], 42, "u")
+    assert (
+        m.to_cpp_type()
+        == "sc::message<sc::undefined<sc::args<int>, 42u, char, static_cast<char>(97), static_cast<char>(98), static_cast<char>(99)>>"
+    )
+
+
 def test_message_json():
     m = gen.Message("abc {}", ["int"], 42)
     assert m.to_json() == {
@@ -64,6 +72,14 @@ def test_module_cpp_type():
     assert (
         m.to_cpp_type()
         == "sc::module_string<sc::undefined<void, 42, char, static_cast<char>(97), static_cast<char>(98), static_cast<char>(99)>>"
+    )
+
+
+def test_module_cpp_type():
+    m = gen.Module("abc", 42, "u")
+    assert (
+        m.to_cpp_type()
+        == "sc::module_string<sc::undefined<void, 42u, char, static_cast<char>(97), static_cast<char>(98), static_cast<char>(99)>>"
     )
 
 


### PR DESCRIPTION
Problem:
- If a string ID or a module ID is not a plain `int`, its value appears with a suffix, e.g. `1337u` or `1337ull` rather than `1337`. This is not properly handled by the string catalog generation.

Solution:
- Handle ID value suffixes correctly.

Note:
- The specialization must match the types, but `string_id` or `module_id` (both of which are aliases for`std::uint32_t`) is still returned from the function.