### PR TITLE
Fix link to User Guide in examples README.md

### DIFF
--- a/examples/nexus/hello_world/README.md
+++ b/examples/nexus/hello_world/README.md
@@ -137,4 +137,4 @@ Hello, world!
 
 ### User guide
 
-For more details on how to use *cib*, see the [User Guide](../../USER_GUIDE.md).
+For more details on how to use *cib*, see the [User Guide](/USER_GUIDE.md).


### PR DESCRIPTION
Existing link is broken.
This should be better than `../../../` and hopefully still work.