### PR TITLE
:art: Consolidate nexus headers for service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,6 @@ target_sources(
               BASE_DIRS
               include
               FILES
-              include/nexus/builder_meta.hpp
-              include/nexus/built.hpp
               include/nexus/callback.hpp
               include/nexus/config.hpp
               include/nexus/detail/components.hpp
@@ -226,7 +224,8 @@ target_sources(
               include/nexus/detail/extend.hpp
               include/nexus/detail/nexus_details.hpp
               include/nexus/func_decl.hpp
-              include/nexus/nexus.hpp)
+              include/nexus/nexus.hpp
+              include/nexus/service.hpp)
 
 add_library(cib_flow INTERFACE)
 target_compile_features(cib_flow INTERFACE cxx_std_20)

--- a/include/cib/cib.hpp
+++ b/include/cib/cib.hpp
@@ -37,9 +37,8 @@
 #include <cib/top.hpp>
 #include <interrupt/manager.hpp>
 #include <log/log.hpp>
-#include <nexus/builder_meta.hpp>
-#include <nexus/built.hpp>
 #include <nexus/callback.hpp>
 #include <nexus/config.hpp>
 #include <nexus/func_decl.hpp>
 #include <nexus/nexus.hpp>
+#include <nexus/service.hpp>

--- a/include/flow/run.hpp
+++ b/include/flow/run.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nexus/built.hpp>
+#include <nexus/service.hpp>
 
 namespace flow {
 /**

--- a/include/nexus/built.hpp
+++ b/include/nexus/built.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <nexus/builder_meta.hpp>
-
-namespace cib {
-template <builder_meta ServiceMeta>
-constinit auto service = ServiceMeta::uninitialized();
-} // namespace cib

--- a/include/nexus/callback.hpp
+++ b/include/nexus/callback.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nexus/builder_meta.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/compiler.hpp>
 #include <stdx/panic.hpp>

--- a/include/nexus/detail/extend.hpp
+++ b/include/nexus/detail/extend.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <nexus/builder_meta.hpp>
 #include <nexus/detail/config_item.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/compiler.hpp>
 #include <stdx/tuple.hpp>

--- a/include/nexus/nexus.hpp
+++ b/include/nexus/nexus.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <nexus/built.hpp>
 #include <nexus/detail/nexus_details.hpp>
+#include <nexus/service.hpp>
 
 #include <type_traits>
 

--- a/include/nexus/service.hpp
+++ b/include/nexus/service.hpp
@@ -12,4 +12,7 @@ concept builder_meta = requires {
 
 template <builder_meta T> using builder_t = typename T::builder_t;
 template <builder_meta T> using interface_t = typename T::interface_t;
+
+template <builder_meta ServiceMeta>
+constinit auto service = ServiceMeta::uninitialized();
 } // namespace cib

--- a/test/flow/flow_uninit.cpp
+++ b/test/flow/flow_uninit.cpp
@@ -1,5 +1,5 @@
 #include <flow/service.hpp>
-#include <nexus/built.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/panic.hpp>
 

--- a/test/msg/handler_uninit.cpp
+++ b/test/msg/handler_uninit.cpp
@@ -1,6 +1,6 @@
 #include <msg/message.hpp>
 #include <msg/service.hpp>
-#include <nexus/built.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/panic.hpp>
 

--- a/test/msg/indexed_handler_uninit.cpp
+++ b/test/msg/indexed_handler_uninit.cpp
@@ -1,6 +1,6 @@
 #include <msg/indexed_service.hpp>
 #include <msg/message.hpp>
-#include <nexus/built.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/panic.hpp>
 

--- a/test/nexus/CMakeLists.txt
+++ b/test/nexus/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_tests(
     FILES
-    builder_meta
     callback
     callback_uninit
     nexus
+    service
     LIBRARIES
     warnings
     cib_nexus)

--- a/test/nexus/callback_uninit.cpp
+++ b/test/nexus/callback_uninit.cpp
@@ -1,5 +1,5 @@
-#include <nexus/built.hpp>
 #include <nexus/callback.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/panic.hpp>
 

--- a/test/nexus/service.cpp
+++ b/test/nexus/service.cpp
@@ -1,4 +1,4 @@
-#include <nexus/builder_meta.hpp>
+#include <nexus/service.hpp>
 
 #include <stdx/compiler.hpp>
 

--- a/usage_test/main_nexus.cpp
+++ b/usage_test/main_nexus.cpp
@@ -1,5 +1,3 @@
-#include <nexus/builder_meta.hpp>
-#include <nexus/built.hpp>
 #include <nexus/callback.hpp>
 #include <nexus/config.hpp>
 #include <nexus/detail/components.hpp>
@@ -12,6 +10,7 @@
 #include <nexus/detail/runtime_conditional.hpp>
 #include <nexus/func_decl.hpp>
 #include <nexus/nexus.hpp>
+#include <nexus/service.hpp>
 
 #if __STDC_HOSTED__ == 0
 extern "C" auto main() -> int;


### PR DESCRIPTION
Problem:
- The `nexus` library exposes the `service` through `built` and `builder_meta` headers which expose internal naming.

Solution:
- Move contents of `built` and `builder_meta` headers to a `service` header. The `cib::service` is what's important here.
- This matches similar changes that are already in place for the callback service and the flow library.