### PR TITLE
:art: Allow the nexus to be injected into flow steps

### DIFF
--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -34,9 +34,9 @@ class builder_for {
         });
     }
 
-    template <typename BuilderValue, typename /*Nexus*/>
+    template <typename BuilderValue, typename Nexus>
     [[nodiscard]] constexpr static auto build() {
-        return Renderer::template render<BuilderValue>();
+        return Renderer::template render<BuilderValue, Nexus>();
     }
 
     stdx::tuple<Fragments...> fragments;

--- a/include/flow/debug_builder.hpp
+++ b/include/flow/debug_builder.hpp
@@ -65,7 +65,7 @@ struct debug_builder {
         constexpr static bool active = true;
     };
 
-    template <typename Initialized>
+    template <typename Initialized, typename /*Nexus*/>
     [[nodiscard]] constexpr static auto render() -> built_flow<Initialized> {
         return {};
     }

--- a/include/flow/viz_builder.hpp
+++ b/include/flow/viz_builder.hpp
@@ -180,7 +180,7 @@ struct viz_builder {
         constexpr static bool active = true;
     };
 
-    template <typename Initialized>
+    template <typename Initialized, typename /*Nexus*/>
     [[nodiscard]] constexpr static auto render() -> built_flow<Initialized> {
         return {};
     }

--- a/include/seq/impl.hpp
+++ b/include/seq/impl.hpp
@@ -25,7 +25,7 @@ struct impl {
 
     using node_t = rt_step;
 
-    template <typename CTNode>
+    template <typename /*Nexus*/, typename CTNode>
     constexpr static auto create_node(CTNode n) -> node_t {
         return n;
     }

--- a/test/flow/flow.cpp
+++ b/test/flow/flow.cpp
@@ -18,6 +18,10 @@ constexpr auto a = flow::action<"a">([] { actual += "a"; });
 constexpr auto b = flow::action<"b">([] { actual += "b"; });
 constexpr auto c = flow::action<"c">([] { actual += "c"; });
 constexpr auto d = flow::action<"d">([] { actual += "d"; });
+constexpr auto injected = flow::action<"injected">([]<typename Nexus>() {
+    [[maybe_unused]] Nexus n{};
+    actual += "i";
+});
 
 struct TestFlowAlpha : public flow::service<> {};
 struct TestFlowBeta : public flow::service<> {};
@@ -82,6 +86,12 @@ flowchart TD
 TEST_CASE("add single action through cib::nexus", "[flow]") {
     check_flow<TestFlowAlpha, cib::exports<TestFlowAlpha>,
                cib::extend<TestFlowAlpha>(*a)>("a");
+}
+
+TEST_CASE("add single action with injected nexus through cib::nexus",
+          "[flow]") {
+    check_flow<TestFlowAlpha, cib::exports<TestFlowAlpha>,
+               cib::extend<TestFlowAlpha>(*injected)>("i");
 }
 
 TEST_CASE("add runtime conditional action through cib::nexus", "[flow]") {


### PR DESCRIPTION
Problem:
- The flow service does not take account of the nexus that can be injected; flow steps cannot use it.

Solution:
- Allow flow steps to take the nexus as an injected template argument.