### PR TITLE
:art: Allow unnamed services in nexus

### DIFF
--- a/include/nexus/detail/nexus_details.hpp
+++ b/include/nexus/detail/nexus_details.hpp
@@ -17,8 +17,11 @@ namespace cib {
 template <typename T> using extract_service_tag = typename T::Service;
 
 namespace detail {
+template <typename T, stdx::ct_string Name>
+concept name_matches = T::name == Name;
+
 template <stdx::ct_string Name> struct matching_name {
-    template <typename T> using fn = std::bool_constant<T::name == Name>;
+    template <typename T> using fn = std::bool_constant<name_matches<T, Name>>;
 };
 
 template <typename Exports, typename T>


### PR DESCRIPTION
Problem:
- A nexus that mixes named services with unnamed ones is fine, providing we do not try to access the unnamed ones by name. However the `matching_name` metafunction is ill-formed for services that don't have names. In reality we would like to return `false` for those cases so that we can still look up named services in the presence of unnamed ones.

Solution:
- Change `matching_name` to use a concept that will evaluate to false when `T::name` doesn't exist.