### PR TITLE
:art: Tweak `interrupt::manager` initialization

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -418,12 +418,17 @@ struct dynamic_controller {
     using hal_t = Hal;
     struct mutex_t;
 
-    template <bool Enable = true> static auto init() -> void {
-        using enable_irqs_t =
+    template <bool Enable = true, typename... AlreadyEnabled>
+    static auto init() -> void {
+        using potential_enable_irqs_t =
             boost::mp11::mp_copy_if<detail::descendants_t<Root>,
                                     detail::has_enable_field>;
+        using enable_irqs_t = boost::mp11::mp_set_difference<
+            potential_enable_irqs_t,
+            stdx::tuple<typename AlreadyEnabled::config_t...>>;
+
         conc::call_in_critical_section<mutex_t>([] {
-            reset_internal_state<Enable, enable_irqs_t>();
+            reset_internal_state<Enable, potential_enable_irqs_t>();
             update(enable_irqs_t{});
         });
     }

--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -51,6 +51,9 @@ using get_enable_field_t =
                                 enable_fields_t, Irq>;
 
 template <typename Root>
+using children_t = std::remove_cvref_t<decltype(Root::children)>;
+
+template <typename Root>
 using descendants_t = std::remove_cvref_t<decltype(Root::descendants)>;
 
 template <typename Root, template <typename...> typename F,
@@ -350,8 +353,22 @@ struct dynamic_controller {
         }
     }
 
+    constexpr static auto force_write = [](auto reg, auto &cached_value,
+                                           auto new_value) {
+        cached_value = new_value;
+        Hal::write(reg, cached_value);
+    };
+
+    constexpr static auto write_if_changed = [](auto reg, auto &cached_value,
+                                                auto new_value) {
+        if (new_value != std::exchange(cached_value, new_value)) {
+            Hal::write(reg, cached_value);
+        }
+    };
+
     // update cached values and write the changed registers
-    template <template <typename...> typename L, typename... Irqs>
+    template <auto WriteFn = write_if_changed,
+              template <typename...> typename L, typename... Irqs>
     static auto update(L<Irqs...>) -> void {
         constexpr auto by_registers =
             stdx::gather_by<detail::get_register_q<Hal>::template from_irq>(
@@ -371,12 +388,18 @@ struct dynamic_controller {
 
                     auto &cached_value = cached_enable<reg_t>;
                     auto new_value = (cached_value & ~mask) | value;
-                    if (new_value != std::exchange(cached_value, new_value)) {
-                        Hal::write(r, cached_value);
-                    }
+                    WriteFn(r, cached_value, new_value);
                 }
             },
             by_registers);
+    }
+
+    template <template <typename> typename F>
+    static auto refresh_enables() -> void {
+        using update_irqs_t =
+            boost::mp11::mp_copy_if<F<Root>, detail::has_enable_field>;
+        conc::call_in_critical_section<mutex_t>(
+            [] { update<force_write>(update_irqs_t{}); });
     }
 
     // reset: mark all resources, flows and named irqs enabled
@@ -432,6 +455,11 @@ struct dynamic_controller {
             update(enable_irqs_t{});
         });
     }
