### PR TITLE
:bug: Fix interrupt config interaction with nexus

### DIFF
--- a/include/interrupt/concepts.hpp
+++ b/include/interrupt/concepts.hpp
@@ -75,7 +75,7 @@ concept sub_irq_interface = base_irq_interface<T>;
 template <typename T, typename Flow>
 concept nexus_for = requires {
     T::template service<Flow>();
-    { T::template service<Flow>.active } -> std::same_as<bool const &>;
+    { T::template service_v<Flow>.active } -> std::same_as<bool const &>;
 };
 
 namespace detail {

--- a/include/interrupt/config.hpp
+++ b/include/interrupt/config.hpp
@@ -96,7 +96,7 @@ template <typename... Flows> struct flow_config {
   private:
     template <typename Flow, typename... Nexi>
     constexpr static auto one_active() {
-        return (... or Nexi::template service<Flow>.active);
+        return (... or Nexi::template service_v<Flow>.active);
     }
 
     template <typename Flow, typename... Nexi>

--- a/test/interrupt/common.hpp
+++ b/test/interrupt/common.hpp
@@ -76,5 +76,9 @@ template <typename T> struct flow_t {
 };
 
 struct test_nexus {
-    template <typename T> constexpr static auto service = flow_t<T>{};
+    template <typename T> constexpr static auto service_v = flow_t<T>{};
+
+    template <typename T> constexpr static auto service() {
+        return service_v<T>();
+    }
 };

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -82,7 +82,12 @@ namespace {
 template <typename Flow> struct alt_flow : Flow {};
 
 struct alt_nexus {
-    template <typename T> constexpr static auto service = flow_t<alt_flow<T>>{};
+    template <typename T>
+    constexpr static auto service_v = flow_t<alt_flow<T>>{};
+
+    template <typename T> constexpr static auto service() {
+        return service_v<T>();
+    }
 };
 } // namespace
 


### PR DESCRIPTION
Problem:
- The check that determines if a flow connected to an irq is represented in the nexus uses an old nexus interface.

Solution:
- Update the check to use the current nexus interface.