### PR TITLE
:children_crossing: Add concepts to nexus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#de60a38")
-add_versioned_package("gh:intel/cpp-std-extensions#a1ae0b4")
+add_versioned_package("gh:intel/cpp-std-extensions#44e1790")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#27db6e1")
 
 set(GEN_STR_CATALOG

--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -3,12 +3,14 @@
 #include <log/log.hpp>
 #include <msg/handler_interface.hpp>
 
+#include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/utility.hpp>
 
 namespace msg {
 
-template <typename Callbacks, typename MsgBase, typename... ExtraCallbackArgs>
+template <stdx::tuplelike Callbacks, typename MsgBase,
+          typename... ExtraCallbackArgs>
 struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
     Callbacks callbacks{};
 

--- a/include/msg/handler_builder.hpp
+++ b/include/msg/handler_builder.hpp
@@ -6,7 +6,9 @@
 #include <stdx/tuple_algorithms.hpp>
 
 namespace msg {
-template <typename Callbacks, typename MsgBase, typename... ExtraCallbackArgs>
+
+template <stdx::tuplelike Callbacks, typename MsgBase,
+          typename... ExtraCallbackArgs>
 struct handler_builder {
     Callbacks callbacks;
 

--- a/include/msg/indexed_handler.hpp
+++ b/include/msg/indexed_handler.hpp
@@ -2,17 +2,27 @@
 
 #include <msg/detail/indexed_handler_common.hpp>
 
+#include <stdx/bitset.hpp>
 #include <stdx/compiler.hpp>
 
-namespace msg {
+#include <cstdint>
 
+namespace msg {
 template <typename... Indices> struct indices : Indices... {
     CONSTEVAL explicit indices(Indices... index_args)
         : Indices{index_args}... {}
 
     constexpr auto operator()(auto const &data) const {
-        return (this->Indices::operator()(data) & ...);
+        return (... & this->Indices::operator()(data));
     }
 };
 
+template <> struct indices<> {
+    CONSTEVAL explicit indices() = default;
+
+    constexpr auto operator()(auto const &) const
+        -> stdx::bitset<0, std::uint32_t> {
+        return {};
+    }
+};
 } // namespace msg

--- a/include/nexus/detail/extend.hpp
+++ b/include/nexus/detail/extend.hpp
@@ -7,9 +7,9 @@
 #include <stdx/tuple.hpp>
 
 namespace cib::detail {
-template <typename ServiceType, typename... Args>
+template <typename Service, typename... Args>
 struct extend : public config_item {
-    using service_type = ServiceType;
+    using service_type = Service;
     constexpr static auto builder = cib::builder_t<service_type>{};
     stdx::tuple<Args...> args_tuple;
 

--- a/include/nexus/nexus.hpp
+++ b/include/nexus/nexus.hpp
@@ -18,30 +18,18 @@ namespace cib {
  */
 
 template <typename Config> struct nexus {
-    template <typename Tag>
+    template <builder_meta T>
     constexpr static auto service = [] {
-        using init_t = initialized<Config, Tag>;
+        using init_t = initialized<Config, T>;
         return init_t::value.template build<init_t>();
     }();
 
     static void init() {
-        auto const service = []<typename T> {
-            auto &service_impl = nexus::service<T>;
-            using from_t = std::remove_cvref_t<decltype(service_impl)>;
-            using to_t = std::remove_cvref_t<decltype(cib::service<T>)>;
-
-            if constexpr (std::is_convertible_v<from_t, to_t>) {
-                cib::service<T> = service_impl;
-            } else {
-                if constexpr (std::is_pointer_v<from_t>) {
-                    cib::service<T> = service_impl;
-                } else {
-                    cib::service<T> = &service_impl;
-                }
-            }
+        auto const init_interface = []<builder_meta T> {
+            cib::service<T> = to_interface<typename T::interface_t>(service<T>);
         };
         initialized_builders<Config>.apply([&]<typename... Ts>(Ts const &...) {
-            (service.template
+            (init_interface.template
              operator()<std::remove_cvref_t<typename Ts::Service>>(),
              ...);
         });

--- a/include/nexus/service.hpp
+++ b/include/nexus/service.hpp
@@ -1,12 +1,55 @@
 #pragma once
 
+#include <stdx/concepts.hpp>
+
 #include <concepts>
+#include <memory>
+#include <type_traits>
 
 namespace cib {
+namespace archetypes {
+template <typename T> struct initialized_service {
+    constexpr static auto value = T{};
+};
+} // namespace archetypes
+
+template <typename Interface, typename T>
+constexpr auto to_interface(T const &t) {
+    if constexpr (std::is_convertible_v<T, Interface>) {
+        return t;
+    } else {
+        if constexpr (std::is_pointer_v<T>) {
+            return t;
+        } else {
+            return std::addressof(t);
+        }
+    }
+}
+
+template <typename Built, typename Interface>
+concept interface_convertible =
+    requires(Built const &b) { to_interface<Interface>(b); };
+
+namespace detail {
+struct add_base {
+    constexpr auto add() const -> void;
+};
+template <typename T> struct add_tester : T, add_base {};
+
 template <typename T>
-concept builder_meta = requires {
-    typename T::builder_t;
-    typename T::interface_t;
+concept has_add_function = not requires(add_tester<T> &t) { t.add(); };
+} // namespace detail
+
+template <typename Builder, typename Meta>
+concept builder_for =
+    detail::has_add_function<Builder> and requires(Builder &b) {
+        {
+            Builder::template build<archetypes::initialized_service<Builder>>()
+        } -> interface_convertible<typename Meta::interface_t>;
+    };
+
+template <typename T>
+concept builder_meta = builder_for<typename T::builder_t, T> and requires {
     { T::uninitialized() } -> std::same_as<typename T::interface_t>;
 };
 

--- a/test/nexus/service.cpp
+++ b/test/nexus/service.cpp
@@ -7,8 +7,12 @@
 #include <type_traits>
 
 namespace {
-struct TestBuilder;
 struct TestInterface {};
+
+struct TestBuilder {
+    constexpr auto add(int) -> TestBuilder;
+    template <typename> constexpr static auto build() -> TestInterface;
+};
 
 struct test_builder_meta {
     using builder_t = TestBuilder;


### PR DESCRIPTION
Problem:
- Nexus services are not very well constrained/described in code: it is not obvious how to achieve the correct alignment of builder, interface, etc.

Solution:
- Add concepts that tie together the builder, interface and builder_meta ideas.