### PR TITLE
:art: Invert interrupt enable propagation

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -428,7 +428,7 @@ struct dynamic_controller {
         });
     }
 
-    template <typename... Ts, typename PropagatePolicy = detail::propagate_t>
+    template <typename... Ts, typename PropagatePolicy = detail::no_propagate_t>
     static auto enable(PropagatePolicy = {}) -> void {
         conc::call_in_critical_section<mutex_t>([] {
             constexpr auto affected_irqs =
@@ -437,7 +437,7 @@ struct dynamic_controller {
             update(affected_irqs);
         });
     }
-    template <typename... Ts, typename PropagatePolicy = detail::propagate_t>
+    template <typename... Ts, typename PropagatePolicy = detail::no_propagate_t>
     static auto disable(PropagatePolicy = {}) -> void {
         conc::call_in_critical_section<mutex_t>([] {
             constexpr auto affected_irqs =

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -202,7 +202,6 @@ TEST_CASE("IRQ is enabled only when all its contingencies are enabled",
     using namespace groov::literals;
     reset_dynamic_state();
 
-    dynamic_t::enable<"shared">();
     dynamic_t::enable<"sub0">();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(not v);
@@ -214,7 +213,7 @@ TEST_CASE("IRQ is enabled only when all its contingencies are enabled",
     dynamic_t::enable<test_flow_0_t>();
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t>));
+    CHECK(*v == EN0::mask<std::uint32_t>);
 }
 
 TEST_CASE("disabling resource disables any IRQs that require it",
@@ -270,33 +269,33 @@ TEST_CASE("disabling one sub_irq by flow does not disable parent",
                  EN2::mask<std::uint32_t>));
 }
 
-TEST_CASE("disabling all sub_irqs by flow disables parent (default policy)",
+TEST_CASE("disabling all sub_irqs by flow disables parent (propagate)",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_flow_1_t>();
-    shared_sub_dynamic_t::disable<test_flow_2_t>();
+    shared_sub_dynamic_t::disable<test_flow_2_t>(interrupt::propagate);
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == 0);
 
-    shared_sub_dynamic_t::enable<test_flow_1_t>();
+    shared_sub_dynamic_t::enable<test_flow_1_t>(interrupt::propagate);
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t>));
 }
 
 TEST_CASE(
-    "disabling all sub_irqs by flow does not disable parent (no propagate)",
+    "disabling all sub_irqs by flow does not disable parent (default policy)",
     "[dynamic controller]") {
     using namespace groov::literals;
     reset_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_flow_1_t>();
-    shared_sub_dynamic_t::disable<test_flow_2_t>(interrupt::no_propagate);
+    shared_sub_dynamic_t::disable<test_flow_2_t>();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == EN0::mask<std::uint32_t>);
@@ -313,7 +312,7 @@ TEST_CASE("disabling one sub_irq by resource does not disable parent",
     reset_dynamic_state();
     shared_sub_dynamic_t::init();
 
-    shared_sub_dynamic_t::disable<test_resource_1>();
+    shared_sub_dynamic_t::disable<test_resource_1>(interrupt::propagate);
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == (EN0::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
@@ -326,26 +325,26 @@ TEST_CASE("disabling one sub_irq by resource does not disable parent",
 }
 
 TEST_CASE("disabling all sub_irqs by resource disables parent without its own "
-          "resources (default policy)",
+          "resources (propagate)",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_resource_1>();
-    shared_sub_dynamic_t::disable<test_resource_2>();
+    shared_sub_dynamic_t::disable<test_resource_2>(interrupt::propagate);
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == 0);
 
-    shared_sub_dynamic_t::enable<test_resource_1>();
+    shared_sub_dynamic_t::enable<test_resource_1>(interrupt::propagate);
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
     CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t>));
 }
 
 TEST_CASE("disabling all sub_irqs by resource does not disable parent without "
-          "its own resources (no propagate)",
+          "its own resources (default policy)",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_dynamic_state();


### PR DESCRIPTION
Problem:
- https://github.com/intel/compile-time-init-build/commit/1f804e0f9d1299387969f72d76c5b5fdece62df3 added a propagation policy so that when enabling/disabling sub IRQs it would propagate up to higher levels by default.
- This is fine if needed, but this is also commonly handled in hardware: interrupt status at a higher-level is formed in part by ANDing together sub-IRQ enables anyway. So propagation is not necessary in this case.

Solution:
- Invert the default: assume that well-functioning hardware will not require the extra writes to enable/disable higher level IRQs. The normal operation is that enable/disable acts only on the specific interrupts that need it.
- Propagation up the tree is still possible by passing `interrupt::propagate` to the enable/disable functions.