### PR TITLE
:art: Allow nexus to be injected into services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ if(PROJECT_IS_TOP_LEVEL)
     clang_tidy_interface(cib_seq)
 
     # Enable functional and performance test suites.
+    include(CTest)
     add_subdirectory(test)
     add_subdirectory(benchmark)
     add_subdirectory(examples)

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -34,7 +34,7 @@ class builder_for {
         });
     }
 
-    template <typename BuilderValue>
+    template <typename BuilderValue, typename /*Nexus*/>
     [[nodiscard]] constexpr static auto build() {
         return Renderer::template render<BuilderValue>();
     }

--- a/include/msg/handler_builder.hpp
+++ b/include/msg/handler_builder.hpp
@@ -20,7 +20,8 @@ struct handler_builder {
             new_callbacks};
     }
 
-    template <typename BuilderValue> constexpr static auto build() {
+    template <typename BuilderValue, typename /*Nexus*/>
+    constexpr static auto build() {
         return handler<Callbacks, MsgBase, ExtraCallbackArgs...>{
             BuilderValue::value.callbacks};
     }

--- a/include/msg/indexed_builder.hpp
+++ b/include/msg/indexed_builder.hpp
@@ -50,7 +50,8 @@ struct indexed_builder
         } val;
         return val;
     }
-    template <typename BuilderValue> static CONSTEVAL auto build() {
+    template <typename BuilderValue, typename /*Nexus*/>
+    static CONSTEVAL auto build() {
         constexpr auto make_index_lookup =
             []<typename I, std::size_t... Es>(std::index_sequence<Es...>) {
                 return lookup::make(make_input<BuilderValue, I, Es...>());

--- a/include/nexus/callback.hpp
+++ b/include/nexus/callback.hpp
@@ -70,7 +70,7 @@ template <std::size_t NumFuncs = 0, typename... ArgTypes> struct builder {
      * @return
      *      Function pointer to the implemented callback service.
      */
-    template <typename BuilderValue>
+    template <typename BuilderValue, typename>
     [[nodiscard]] CONSTEVAL static auto build() {
         return run<BuilderValue>;
     }

--- a/include/nexus/nexus.hpp
+++ b/include/nexus/nexus.hpp
@@ -21,7 +21,7 @@ template <typename Config> struct nexus {
     template <builder_meta T>
     constexpr static auto service = [] {
         using init_t = initialized<Config, T>;
-        return init_t::value.template build<init_t>();
+        return init_t::value.template build<init_t, nexus>();
     }();
 
     static void init() {

--- a/test/nexus/CMakeLists.txt
+++ b/test/nexus/CMakeLists.txt
@@ -2,6 +2,7 @@ add_tests(
     FILES
     callback
     callback_uninit
+    injected_nexus_service
     nexus
     service
     LIBRARIES

--- a/test/nexus/callback.cpp
+++ b/test/nexus/callback.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <typename BuilderValue> constexpr static auto build() {
-    return BuilderValue::value.template build<BuilderValue>();
+    return BuilderValue::value.template build<BuilderValue, void>();
 }
 
 template <typename BuilderMeta, typename BuiltCallback>

--- a/test/nexus/injected_nexus_service.cpp
+++ b/test/nexus/injected_nexus_service.cpp
@@ -1,0 +1,64 @@
+#include <nexus/config.hpp>
+#include <nexus/nexus.hpp>
+#include <nexus/service.hpp>
+
+#include <stdx/compiler.hpp>
+#include <stdx/ct_conversions.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <string_view>
+#include <tuple>
+#include <utility>
+
+namespace {
+bool nexus_injected{};
+
+template <typename B> struct test_service {
+    using builder_t = B;
+    using interface_t = typename B::interface_t;
+    CONSTEVAL static auto uninitialized() -> interface_t { return {}; }
+};
+
+template <typename... Fs> struct test_builder {
+    using interface_t = auto (*)() -> void;
+    std::tuple<Fs...> funcs;
+
+    template <typename... Args> constexpr auto add(Args... as) {
+        return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            return test_builder<Fs..., Args...>{
+                .funcs = {get<Is>(funcs)..., as...}};
+        }(std::make_index_sequence<sizeof...(Fs)>{});
+    }
+
+    template <typename BuilderValue, typename Nexus> static auto run() -> void {
+        constexpr auto v = BuilderValue::value;
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (get<Is>(v.funcs)(Nexus{}), ...);
+        }(std::make_index_sequence<sizeof...(Fs)>{});
+    }
+
+    template <typename BuilderValue, typename Nexus>
+    [[nodiscard]] CONSTEVAL static auto build() -> interface_t {
+        return run<BuilderValue, Nexus>;
+    }
+};
+
+using service_t = test_service<test_builder<>>;
+
+struct test_config {
+    constexpr static auto config =
+        cib::config(cib::exports<service_t>,
+                    cib::extend<service_t>(
+                        []<typename Nexus>(Nexus) { nexus_injected = true; }));
+};
+} // namespace
+
+TEST_CASE("injected nexus", "[injected_nexus_service]") {
+    nexus_injected = false;
+    cib::nexus<test_config> nexus{};
+    nexus.init();
+    cib::service<test_service<test_builder<>>>();
+    CHECK(nexus_injected);
+}

--- a/test/nexus/service.cpp
+++ b/test/nexus/service.cpp
@@ -11,7 +11,8 @@ struct TestInterface {};
 
 struct TestBuilder {
     constexpr auto add(int) -> TestBuilder;
-    template <typename> constexpr static auto build() -> TestInterface;
+    template <typename, typename>
+    constexpr static auto build() -> TestInterface;
 };
 
 struct test_builder_meta {
@@ -21,12 +22,13 @@ struct test_builder_meta {
 };
 } // namespace
 
-TEST_CASE("builder_meta concept") {
+TEST_CASE("builder_meta concept", "[service]") {
     STATIC_REQUIRE(cib::builder_meta<test_builder_meta>);
 }
 
 TEST_CASE(
-    "builder_meta builder and interface type traits return correct values") {
+    "builder_meta builder and interface type traits return correct values",
+    "[service]") {
     STATIC_REQUIRE(
         std::is_same_v<TestBuilder, cib::builder_t<test_builder_meta>>);
     STATIC_REQUIRE(


### PR DESCRIPTION
Problem:
- Services have to use the type-erased interface for other services through `cib::service`. It could open up interesting avenues if they could use the typeful services directly through the nexus.

Solution:
- Pass the nexus type into the build function for a service.

Note:
- This is a step towards addressing issue #806.