### PR TITLE
:construction_worker: Protect against boost_mp11 coming from boost

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -12,7 +12,7 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
-  USER_CMAKE_VERSION: 3.25
+  USER_CMAKE_VERSION: 3.27
 
 jobs:
   usage_test:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(
 include(cmake/debug_flow.cmake)
 include(cmake/string_catalog.cmake)
 
-add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
+add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)
 fmt_recipe(12.1.0)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#536bdd7")
 add_versioned_package("gh:intel/cpp-std-extensions#c932eba")

--- a/usage_test/CMakeLists.txt
+++ b/usage_test/CMakeLists.txt
@@ -7,8 +7,10 @@ message(STATUS "Actual cmake version: ${CMAKE_VERSION}")
 project(cib_usage)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/get_cpm.cmake)
-cpmaddpackage(NAME compile-time-init-build SOURCE_DIR
-              "${CMAKE_CURRENT_LIST_DIR}/.." GIT_TAG HEAD)
+cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")
+
+add_versioned_package(NAME compile-time-init-build SOURCE_DIR
+                      "${CMAKE_CURRENT_LIST_DIR}/.." GIT_TAG HEAD)
 
 function(add_app NAME FILE LIB)
     add_executable(${NAME} ${FILE})


### PR DESCRIPTION
Problem:
- When `boost` is already fetched as a dependency and the `boost_mp11` target exists, fetching `boost_mp11` fails.

Solution:
- Allow `boost_mp11` target to exist.