### PR TITLE
:art: Use a default nexus injected into a flow step function

### DIFF
--- a/include/flow/func_list.hpp
+++ b/include/flow/func_list.hpp
@@ -17,7 +17,7 @@
 namespace flow {
 namespace detail {
 template <stdx::ct_string FlowName, log_policy LogPolicy, typename CTNode,
-          typename Nexus>
+          typename Nexus = void>
 constexpr static auto run_func = []() -> void {
     if (CTNode::condition) {
         LogPolicy::template log<


### PR DESCRIPTION
Problem:
- Migration from legacy code uses `flow::detail::run_func` without an injected nexus. This is a compilation error with the new injection code.

Solution:
- Default the injected nexus type to `void`.