### PR TITLE
:sparkles: Add policy to interrupt control for dealing with unknowns

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -5,6 +5,7 @@
 #include <stdx/bitset.hpp>
 #include <stdx/compiler.hpp>
 #include <stdx/concepts.hpp>
+#include <stdx/static_assert.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
@@ -211,7 +212,52 @@ struct no_propagate_t {
 constexpr inline auto propagate = detail::propagate_t{};
 constexpr inline auto no_propagate = detail::no_propagate_t{};
 
-template <typename Root, detail::dynamic_hal_for<Root> Hal>
+struct error_unknowns {
+    template <typename T> [[noreturn]] constexpr static auto enable() {
+        STATIC_ASSERT(false, "Can't enable flow ({}) not in config!", T);
+        stdx::unreachable();
+    }
+    template <typename T> [[noreturn]] constexpr static auto disable() {
+        STATIC_ASSERT(false, "Can't disable flow ({}) not in config!", T);
+        stdx::unreachable();
+    }
+};
+struct ignore_unknowns {
+    template <typename> constexpr static auto enable() {}
+    template <typename> constexpr static auto disable() {}
+};
+
+namespace detail {
+struct unspecified_unknowns {};
+} // namespace detail
+
+template <typename...>
+constexpr auto injected_unknown_policy = detail::unspecified_unknowns{};
+
+namespace detail {
+template <typename T, typename DefaultPolicy, typename... DummyArgs>
+constexpr auto handle_unknown_enable() -> void {
+    auto &policy = injected_unknown_policy<DummyArgs...>;
+    if constexpr (requires { policy.template enable<T>(); }) {
+        policy.template enable<T>();
+    } else {
+        DefaultPolicy::template enable<T>;
+    }
+}
+
+template <typename T, typename DefaultPolicy, typename... DummyArgs>
+constexpr auto handle_unknown_disable() -> void {
+    auto &policy = injected_unknown_policy<DummyArgs...>;
+    if constexpr (requires { policy.template disable<T>(); }) {
+        policy.template disable<T>();
+    } else {
+        DefaultPolicy::template disable<T>;
+    }
+}
+} // namespace detail
+
+template <typename Root, detail::dynamic_hal_for<Root> Hal,
+          typename UnknownPolicy = error_unknowns>
 struct dynamic_controller {
   private:
     // keep track of which resources/flows/irqs have been manually
@@ -231,8 +277,10 @@ struct dynamic_controller {
             resource_enables.template set<T>();
         } else if constexpr (boost::mp11::mp_contains<flows_t, T>::value) {
             flow_enables.template set<T>();
-        } else {
+        } else if constexpr (boost::mp11::mp_contains<irq_names_t, T>::value) {
             named_enables.template set<T>();
+        } else {
+            detail::handle_unknown_enable<T, UnknownPolicy>();
         }
     }
 
@@ -241,8 +289,10 @@ struct dynamic_controller {
             resource_enables.template reset<T>();
         } else if constexpr (boost::mp11::mp_contains<flows_t, T>::value) {
             flow_enables.template reset<T>();
-        } else {
+        } else if constexpr (boost::mp11::mp_contains<irq_names_t, T>::value) {
             named_enables.template reset<T>();
+        } else {
+            detail::handle_unknown_disable<T, UnknownPolicy>();
         }
     }
 

--- a/test/interrupt/CMakeLists.txt
+++ b/test/interrupt/CMakeLists.txt
@@ -10,5 +10,8 @@ add_tests(
     sub_irq_impl
     policies
     LIBRARIES
+    warnings
     cib_interrupt
     groov)
+
+add_subdirectory(fail)

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -393,3 +393,14 @@ TEST_CASE("disabling all sub_irqs by resource does not disable parent with its "
     REQUIRE(v);
     CHECK(*v == EN0::mask<std::uint32_t>);
 }
+
+template <>
+constexpr auto interrupt::injected_unknown_policy<> =
+    interrupt::ignore_unknowns{};
+
+TEST_CASE("enabling/disabling unknown flows can be ignored",
+          "[dynamic controller]") {
+    using ignoring_dynamic_t =
+        interrupt::dynamic_controller<config_t, test_hal<G>>;
+    ignoring_dynamic_t::disable<void>();
+}

--- a/test/interrupt/fail/CMakeLists.txt
+++ b/test/interrupt/fail/CMakeLists.txt
@@ -1,0 +1,8 @@
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                 VERSION_GREATER_EQUAL 15)
+    add_compile_fail_test(nonexistent_flow.cpp LIBRARIES cib_interrupt)
+endif()
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                               VERSION_GREATER_EQUAL 13.2)
+    add_compile_fail_test(nonexistent_flow.cpp LIBRARIES cib_interrupt)
+endif()

--- a/test/interrupt/fail/nonexistent_flow.cpp
+++ b/test/interrupt/fail/nonexistent_flow.cpp
@@ -1,0 +1,35 @@
+#include <interrupt/config.hpp>
+#include <interrupt/dynamic_controller.hpp>
+
+// EXPECT: disable flow \(void\) not in config!
+
+using interrupt::operator""_irq;
+
+using config_t = interrupt::root<
+    interrupt::irq<"", 0_irq, 0, interrupt::no_field_t, interrupt::policies<>>>;
+
+struct test_hal {
+    static auto init() -> void {}
+    template <auto...> static auto irq_init() -> void {}
+
+    template <typename Field> CONSTEVAL static auto get_field() -> Field {
+        return Field{};
+    }
+    template <typename Field> CONSTEVAL static auto get_register() -> Field {
+        return Field{};
+    }
+
+    template <typename Register> using register_datatype_t = std::uint32_t;
+
+    template <typename Register, typename Field>
+    constexpr static register_datatype_t<Register> mask = {};
+
+    static auto write(auto, auto) -> void {}
+    static auto read(auto) -> bool { return true; }
+    static auto clear(auto) -> void {}
+};
+
+auto main() -> int {
+    using dynamic_t = interrupt::dynamic_controller<config_t, test_hal>;
+    dynamic_t::disable<void>();
+}


### PR DESCRIPTION
Problem:
- In tests, it is useful to be able to define small interrupt configs that only need to handle the interrupts, flows, resources, etc we're interested in testing. But the broader code under test might try to enable/disable other things unknown to the test, and we need to be able to ignore that.

Solution:
- Add a policy for dealing with unknowns.
- The default is a compile-time error, which is advisable for production code.