### PR TITLE
:rewind: Revert previous changes to accommodate `stdx` update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#9332543")
-add_versioned_package("gh:intel/cpp-std-extensions#130fb59")
+add_versioned_package("gh:intel/cpp-std-extensions#59bd98c")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#b441b63")
 
 set(GEN_STR_CATALOG
@@ -180,14 +180,8 @@ target_sources(
 
 add_library(cib_log_binary INTERFACE)
 target_compile_features(cib_log_binary INTERFACE cxx_std_20)
-target_link_libraries_system(
-    cib_log_binary
-    INTERFACE
-    boost_mp11
-    cib_log
-    cib_msg
-    concurrency
-    stdx)
+target_link_libraries_system(cib_log_binary INTERFACE cib_log cib_msg
+                             concurrency stdx)
 
 target_sources(
     cib_log_binary

--- a/include/log_binary/catalog/arguments.hpp
+++ b/include/log_binary/catalog/arguments.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <concepts>
@@ -12,7 +11,6 @@ template <typename> struct encode_64;
 template <typename> struct encode_u32;
 template <typename> struct encode_u64;
 template <typename...> struct encode_enum;
-template <typename...> struct encode_ct_arg;
 
 namespace logging {
 template <typename T>
@@ -31,11 +29,8 @@ template <typename T>
 concept enum_packable = std::is_enum_v<T> and sizeof(T) <= sizeof(std::int64_t);
 
 template <typename T>
-concept ct_packable = stdx::is_specialization_of_v<T, stdx::ct_format_arg>;
-
-template <typename T>
 concept packable = signed_packable<T> or unsigned_packable<T> or
-                   float_packable<T> or enum_packable<T> or ct_packable<T>;
+                   float_packable<T> or enum_packable<T>;
 
 template <typename T> struct encoding;
 
@@ -75,14 +70,6 @@ struct encoding<T> : encoding<stdx::underlying_type_t<T>> {
                             detail::signed_encode_t<T>,
                             detail::unsigned_encode_t<T>>>;
 };
-
-template <typename T> struct encoding<stdx::ct_format_arg<T>> {
-    using pack_t = void;
-    using encode_t = encode_ct_arg<T>;
-};
-
-template <typename T> constexpr inline std::size_t pack_size = sizeof(T);
-template <> constexpr inline std::size_t pack_size<void> = 0;
 
 struct default_arg_packer {
     template <packable T> using pack_as_t = typename encoding<T>::pack_t;

--- a/include/log_binary/catalog/encoder.hpp
+++ b/include/log_binary/catalog/encoder.hpp
@@ -17,8 +17,6 @@
 
 #include <conc/concurrency.hpp>
 
-#include <boost/mp11/algorithm.hpp>
-
 #include <cstddef>
 #include <string_view>
 #include <type_traits>
@@ -26,12 +24,8 @@
 
 namespace logging::binary {
 namespace detail {
-template <typename T>
-using is_rt_encoded_arg = std::bool_constant<
-    not stdx::is_specialization_of_v<std::remove_cvref_t<T>, encode_ct_arg>>;
-
 template <typename S, auto Id, typename... Args>
-constexpr static auto to_message(boost::mp11::mp_list<Args...>) {
+constexpr static auto to_message() {
     constexpr auto s = std::string_view{S::value};
     using char_t = typename std::remove_cv_t<decltype(s)>::value_type;
     return [&]<std::size_t... Is>(std::integer_sequence<std::size_t, Is...>) {
@@ -49,9 +43,7 @@ template <stdx::ct_string S, auto Id> constexpr static auto to_module() {
 
 template <typename S, auto Id> struct to_message_t {
     template <typename... Args>
-    using fn = decltype(to_message<S, Id>(
-        boost::mp11::mp_copy_if<boost::mp11::mp_list<Args...>,
-                                is_rt_encoded_arg>{}));
+    using fn = decltype(to_message<S, Id, Args...>());
 };
 
 } // namespace detail

--- a/include/log_fmt/logger.hpp
+++ b/include/log_fmt/logger.hpp
@@ -44,11 +44,6 @@ template <logging::level L>
 }
 
 namespace fmt {
-template <typename T>
-using is_rt_arg =
-    std::bool_constant<not stdx::is_specialization_of_v<std::remove_cvref_t<T>,
-                                                        stdx::ct_format_arg>>;
-
 template <typename TDestinations> struct log_handler {
     constexpr explicit log_handler(TDestinations &&ds) : dests{std::move(ds)} {}
 
@@ -68,14 +63,11 @@ template <typename TDestinations> struct log_handler {
                 constexpr auto fmtstr =
                     std::string_view{decltype(fr.str)::value};
                 fr.args.apply([&]<typename... Args>(Args &&...args) {
-                    auto real_args = filter<is_rt_arg>(
-                        stdx::tuple<Args &&...>{std::forward<Args>(args)...});
-                    std::move(real_args).apply([&]<typename... As>(As &&...as) {
-                        ::fmt::format_to(out, fmtstr,
-                                         fmt_detail::decay_enum_value(as)...);
-                    });
-                    *out = '\n';
+                    ::fmt::format_to(out, fmtstr,
+                                     fmt_detail::decay_enum_value(
+                                         std::forward<Args>(args))...);
                 });
+                *out = '\n';
             },
             dests);
     }

--- a/test/log/log.cpp
+++ b/test/log/log.cpp
@@ -132,8 +132,7 @@ TEST_CASE("CIB_FATAL formats compile-time arguments where possible", "[log]") {
     using namespace stdx::literals;
     reset_test_state();
     expected_why = "Hello 17";
-    expected_args = std::make_tuple(stdx::make_tuple(
-        stdx::ct_format_arg<stdx::ct_string<6>>{}, stdx::ct_format_arg<int>{}));
+    expected_args = std::make_tuple(stdx::make_tuple());
 
     []<stdx::ct_string S>() {
         CIB_FATAL("{} {}", S, 17);

--- a/test/match/and.cpp
+++ b/test/match/and.cpp
@@ -29,9 +29,8 @@ TEST_CASE("AND description flattens", "[match and]") {
 TEST_CASE("AND describes a match", "[match and]") {
     using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{};
-    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) {} ({})">(
+    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) and ({})">(
                                             test_m<0>{}.describe_match(1),
-                                            "and"_ctst,
                                             test_m<1>{}.describe_match(1)));
 }
 
@@ -39,9 +38,9 @@ TEST_CASE("AND match description flattens", "[match and]") {
     using namespace stdx::literals;
     constexpr auto e = test_m<0>{} and test_m<1>{} and test_m<2>{};
     STATIC_CHECK(e.describe_match(1) ==
-                 stdx::ct_format<"({}) {} ({}) {} ({})">(
-                     test_m<0>{}.describe_match(1), "and"_ctst,
-                     test_m<1>{}.describe_match(1), "and"_ctst,
+                 stdx::ct_format<"({}) and ({}) and ({})">(
+                     test_m<0>{}.describe_match(1),
+                     test_m<1>{}.describe_match(1),
                      test_m<2>{}.describe_match(1)));
 }
 

--- a/test/match/or.cpp
+++ b/test/match/or.cpp
@@ -29,20 +29,18 @@ TEST_CASE("OR description flattens", "[match or]") {
 TEST_CASE("OR describes a match", "[match or]") {
     using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{};
-    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) {} ({})">(
+    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) or ({})">(
                                             test_m<0>{}.describe_match(1),
-                                            "or"_ctst,
                                             test_m<1>{}.describe_match(1)));
 }
 
 TEST_CASE("OR match description flattens", "[match or]") {
     using namespace stdx::literals;
     constexpr auto e = test_m<0>{} or test_m<1>{} or test_m<2>{};
-    STATIC_CHECK(e.describe_match(1) ==
-                 stdx::ct_format<"({}) {} ({}) {} ({})">(
-                     test_m<0>{}.describe_match(1), "or"_ctst,
-                     test_m<1>{}.describe_match(1), "or"_ctst,
-                     test_m<2>{}.describe_match(1)));
+    STATIC_CHECK(e.describe_match(1) == stdx::ct_format<"({}) or ({}) or ({})">(
+                                            test_m<0>{}.describe_match(1),
+                                            test_m<1>{}.describe_match(1),
+                                            test_m<2>{}.describe_match(1)));
 }
 
 TEST_CASE("OR matches correctly", "[match or]") {

--- a/test/msg/field_matchers.cpp
+++ b/test/msg/field_matchers.cpp
@@ -17,11 +17,6 @@ enum struct E { A, B, C };
 
 using test_enum_field =
     field<"enum_field", E>::located<at{0_dw, 31_msb, 24_lsb}>;
-
-template <typename T>
-using is_rt_arg =
-    std::bool_constant<not stdx::is_specialization_of_v<std::remove_cvref_t<T>,
-                                                        stdx::ct_format_arg>>;
 } // namespace
 
 TEST_CASE("matcher description", "[field matchers]") {
@@ -38,7 +33,7 @@ TEST_CASE("matcher description of match", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_field, 5>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
     STATIC_REQUIRE(desc.str == "test_field (0x{:x}) < 0x5"_ctst);
-    STATIC_REQUIRE(filter<is_rt_arg>(desc.args) == stdx::tuple{1});
+    STATIC_REQUIRE(desc.args == stdx::tuple{1});
 }
 
 TEST_CASE("matcher description (enum field)", "[field matchers]") {
@@ -55,7 +50,7 @@ TEST_CASE("matcher description of match (enum field)", "[field matchers]") {
     constexpr auto m = msg::less_than_t<test_enum_field, E::C>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
     STATIC_REQUIRE(desc.str == "enum_field ({}) < C"_ctst);
-    STATIC_REQUIRE(filter<is_rt_arg>(desc.args) == stdx::tuple{E::B});
+    STATIC_REQUIRE(desc.args == stdx::tuple{E::B});
 }
 
 TEST_CASE("negate less_than", "[field matchers]") {
@@ -259,7 +254,7 @@ TEST_CASE("predicate matcher description of match", "[field matchers]") {
         msg::pred_matcher_t<test_field, [](std::uint32_t) { return true; }>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
     STATIC_REQUIRE(desc.str == "<predicate>(test_field(0x{:x}))"_ctst);
-    STATIC_REQUIRE(filter<is_rt_arg>(desc.args) == stdx::tuple{1});
+    STATIC_REQUIRE(desc.args == stdx::tuple{1});
 }
 
 TEST_CASE("predicate matcher description of match (enum field)",
@@ -271,5 +266,5 @@ TEST_CASE("predicate matcher description of match (enum field)",
         msg::pred_matcher_t<test_enum_field, [](auto) { return true; }>{};
     constexpr auto desc = m.describe_match(msg_data{0x01ff'ffff});
     STATIC_REQUIRE(desc.str == "<predicate>(enum_field({}))"_ctst);
-    STATIC_REQUIRE(filter<is_rt_arg>(desc.args) == stdx::tuple{E::B});
+    STATIC_REQUIRE(desc.args == stdx::tuple{E::B});
 }

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -320,10 +320,6 @@ def extract_enums(filename: str):
 def write_json(
     messages, modules, enums, extra_inputs: list[str], filename: str, stable_data
 ):
-    # temporary: filter out ct args
-    for m in messages:
-        m.args = [a for a in m.args if "encode_ct_arg" not in a]
-
     d = dict(
         messages=[m.to_json() for m in messages], modules=[m.to_json() for m in modules]
     )
@@ -403,7 +399,7 @@ def serialize_modules(client_node: et.Element, modules: list[Module]):
 
 
 def arg_type_encoding(arg):
-    string_re = re.compile(r"encode_(32|u32|64|u64|enum|ct_arg)<(.*)>")
+    string_re = re.compile(r"encode_(32|u32|64|u64|enum)<(.*)>")
     m = string_re.match(arg)
     if "enum" in m.group(1):
         args_re = re.compile(r"(.*), (.*)")


### PR DESCRIPTION
Problem:
- The `stdx` update for formatting named arguments is simpler now; the existing code is no longer needed.

Solution:
- Remove the workarounds.