### PR TITLE
:arrow_up: Update `stdx`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ include(cmake/string_catalog.cmake)
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#de60a38")
-add_versioned_package("gh:intel/cpp-std-extensions#44e1790")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#27db6e1")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#9332543")
+add_versioned_package("gh:intel/cpp-std-extensions#130fb59")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#b441b63")
 
 set(GEN_STR_CATALOG
     ${CMAKE_CURRENT_LIST_DIR}/tools/gen_str_catalog.py

--- a/include/log_binary/catalog/arguments.hpp
+++ b/include/log_binary/catalog/arguments.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <concepts>
@@ -11,6 +12,7 @@ template <typename> struct encode_64;
 template <typename> struct encode_u32;
 template <typename> struct encode_u64;
 template <typename...> struct encode_enum;
+template <typename...> struct encode_ct_arg;
 
 namespace logging {
 template <typename T>
@@ -29,8 +31,11 @@ template <typename T>
 concept enum_packable = std::is_enum_v<T> and sizeof(T) <= sizeof(std::int64_t);
 
 template <typename T>
+concept ct_packable = stdx::is_specialization_of_v<T, stdx::ct_format_arg>;
+
+template <typename T>
 concept packable = signed_packable<T> or unsigned_packable<T> or
-                   float_packable<T> or enum_packable<T>;
+                   float_packable<T> or enum_packable<T> or ct_packable<T>;
 
 template <typename T> struct encoding;
 
@@ -70,6 +75,14 @@ struct encoding<T> : encoding<stdx::underlying_type_t<T>> {
                             detail::signed_encode_t<T>,
                             detail::unsigned_encode_t<T>>>;
 };
+
+template <typename T> struct encoding<stdx::ct_format_arg<T>> {
+    using pack_t = void;
+    using encode_t = encode_ct_arg<T>;
+};
+
+template <typename T> constexpr inline std::size_t pack_size = sizeof(T);
+template <> constexpr inline std::size_t pack_size<void> = 0;
 
 struct default_arg_packer {
     template <packable T> using pack_as_t = typename encoding<T>::pack_t;

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -132,7 +132,8 @@ TEST_CASE("CIB_FATAL formats compile-time arguments where possible", "[log]") {
     using namespace stdx::literals;
     reset_test_state();
     expected_why = "Hello 17";
-    expected_args = std::make_tuple(stdx::make_tuple());
+    expected_args = std::make_tuple(stdx::make_tuple(
+        stdx::ct_format_arg<stdx::ct_string<6>>{}, stdx::ct_format_arg<int>{}));
 
     []<stdx::ct_string S>() {
         CIB_FATAL("{} {}", S, 17);

--- a/test/log_binary/encoder.cpp
+++ b/test/log_binary/encoder.cpp
@@ -335,7 +335,7 @@ TEST_CASE("injection", "[mipi]") {
 
 TEST_CASE("injection - log runtime arg", "[mipi]") {
     test_critical_section::count = 0;
-    expected_args = std::vector<std::uint32_t>{42, 17};
+    expected_args = std::vector<std::uint32_t>{test_string_id, 17};
     auto x = 17;
     CIB_TRACE("Hello {}", x);
     CHECK(test_critical_section::count == 2);

--- a/test/match/and.cpp
+++ b/test/match/and.cpp
@@ -10,56 +10,56 @@
 
 TEST_CASE("AND fulfils matcher concept", "[match and]") {
     using T = match::and_t<test_matcher, test_matcher>;
-    STATIC_REQUIRE(match::matcher<T>);
-    STATIC_REQUIRE(match::matcher_for<T, int>);
+    STATIC_CHECK(match::matcher<T>);
+    STATIC_CHECK(match::matcher_for<T, int>);
 }
 
 TEST_CASE("AND describes itself", "[match and]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    STATIC_REQUIRE(e.describe() ==
-                   stdx::ct_format<"({}) and ({})">(test_m<0>{}.describe(),
-                                                    test_m<1>{}.describe()));
+    STATIC_CHECK(e.describe().str == "(test) and (test)"_ctst);
 }
 
 TEST_CASE("AND description flattens", "[match and]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    STATIC_REQUIRE(e.describe() == stdx::ct_format<"({}) and ({}) and ({})">(
-                                       test_m<0>{}.describe(),
-                                       test_m<1>{}.describe(),
-                                       test_m<2>{}.describe()));
+    STATIC_CHECK(e.describe().str == "(test) and (test) and (test)"_ctst);
 }
 
 TEST_CASE("AND describes a match", "[match and]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    STATIC_REQUIRE(e.describe_match(1) == stdx::ct_format<"({}) and ({})">(
-                                              test_m<0>{}.describe_match(1),
-                                              test_m<1>{}.describe_match(1)));
+    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) {} ({})">(
+                                            test_m<0>{}.describe_match(1),
+                                            "and"_ctst,
+                                            test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("AND match description flattens", "[match and]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
-    STATIC_REQUIRE(e.describe_match(1) ==
-                   stdx::ct_format<"({}) and ({}) and ({})">(
-                       test_m<0>{}.describe_match(1),
-                       test_m<1>{}.describe_match(1),
-                       test_m<2>{}.describe_match(1)));
+    STATIC_CHECK(e.describe_match(1) ==
+                 stdx::ct_format<"({}) {} ({}) {} ({})">(
+                     test_m<0>{}.describe_match(1), "and"_ctst,
+                     test_m<1>{}.describe_match(1), "and"_ctst,
+                     test_m<2>{}.describe_match(1)));
 }
 
 TEST_CASE("AND matches correctly", "[match and]") {
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    STATIC_REQUIRE(
+    STATIC_CHECK(
         std::is_same_v<decltype(e), match::and_t<test_m<0>, test_m<1>> const>);
-    STATIC_REQUIRE(e(1));
-    STATIC_REQUIRE(not e(0));
+    STATIC_CHECK(e(1));
+    STATIC_CHECK(not e(0));
 }
 
 TEST_CASE("AND simplifies correctly", "[match and]") {
     constexpr auto e = test_matcher{} and test_matcher{};
-    STATIC_REQUIRE(std::is_same_v<decltype(e), test_matcher const>);
+    STATIC_CHECK(std::is_same_v<decltype(e), test_matcher const>);
 }
 
 TEST_CASE("all expression simplifies", "[match and]") {
     constexpr auto m = match::all(test_m<0>{}, test_m<1>{}, match::always);
-    STATIC_REQUIRE(
+    STATIC_CHECK(
         std::is_same_v<decltype(m), match::and_t<test_m<0>, test_m<1>> const>);
 }

--- a/test/match/or.cpp
+++ b/test/match/or.cpp
@@ -15,51 +15,51 @@ TEST_CASE("OR fulfils matcher concept", "[match or]") {
 }
 
 TEST_CASE("OR describes itself", "[match or]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    STATIC_REQUIRE(e.describe() ==
-                   stdx::ct_format<"({}) or ({})">(test_m<0>{}.describe(),
-                                                   test_m<1>{}.describe()));
+    STATIC_CHECK(e.describe().str == "(test) or (test)"_ctst);
 }
 
 TEST_CASE("OR description flattens", "[match or]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    STATIC_REQUIRE(e.describe() == stdx::ct_format<"({}) or ({}) or ({})">(
-                                       test_m<0>{}.describe(),
-                                       test_m<1>{}.describe(),
-                                       test_m<2>{}.describe()));
+    STATIC_CHECK(e.describe().str == "(test) or (test) or (test)"_ctst);
 }
 
 TEST_CASE("OR describes a match", "[match or]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    STATIC_REQUIRE(e.describe_match(1) == stdx::ct_format<"({}) or ({})">(
-                                              test_m<0>{}.describe_match(1),
-                                              test_m<1>{}.describe_match(1)));
+    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) {} ({})">(
+                                            test_m<0>{}.describe_match(1),
+                                            "or"_ctst,
+                                            test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("OR match description flattens", "[match or]") {
+    using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    STATIC_REQUIRE(
-        e.describe_match(1) ==
-        stdx::ct_format<"({}) or ({}) or ({})">(test_m<0>{}.describe_match(1),
-                                                test_m<1>{}.describe_match(1),
-                                                test_m<2>{}.describe_match(1)));
+    STATIC_CHECK(e.describe_match(1) ==
+                 stdx::ct_format<"({}) {} ({}) {} ({})">(
+                     test_m<0>{}.describe_match(1), "or"_ctst,
+                     test_m<1>{}.describe_match(1), "or"_ctst,
+                     test_m<2>{}.describe_match(1)));
 }
 
 TEST_CASE("OR matches correctly", "[match or]") {
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    STATIC_REQUIRE(
+    STATIC_CHECK(
         std::is_same_v<decltype(e), match::or_t<test_m<0>, test_m<1>> const>);
-    STATIC_REQUIRE(e(1));
-    STATIC_REQUIRE(not e(0));
+    STATIC_CHECK(e(1));
+    STATIC_CHECK(not e(0));
 }
 
 TEST_CASE("OR simplifies correctly", "[match or]") {
     constexpr auto e = test_matcher{} and test_matcher{};
-    STATIC_REQUIRE(std::is_same_v<decltype(e), test_matcher const>);
+    STATIC_CHECK(std::is_same_v<decltype(e), test_matcher const>);
 }
 
 TEST_CASE("any expression simplifies", "[match or]") {
     constexpr auto m = match::any(test_m<0>{}, test_m<1>{}, match::never);
-    STATIC_REQUIRE(
+    STATIC_CHECK(
         std::is_same_v<decltype(m), match::or_t<test_m<0>, test_m<1>> const>);
 }

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -320,9 +320,14 @@ def extract_enums(filename: str):
 def write_json(
     messages, modules, enums, extra_inputs: list[str], filename: str, stable_data
 ):
+    # temporary: filter out ct args
+    for m in messages:
+        m.args = [a for a in m.args if "encode_ct_arg" not in a]
+
     d = dict(
         messages=[m.to_json() for m in messages], modules=[m.to_json() for m in modules]
     )
+    
     for m in stable_data.get("messages"):
         j = m.to_json()
         if j not in d["messages"]:
@@ -398,7 +403,7 @@ def serialize_modules(client_node: et.Element, modules: list[Module]):
 
 
 def arg_type_encoding(arg):
-    string_re = re.compile(r"encode_(32|u32|64|u64|enum)<(.*)>")
+    string_re = re.compile(r"encode_(32|u32|64|u64|enum|ct_arg)<(.*)>")
     m = string_re.match(arg)
     if "enum" in m.group(1):
         args_re = re.compile(r"(.*), (.*)")


### PR DESCRIPTION
Problem:
- `stdx` updates changed the output of `stdx::ct_format`.

Solution:
- Update CIB code to work with the new API.

Note:
- The new `ct_format_arg` and span information is not yet output to the `strings.json`.