### PR TITLE
:bug: Fix conditional compilation guards for sanitizers 

### DIFF
--- a/test/log_fmt/fmt_logger.cpp
+++ b/test/log_fmt/fmt_logger.cpp
@@ -9,7 +9,6 @@
 
 #include <atomic>
 #include <cstddef>
-#include <cstdlib>
 #include <iostream>
 #include <iterator>
 #include <string>
@@ -27,18 +26,20 @@ template <>
 inline auto logging::config<> =
     logging::fmt::config{std::back_inserter(buffer)};
 
-#ifndef SANITIZER_NEW_DEL
+#ifdef __clang__
+#define USING_SANITIZER                                                        \
+    (__has_feature(address_sanitizer) or __has_feature(thread_sanitizer))
+#else
+#define USING_SANITIZER (__SANITIZE_ADDRESS__ or __SANITIZE_THREAD__)
+#endif
+
+#if not USING_SANITIZER
 void *operator new(std::size_t count) {
     allocation_happened.store(true);
     return malloc(count);
 }
 
 void operator delete(void *ptr) noexcept { return free(ptr); }
-
-// Clang (libc++) requires a previous prototype declaration for sized delete
-#ifdef __clang__
-void operator delete(void *, std::size_t) noexcept;
-#endif
 void operator delete(void *ptr, std::size_t) noexcept { return free(ptr); }
 #endif
 


### PR DESCRIPTION
Problem:
- Conditional compilation guards for detecting sanitizers have changed upstream.

Solution:
- Replace the old guards.