### PR TITLE
:art: Allow the nexus to be injected into message callbacks

### DIFF
--- a/include/msg/callback.hpp
+++ b/include/msg/callback.hpp
@@ -27,7 +27,8 @@ struct callback {
         return msg::call_with_message<Msg>(matcher, data);
     }
 
-    template <stdx::ct_string Extra = "", typename... Args>
+    template <typename Nexus = void, stdx::ct_string Extra = "",
+              typename... Args>
     // NOLINTNEXTLINE (readability-function-cognitive-complexity)
     [[nodiscard]] auto handle(auto const &data, Args &&...args) const -> bool {
         CIB_LOG_ENV(logging::get_level, logging::level::INFO);
@@ -37,8 +38,8 @@ struct callback {
                     "callback",
                     stdx::cts_t<Name>{}, matcher.describe(),
                     stdx::cts_t<Extra>{});
-            msg::call_with_message<Msg>(callable, data,
-                                        std::forward<Args>(args)...);
+            msg::call_with_message<Msg, Nexus>(callable, data,
+                                               std::forward<Args>(args)...);
             return true;
         }
         return false;

--- a/include/msg/detail/indexed_builder_common.hpp
+++ b/include/msg/detail/indexed_builder_common.hpp
@@ -144,7 +144,7 @@ struct indexed_builder_base {
     using callback_func_t = auto (*)(MsgBase const &, ExtraCallbackArgs... args)
         -> bool;
 
-    template <typename BuilderValue, std::size_t I>
+    template <typename BuilderValue, typename Nexus, std::size_t I>
     constexpr static auto invoke_callback(MsgBase const &data,
                                           ExtraCallbackArgs... args) -> bool {
         constexpr auto cb = IndexSpec{}.apply([&]<typename... Indices>(
@@ -165,13 +165,13 @@ struct indexed_builder_base {
         constexpr auto matcher_str =
             stdx::ct_format<" (collapsed by index from [{}])">(
                 orig_cb.matcher.describe());
-        return cb.template handle<matcher_str>(data, args...);
+        return cb.template handle<Nexus, matcher_str>(data, args...);
     }
 
-    template <typename BuilderValue, std::size_t... Is>
+    template <typename BuilderValue, typename Nexus, std::size_t... Is>
     static CONSTEVAL auto create_callback_array(std::index_sequence<Is...>)
         -> std::array<callback_func_t, BuilderValue::value.callbacks.size()> {
-        return {invoke_callback<BuilderValue, Is>...};
+        return {invoke_callback<BuilderValue, Nexus, Is>...};
     }
 
     static CONSTEVAL auto walk_matcher(auto const &tag, auto const &callbacks,

--- a/include/msg/handler.hpp
+++ b/include/msg/handler.hpp
@@ -9,7 +9,7 @@
 
 namespace msg {
 
-template <stdx::tuplelike Callbacks, typename MsgBase,
+template <typename Nexus, stdx::tuplelike Callbacks, typename MsgBase,
           typename... ExtraCallbackArgs>
 struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
     Callbacks callbacks{};
@@ -26,7 +26,7 @@ struct handler : handler_interface<MsgBase, ExtraCallbackArgs...> {
         -> bool final {
         auto const found_valid_callback = stdx::apply(
             [&](auto &...cbs) -> bool {
-                return (0u | ... | cbs.handle(msg, args...));
+                return (0u | ... | cbs.template handle<Nexus>(msg, args...));
             },
             callbacks);
         if (!found_valid_callback) {

--- a/include/msg/handler_builder.hpp
+++ b/include/msg/handler_builder.hpp
@@ -20,9 +20,9 @@ struct handler_builder {
             new_callbacks};
     }
 
-    template <typename BuilderValue, typename /*Nexus*/>
+    template <typename BuilderValue, typename Nexus>
     constexpr static auto build() {
-        return handler<Callbacks, MsgBase, ExtraCallbackArgs...>{
+        return handler<Nexus, Callbacks, MsgBase, ExtraCallbackArgs...>{
             BuilderValue::value.callbacks};
     }
 };

--- a/include/msg/indexed_builder.hpp
+++ b/include/msg/indexed_builder.hpp
@@ -50,7 +50,7 @@ struct indexed_builder
         } val;
         return val;
     }
-    template <typename BuilderValue, typename /*Nexus*/>
+    template <typename BuilderValue, typename Nexus>
     static CONSTEVAL auto build() {
         constexpr auto make_index_lookup =
             []<typename I, std::size_t... Es>(std::index_sequence<Es...>) {
@@ -74,7 +74,7 @@ struct indexed_builder
 
         constexpr auto num_callbacks = BuilderValue::value.callbacks.size();
         constexpr auto callback_array =
-            base_t::template create_callback_array<BuilderValue>(
+            base_t::template create_callback_array<BuilderValue, Nexus>(
                 std::make_index_sequence<num_callbacks>{});
 
         return make_indexed_handler<MsgBase, ExtraCallbackArgs...>(

--- a/test/msg/handler.cpp
+++ b/test/msg/handler.cpp
@@ -40,7 +40,8 @@ TEST_CASE("is_match is true for a match", "[handler]") {
     auto const msg = std::array{0x8000ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
-    auto handler = msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+    auto handler =
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
     CHECK(handler.is_match(msg));
 }
 
@@ -50,10 +51,26 @@ TEST_CASE("dispatch single callback (match, raw data)", "[handler]") {
     auto const msg = std::array{0x8000ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
-    auto handler = msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+    auto handler =
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
     dispatched = false;
     CHECK(handler.handle(msg));
     CHECK(dispatched);
+}
+
+TEST_CASE("dispatch single callback with template arg (match, raw data)",
+          "[handler]") {
+    int value{};
+    auto callback = msg::callback<"cb", msg_defn>(
+        id_match<0x80>,
+        [&]<typename I>(msg::const_view<msg_defn>) { value = I::value; });
+    auto const msg = std::array{0x8000ba11u, 0x0042d00du};
+
+    auto callbacks = stdx::make_tuple(callback);
+    auto handler = msg::handler<std::integral_constant<int, 17>,
+                                decltype(callbacks), decltype(msg)>{callbacks};
+    CHECK(handler.handle(msg));
+    CHECK(value == 17);
 }
 
 TEST_CASE("dispatch single callback (match, typed data)", "[handler]") {
@@ -62,10 +79,26 @@ TEST_CASE("dispatch single callback (match, typed data)", "[handler]") {
     auto const msg = msg::owning<msg_defn>{"id"_field = 0x80};
 
     auto callbacks = stdx::make_tuple(callback);
-    auto handler = msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+    auto handler =
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
     dispatched = false;
     CHECK(handler.handle(msg));
     CHECK(dispatched);
+}
+
+TEST_CASE("dispatch single callback with template arg (match, typed data)",
+          "[handler]") {
+    int value{};
+    auto callback = msg::callback<"cb", msg_defn>(
+        id_match<0x80>,
+        [&]<typename I>(msg::const_view<msg_defn>) { value = I::value; });
+    auto const msg = msg::owning<msg_defn>{"id"_field = 0x80};
+
+    auto callbacks = stdx::make_tuple(callback);
+    auto handler = msg::handler<std::integral_constant<int, 17>,
+                                decltype(callbacks), decltype(msg)>{callbacks};
+    CHECK(handler.handle(msg));
+    CHECK(value == 17);
 }
 
 TEST_CASE("dispatch single callback (no match)", "[handler]") {
@@ -74,7 +107,8 @@ TEST_CASE("dispatch single callback (no match)", "[handler]") {
     auto const msg = std::array{0x8100ba11u, 0x0042d00du};
 
     auto callbacks = stdx::make_tuple(callback);
-    auto handler = msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+    auto handler =
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
     dispatched = false;
     CHECK(not handler.handle(msg));
     CHECK(not dispatched);
@@ -83,7 +117,8 @@ TEST_CASE("dispatch single callback (no match)", "[handler]") {
 TEST_CASE("log mismatch when no match", "[handler]") {
     auto const msg = std::array{0x8000ba11u, 0x0042d00du};
     auto callbacks = stdx::tuple{};
-    auto handler = msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+    auto handler =
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
     CHECK(not handler.handle(msg));
     CAPTURE(log_buffer);
     CHECK(log_buffer.find(
@@ -100,7 +135,7 @@ TEST_CASE("match and dispatch only one callback", "[handler]") {
 
     auto callbacks = stdx::make_tuple(callback1, callback2);
     static auto handler =
-        msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
 
     dispatched = false;
     CHECK(handler.handle(msg));
@@ -120,7 +155,7 @@ TEST_CASE("dispatch all callbacks that match", "[handler]") {
 
     auto callbacks = stdx::make_tuple(callback1, callback2, callback3);
     static auto handler =
-        msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
 
     CHECK(handler.handle(msg));
     CHECK(count == 2);
@@ -146,7 +181,7 @@ TEST_CASE("match and dispatch only one callback with uint8_t storage",
 
     auto callbacks = stdx::make_tuple(callback1, callback2);
     static auto handler =
-        msg::handler<decltype(callbacks), decltype(msg)>{callbacks};
+        msg::handler<void, decltype(callbacks), decltype(msg)>{callbacks};
 
     dispatched = false;
     handler.handle(msg);
@@ -163,7 +198,7 @@ TEST_CASE("dispatch with extra args", "[handler]") {
 
     auto callbacks = stdx::make_tuple(callback);
     static auto handler =
-        msg::handler<decltype(callbacks), decltype(msg), int>{callbacks};
+        msg::handler<void, decltype(callbacks), decltype(msg), int>{callbacks};
 
     dispatched = false;
     CHECK(handler.handle(msg, 0xcafe));

--- a/test/msg/indexed_builder.cpp
+++ b/test/msg/indexed_builder.cpp
@@ -511,7 +511,7 @@ struct test_project_multi_cb {
 };
 } // namespace
 
-TEST_CASE("call multiple callbacks", "[handler_builder]") {
+TEST_CASE("call multiple callbacks", "[indexed_builder]") {
     cib::nexus<test_project_multi_cb> test_nexus{};
     test_nexus.init();
 
@@ -521,4 +521,27 @@ TEST_CASE("call multiple callbacks", "[handler_builder]") {
         test_msg_t{"test_id_field"_field = 0x80});
     CHECK(callback_success);
     CHECK(callback2_success);
+}
+
+namespace {
+constexpr auto test_callback_template =
+    msg::callback<"TestCallback2", msg_defn>(
+        msg::in<test_id_field, 0x80>,
+        []<typename>(auto) { callback_success = true; });
+
+struct test_project_template_cb {
+    constexpr static auto config =
+        cib::config(cib::exports<test_service>,
+                    cib::extend<test_service>(test_callback_template));
+};
+} // namespace
+
+TEST_CASE("call template callback", "[indexed_builder]") {
+    cib::nexus<test_project_template_cb> test_nexus{};
+    test_nexus.init();
+
+    callback_success = false;
+    cib::service<test_service>->handle(
+        test_msg_t{"test_id_field"_field = 0x80});
+    CHECK(callback_success);
 }


### PR DESCRIPTION
Problem:
- The message callback service (indexed or otherwise) does not that account of the nexus that can be injected; callbacks cannot use it.

Solution:
- Allow message callbacks to take the nexus as an injected template argument.