+
+    constexpr static auto refresh_top_level_enables =
+        refresh_enables<detail::children_t>;
+    constexpr static auto refresh_all_enables =
+        refresh_enables<detail::descendants_t>;
 
     template <typename... Ts, typename PropagatePolicy = detail::no_propagate_t>
     static auto enable(PropagatePolicy = {}) -> void {

--- a/include/interrupt/impl.hpp
+++ b/include/interrupt/impl.hpp
@@ -42,6 +42,7 @@ concept nexus_for_cfg = Config::template has_flows_for<Nexus>;
 
 template <typename Config, nexus_for_cfg<Config>... Nexi>
 struct element_irq_impl : Config {
+    using config_t = Config;
     constexpr static bool active = Config::template active<Nexi...>;
 
     template <typename Hal> static auto init() -> void {
@@ -66,6 +67,7 @@ struct element_irq_impl : Config {
 
 template <typename Config, sub_irq_interface... Subs>
 struct container_irq_impl : Config {
+    using config_t = Config;
     constexpr static bool active = (Subs::active or ...);
 
     template <typename Hal> static auto init() -> void {

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -34,6 +34,8 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
         if constexpr (DynamicEnableTopLevel) {
             dynamic_t::template init<true>();
         } else {
+            // if init_top_level also enabled the top level interrupts, we don't
+            // want to rewrite the enables
             dynamic_t::template init<true, Impls...>();
         }
     }

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -19,9 +19,11 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
 
     void init() const {
         hal_t::init();
-        (Impls::template init<hal_t>(), ...);
+        init_mcu_interrupts();
         dynamic_t::init();
     }
+
+    void init_mcu_interrupts() const { (Impls::template init<hal_t>(), ...); }
 
     constexpr static auto config() {
         return +stdx::ct_format<"interrupt::root<{}>">(

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -17,20 +17,33 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
     using hal_t = typename Dynamic::hal_t;
     using dynamic_t = Dynamic;
 
-    void init() const {
-        hal_t::init();
-        init_mcu_interrupts();
-        dynamic_t::init();
+    template <bool DynamicEnableTopLevel = false> static auto init() -> void {
+        init_mcu();
+        init_top_level();
+        init_dynamic<DynamicEnableTopLevel>();
     }
 
-    void init_mcu_interrupts() const { (Impls::template init<hal_t>(), ...); }
+    static auto init_mcu() -> void { hal_t::init(); }
+
+    static auto init_top_level() -> void {
+        (Impls::template init<hal_t>(), ...);
+    }
+
+    template <bool DynamicEnableTopLevel = false>
+    static auto init_dynamic() -> void {
+        if constexpr (DynamicEnableTopLevel) {
+            dynamic_t::template init<true>();
+        } else {
+            dynamic_t::template init<true, Impls...>();
+        }
+    }
 
     constexpr static auto config() {
         return +stdx::ct_format<"interrupt::root<{}>">(
             detail::config_string_for<Impls...>());
     }
 
-    template <irq_num_t Number> inline void run() const {
+    template <irq_num_t Number> static auto run() -> void {
         using M = stdx::type_map<stdx::vt_pair<Impls::irq_number, Impls>...>;
         using irq_t = stdx::value_lookup_t<M, Number>;
 
@@ -39,7 +52,7 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
         }
     }
 
-    [[nodiscard]] constexpr auto max_irq() const -> irq_num_t {
+    [[nodiscard]] constexpr static auto max_irq() -> irq_num_t {
         return static_cast<irq_num_t>(
             std::max({stdx::to_underlying(Impls::irq_number)...}));
     }

--- a/test/interrupt/common.hpp
+++ b/test/interrupt/common.hpp
@@ -13,23 +13,27 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstddef>
+#include <vector>
 
 using interrupt::operator""_irq;
 
 namespace {
 template <typename interrupt::irq_num_t> bool enabled{};
 template <typename interrupt::irq_num_t> std::size_t priority{};
-bool inited{};
+
+enum struct call : std::uint8_t { init, irq_init, write, read, clear };
+inline std::vector<call> calls{};
 
 using namespace stdx::literals;
 template <stdx::ct_string S> using en_field_t = stdx::cts_t<"enable."_cts + S>;
 template <stdx::ct_string S> using st_field_t = stdx::cts_t<"status."_cts + S>;
 
 template <typename Group> struct test_hal {
-    static auto init() -> void { inited = true; }
+    static auto init() -> void { calls.push_back(call::init); }
 
     template <bool Enable, interrupt::irq_num_t IrqNumber, std::size_t Priority>
     static auto irq_init() -> void {
+        calls.push_back(call::irq_init);
         enabled<IrqNumber> = Enable;
         priority<IrqNumber> = Priority;
     }
@@ -54,15 +58,18 @@ template <typename Group> struct test_hal {
 
     template <groov::pathlike P>
     static auto write(P p, auto raw_value) -> void {
+        calls.push_back(call::write);
         groov::sync_write(Group{}(p = raw_value));
     }
     template <groov::pathlike P> static auto read(P p) -> bool {
+        calls.push_back(call::read);
         auto const value = groov::test::get_value<Group>(groov::parent(p));
         REQUIRE(value);
         using Field = decltype(groov::resolve(Group{}, P{}));
         return Field::extract(*value);
     }
     template <groov::pathlike P> static auto clear(P p) -> void {
+        calls.push_back(call::clear);
         groov::sync_write(Group{}(p = groov::clear));
     }
 };

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -93,6 +93,14 @@ TEST_CASE("dynamic init enables all fields", "[dynamic controller]") {
                  EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
 }
 
+TEST_CASE("dynamic init minimizes writes", "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_dynamic_state();
+    calls.clear();
+    dynamic_t::init();
+    CHECK(std::count(calls.cbegin(), calls.cend(), call::write) == 1);
+}
+
 TEST_CASE("control IRQ by name", "[dynamic controller]") {
     using namespace groov::literals;
     reset_dynamic_state();
@@ -170,6 +178,20 @@ TEST_CASE("control IRQ by resource", "[dynamic controller]") {
     REQUIRE(v);
     CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
                  EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+}
+
+TEST_CASE("dynamic enable/disable minimizes writes", "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_dynamic_state();
+    dynamic_t::init();
+    calls.clear();
+
+    dynamic_t::disable<test_resource_0, test_resource_1, test_resource_2>();
+    CHECK(std::count(calls.cbegin(), calls.cend(), call::write) == 1);
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
 }
 
 TEST_CASE("type control is thread-safe", "[dynamic controller]") {

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -34,7 +34,6 @@ TEST_CASE("detect enable_field", "[dynamic controller]") {
 }
 
 namespace {
-using EN_TOP = groov::field<"top", std::uint8_t, 7, 7>;
 using EN0 = groov::field<"0", std::uint8_t, 0, 0>;
 using EN1 = groov::field<"1", std::uint8_t, 1, 1>;
 using EN2 = groov::field<"2", std::uint8_t, 2, 2>;
@@ -42,12 +41,17 @@ using EN2 = groov::field<"2", std::uint8_t, 2, 2>;
 using ST1 = groov::field<"1", std::uint8_t, 1, 1>;
 using ST2 = groov::field<"2", std::uint8_t, 2, 2>;
 
-using R_ENABLE = groov::reg<"enable", std::uint32_t, 1234, groov::w::replace,
-                            EN0, EN1, EN2, EN_TOP>;
+using R_ENABLE =
+    groov::reg<"enable", std::uint32_t, 1234, groov::w::replace, EN0, EN1, EN2>;
 using R_STATUS =
     groov::reg<"status", std::uint32_t, 5678, groov::w::replace, ST1, ST2>;
 
-using G = groov::group<"test", groov::test::bus<"test">, R_ENABLE, R_STATUS>;
+using EN_TOP = groov::field<"top", std::uint8_t, 7, 7>;
+using R_TOP_ENABLE =
+    groov::reg<"enable_top", std::uint32_t, 5678, groov::w::replace, EN_TOP>;
+
+using G = groov::group<"test", groov::test::bus<"test">, R_ENABLE, R_STATUS,
+                       R_TOP_ENABLE>;
 
 using interrupt::operator""_irq;
 
@@ -60,7 +64,8 @@ struct test_resource_1;
 struct test_resource_2;
 
 using config_t = interrupt::root<interrupt::shared_irq<
-    "shared", 0_irq, 0, en_field_t<"top">, interrupt::policies<>,
+    "shared", 0_irq, 0, stdx::cts_t<"enable_top.top"_cts>,
+    interrupt::policies<>,
     interrupt::sub_irq<
         "sub0", en_field_t<"0">, st_field_t<"0">,
         interrupt::policies<interrupt::required_resources<test_resource_0>>,
@@ -89,8 +94,49 @@ TEST_CASE("dynamic init enables all fields", "[dynamic controller]") {
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
+}
+
+TEST_CASE("dynamic init refresh all enables", "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_dynamic_state();
+    dynamic_t::init();
+
+    groov::test::set_value<G>("enable"_r, 0);
+    groov::test::set_value<G>("enable_top"_r, 0);
+    dynamic_t::refresh_all_enables();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    REQUIRE(v);
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
+}
+
+TEST_CASE("dynamic init refresh top level", "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_dynamic_state();
+    dynamic_t::init();
+
+    groov::test::set_value<G>("enable"_r, 0);
+    groov::test::set_value<G>("enable_top"_r, 0);
+    dynamic_t::refresh_top_level_enables();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    REQUIRE(v);
+    CHECK(*v == 0);
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
 }
 
 TEST_CASE("dynamic init minimizes writes", "[dynamic controller]") {
@@ -98,7 +144,7 @@ TEST_CASE("dynamic init minimizes writes", "[dynamic controller]") {
     reset_dynamic_state();
     calls.clear();
     dynamic_t::init();
-    CHECK(std::count(calls.cbegin(), calls.cend(), call::write) == 1);
+    CHECK(std::count(calls.cbegin(), calls.cend(), call::write) == 2);
 }
 
 TEST_CASE("control IRQ by name", "[dynamic controller]") {
@@ -109,14 +155,13 @@ TEST_CASE("control IRQ by name", "[dynamic controller]") {
     dynamic_t::disable<"sub1">();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
 
     dynamic_t::enable<"sub1">();
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 TEST_CASE("name control is thread-safe", "[dynamic controller]") {
@@ -131,7 +176,7 @@ TEST_CASE("name control is thread-safe", "[dynamic controller]") {
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == EN2::mask<std::uint32_t>);
 
     auto t3 = std::thread([&] { dynamic_t::enable<"sub0">(); });
     auto t4 = std::thread([&] { dynamic_t::enable<"sub1">(); });
@@ -140,8 +185,8 @@ TEST_CASE("name control is thread-safe", "[dynamic controller]") {
 
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 TEST_CASE("control IRQ by flow", "[dynamic controller]") {
@@ -152,14 +197,13 @@ TEST_CASE("control IRQ by flow", "[dynamic controller]") {
     dynamic_t::disable<test_flow_1_t>();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
 
     dynamic_t::enable<test_flow_1_t>();
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 TEST_CASE("control IRQ by resource", "[dynamic controller]") {
@@ -170,14 +214,13 @@ TEST_CASE("control IRQ by resource", "[dynamic controller]") {
     dynamic_t::disable<test_resource_0>();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
-                 EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
 
     dynamic_t::enable<test_resource_0>();
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 TEST_CASE("dynamic enable/disable minimizes writes", "[dynamic controller]") {
@@ -191,7 +234,7 @@ TEST_CASE("dynamic enable/disable minimizes writes", "[dynamic controller]") {
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == EN_TOP::mask<std::uint32_t>);
+    CHECK(*v == 0);
 }
 
 TEST_CASE("type control is thread-safe", "[dynamic controller]") {
@@ -206,7 +249,7 @@ TEST_CASE("type control is thread-safe", "[dynamic controller]") {
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN1::mask<std::uint32_t>));
+    CHECK(*v == EN1::mask<std::uint32_t>);
 
     auto t3 = std::thread([&] { dynamic_t::enable<test_resource_0>(); });
     auto t4 = std::thread([&] { dynamic_t::enable<test_resource_2>(); });
@@ -215,8 +258,8 @@ TEST_CASE("type control is thread-safe", "[dynamic controller]") {
 
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 TEST_CASE("IRQ is enabled only when all its contingencies are enabled",
@@ -247,13 +290,13 @@ TEST_CASE("disabling resource disables any IRQs that require it",
     dynamic_t::disable<test_resource_1>();
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t>));
+    CHECK(*v == EN0::mask<std::uint32_t>);
 
     dynamic_t::enable<test_resource_1>();
     v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
-    CHECK(*v == (EN_TOP::mask<std::uint32_t> | EN0::mask<std::uint32_t> |
-                 EN1::mask<std::uint32_t> | EN2::mask<std::uint32_t>));
+    CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
+                 EN2::mask<std::uint32_t>));
 }
 
 namespace {

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -41,7 +41,12 @@ using R_ENABLE = groov::reg<"enable", std::uint32_t, 1234, groov::w::replace,
 using R_STATUS = groov::reg<"status", std::uint32_t, 5678, groov::w::replace,
                             ST_33_0, ST_33_1, ST_33_2, ST_33_2_1, ST_33_2_2>;
 
-using G = groov::group<"test", groov::test::bus<"test">, R_ENABLE, R_STATUS>;
+using EN_38 = groov::field<"38", std::uint8_t, 0, 0>;
+using R_ENABLE_38 =
+    groov::reg<"enable38", std::uint32_t, 5678, groov::w::replace, EN_38>;
+
+using G = groov::group<"test", groov::test::bus<"test">, R_ENABLE, R_STATUS,
+                       R_ENABLE_38>;
 } // namespace
 
 TEST_CASE("manager can dump config", "[manager]") {
@@ -114,7 +119,7 @@ using config_shared = interrupt::root<
                            interrupt::policies<>, flow_33_1>,
         interrupt::sub_irq<"sub_33_2", en_field_t<"33_2">, st_field_t<"33_2">,
                            interrupt::policies<>, flow_33_2>>,
-    interrupt::irq<"irq_38", 38_irq, 39, interrupt::no_field_t,
+    interrupt::irq<"irq_38", 38_irq, 39, stdx::cts_t<"enable38.38"_cts>,
                    interrupt::policies<>, flow_38>>;
 } // namespace
 
@@ -147,6 +152,27 @@ TEST_CASE("init enables dynamic interrupts third", "[manager]") {
 
     REQUIRE(calls.size() >= 4);
     CHECK(calls[3] == call::write);
+}
+
+TEST_CASE("init does not re-enable top-level interrupts by default",
+          "[manager]") {
+    calls.clear();
+
+    auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
+    m.init();
+    REQUIRE(calls.size() == 4);
+    // only the 33 register was written
+}
+
+TEST_CASE("init can re-enable top-level dynamic interrupts", "[manager]") {
+    calls.clear();
+
+    auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
+    m.init<true>();
+    REQUIRE(calls.size() == 5);
+    CHECK(calls[3] == call::write);
+    CHECK(calls[4] == call::write);
+    // 33 and 38 registers were written
 }
 
 TEST_CASE("init enables mcu interrupts", "[manager]") {

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -118,18 +118,47 @@ using config_shared = interrupt::root<
                    interrupt::policies<>, flow_38>>;
 } // namespace
 
-TEST_CASE("init enables mcu interrupts", "[manager]") {
+TEST_CASE("init does top-level hal init first", "[manager]") {
+    calls.clear();
+
     auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
-    inited = false;
+    m.init();
+
+    REQUIRE(not calls.empty());
+    CHECK(calls[0] == call::init);
+}
+
+TEST_CASE("init enables mcu interrupts second", "[manager]") {
+    calls.clear();
+
+    auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
+    m.init();
+
+    REQUIRE(calls.size() >= 3);
+    CHECK(calls[1] == call::irq_init);
+    CHECK(calls[2] == call::irq_init);
+}
+
+TEST_CASE("init enables dynamic interrupts third", "[manager]") {
+    calls.clear();
+
+    auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
+    m.init();
+
+    REQUIRE(calls.size() >= 4);
+    CHECK(calls[3] == call::write);
+}
+
+TEST_CASE("init enables mcu interrupts", "[manager]") {
     enabled<33_irq> = false;
     priority<33_irq> = 0;
     enabled<38_irq> = false;
     priority<38_irq> = 0;
 
+    auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
     m.init();
-    CHECK(38_irq == m.max_irq());
 
-    CHECK(inited);
+    CHECK(38_irq == m.max_irq());
     CHECK(enabled<33_irq>);
     CHECK(priority<33_irq> == 34);
     CHECK(enabled<38_irq>);

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -160,8 +160,7 @@ TEST_CASE("init does not re-enable top-level interrupts by default",
 
     auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
     m.init();
-    REQUIRE(calls.size() == 4);
-    // only the 33 register was written
+    REQUIRE(calls.size() == 4); // only the 33 register was written
 }
 
 TEST_CASE("init can re-enable top-level dynamic interrupts", "[manager]") {
@@ -171,8 +170,7 @@ TEST_CASE("init can re-enable top-level dynamic interrupts", "[manager]") {
     m.init<true>();
     REQUIRE(calls.size() == 5);
     CHECK(calls[3] == call::write);
-    CHECK(calls[4] == call::write);
-    // 33 and 38 registers were written
+    CHECK(calls[4] == call::write); // 33 and 38 registers were written
 }
 
 TEST_CASE("init enables mcu interrupts", "[manager]") {


### PR DESCRIPTION
Problem:
- The distinction between "MCU-level" and "dynamic" initialization for interrupts is a useful one. There are cases where the MCU needs to be reinitialized.
- Top-level IRQs can be dynamically enabled and disabled, so they are represented in the dynamic controller. However, on `init`, they are likely already enabled through the prior call to `hal::irq_init`. Unless otherwise specified, the dynamic controller `init` will rewrite their enable fields.
- After power gating an MCU (but keeping memory alive), the state of the `dynamic_controller` may differ from the enable states of the IRQs.

Solution:
- Separate `init_mcu_interrupts` from `init`.
- On `init`, Allow `manager::init` to pass the list of already-enabled top-level IRQs to the dynamic controller so that it can filter them from writes.
- Allow the `dynamic_controller` to refresh (i.e. force a rewrite of) the enables based on its internal state: either just for the top-level IRQs, or for all.
