### PR TITLE
:art: Fix `inline` variable  qualifier

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -231,7 +231,7 @@ struct unspecified_unknowns {};
 } // namespace detail
 
 template <typename...>
-constexpr auto injected_unknown_policy = detail::unspecified_unknowns{};
+constexpr inline auto injected_unknown_policy = detail::unspecified_unknowns{};
 
 namespace detail {
 template <typename T, typename DefaultPolicy, typename... DummyArgs>

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -395,7 +395,7 @@ TEST_CASE("disabling all sub_irqs by resource does not disable parent with its "
 }
 
 template <>
-constexpr auto interrupt::injected_unknown_policy<> =
+constexpr inline auto interrupt::injected_unknown_policy<> =
     interrupt::ignore_unknowns{};
 
 TEST_CASE("enabling/disabling unknown flows can be ignored",


### PR DESCRIPTION
Problem:
- `constexpr` variables are not `inline` by default. Even though variable templates are, it's clearer to say `inline`.

Solution:
- Add `inline` to `interrupt::injected_unknown_policy`.