### PR TITLE
:art: On dynamic interrupt init, enable only for active flows

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -345,9 +345,6 @@ struct dynamic_controller {
 
         auto const on_by_flows = [] {
             constexpr auto flows_bs = flows_t{typename Irq::all_flows_t{}};
-            if constexpr (flows_bs.none()) {
-                return true;
-            }
             return (flow_enables & flows_bs) != flows_t{};
         }();
 
@@ -408,11 +405,15 @@ struct dynamic_controller {
 
     // reset: mark all resources, flows and named irqs enabled
     // and clear all cached state
-    template <bool Enable, typename IrqList>
+    template <bool Enable, typename ActiveFlows, typename IrqList>
     static auto reset_internal_state() -> void {
         if constexpr (Enable) {
             resource_enables = resources_t{stdx::all_bits};
-            flow_enables = flows_t{stdx::all_bits};
+            if constexpr (std::is_void_v<ActiveFlows>) {
+                flow_enables = flows_t{stdx::all_bits};
+            } else {
+                flow_enables = flows_t{ActiveFlows{}};
+            }
             named_enables = irq_names_t{stdx::all_bits};
         } else {
             resource_enables.reset();
@@ -429,7 +430,12 @@ struct dynamic_controller {
                     decltype(detail::register_for<
                              typename I::enable_field_t>::template fn<Hal>());
                 if constexpr (not is_no_register_v<reg_t>) {
+                    // if we are enabling, the cached (register) value should
+                    // be all OFF, ready for updating
                     cached_enable<reg_t> = register_t<reg_t>{};
+
+                    // if we are NOT enabling, the cached (register) value
+                    // should be all ON, ready for updating
                     if constexpr (not Enable) {
                         auto value = register_t<reg_t>{};
                         auto &mask = cached_enable<reg_t>;
@@ -445,7 +451,8 @@ struct dynamic_controller {
     using hal_t = Hal;
     struct mutex_t;
 
-    template <bool Enable = true, typename... AlreadyEnabled>
+    template <bool Enable = true, typename ActiveFlows = void,
+              typename... AlreadyEnabled>
     static auto init() -> void {
         using potential_enable_irqs_t =
             boost::mp11::mp_copy_if<detail::descendants_t<Root>,
@@ -455,7 +462,8 @@ struct dynamic_controller {
             stdx::tuple<typename AlreadyEnabled::config_t...>>;
 
         conc::call_in_critical_section<mutex_t>([] {
-            reset_internal_state<Enable, potential_enable_irqs_t>();
+            reset_internal_state<Enable, ActiveFlows,
+                                 potential_enable_irqs_t>();
             update(enable_irqs_t{});
         });
     }

--- a/include/interrupt/impl.hpp
+++ b/include/interrupt/impl.hpp
@@ -4,6 +4,8 @@
 
 #include <conc/concurrency.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+
 namespace interrupt {
 
 namespace detail {
@@ -35,6 +37,11 @@ template <typename Field> struct clear_field {
 template <> struct clear_field<no_field_t> {
     template <typename...> consteval static auto with_hal() -> void {}
 };
+
+template <typename... Nexi> struct flow_is_active {
+    template <typename T>
+    using fn = std::bool_constant<(... or Nexi::template service_v<T>.active)>;
+};
 } // namespace detail
 
 template <typename Nexus, typename Config>
@@ -44,6 +51,10 @@ template <typename Config, nexus_for_cfg<Config>... Nexi>
 struct element_irq_impl : Config {
     using config_t = Config;
     constexpr static bool active = Config::template active<Nexi...>;
+
+    using active_flows_t =
+        boost::mp11::mp_copy_if_q<typename Config::all_flows_t,
+                                  detail::flow_is_active<Nexi...>>;
 
     template <typename Hal> static auto init() -> void {
         Config::template enable<active, Hal>();
@@ -69,6 +80,9 @@ template <typename Config, sub_irq_interface... Subs>
 struct container_irq_impl : Config {
     using config_t = Config;
     constexpr static bool active = (Subs::active or ...);
+
+    using active_flows_t = boost::mp11::mp_unique<
+        boost::mp11::mp_append<typename Subs::active_flows_t...>>;
 
     template <typename Hal> static auto init() -> void {
         Config::template enable<active, Hal>();

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -31,12 +31,15 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
 
     template <bool DynamicEnableTopLevel = false>
     static auto init_dynamic() -> void {
+        using active_flows_t =
+            boost::mp11::mp_append<typename Impls::active_flows_t...>;
+
         if constexpr (DynamicEnableTopLevel) {
-            dynamic_t::template init<true>();
+            dynamic_t::template init<true, active_flows_t>();
         } else {
             // if init_top_level also enabled the top level interrupts, we don't
             // want to rewrite the enables
-            dynamic_t::template init<true, Impls...>();
+            dynamic_t::template init<true, active_flows_t, Impls...>();
         }
     }
 

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -1,6 +1,5 @@
 #include "common.hpp"
 
-#include <flow/flow.hpp>
 #include <interrupt/config.hpp>
 #include <interrupt/dynamic_controller.hpp>
 #include <interrupt/fwd.hpp>
@@ -55,9 +54,9 @@ using G = groov::group<"test", groov::test::bus<"test">, R_ENABLE, R_STATUS,
 
 using interrupt::operator""_irq;
 
-struct test_flow_0_t : public flow::service<"0"> {};
-struct test_flow_1_t : public flow::service<"1"> {};
-struct test_flow_2_t : public flow::service<"2"> {};
+struct test_flow_0_t : std::true_type {};
+struct test_flow_1_t : std::true_type {};
+struct test_flow_2_t : std::true_type {};
 
 struct test_resource_0;
 struct test_resource_1;
@@ -96,6 +95,79 @@ TEST_CASE("dynamic init enables all fields", "[dynamic controller]") {
     REQUIRE(v);
     CHECK(*v == (EN0::mask<std::uint32_t> | EN1::mask<std::uint32_t> |
                  EN2::mask<std::uint32_t>));
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
+}
+
+namespace {
+using noflows_config_t = interrupt::root<interrupt::shared_irq<
+    "shared", 0_irq, 0, stdx::cts_t<"enable_top.top"_cts>,
+    interrupt::policies<>,
+    interrupt::sub_irq<
+        "sub0", en_field_t<"0">, st_field_t<"0">,
+        interrupt::policies<interrupt::required_resources<test_resource_0>>>,
+    interrupt::sub_irq<
+        "sub1", en_field_t<"1">, st_field_t<"1">,
+        interrupt::policies<interrupt::required_resources<test_resource_1>>>>>;
+
+using noflows_dynamic_t =
+    interrupt::dynamic_controller<noflows_config_t, test_hal<G>>;
+
+auto reset_noflows_dynamic_state() -> void {
+    noflows_dynamic_t::init<false>();
+    groov::test::reset_store<G>();
+}
+} // namespace
+
+TEST_CASE("dynamic init does not enable with no flows",
+          "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_noflows_dynamic_state();
+    noflows_dynamic_t::init();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    CHECK(not v);
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    CHECK(not v);
+}
+
+namespace {
+struct inactive_test_flow_1_t : std::false_type {};
+
+using inactiveflow_config_t = interrupt::root<interrupt::shared_irq<
+    "shared", 0_irq, 0, stdx::cts_t<"enable_top.top"_cts>,
+    interrupt::policies<>,
+    interrupt::sub_irq<
+        "sub0", en_field_t<"0">, st_field_t<"0">,
+        interrupt::policies<interrupt::required_resources<test_resource_0>>,
+        test_flow_0_t>,
+    interrupt::sub_irq<
+        "sub1", en_field_t<"1">, st_field_t<"1">,
+        interrupt::policies<interrupt::required_resources<test_resource_1>>,
+        inactive_test_flow_1_t>>>;
+
+using inactiveflow_dynamic_t =
+    interrupt::dynamic_controller<inactiveflow_config_t, test_hal<G>>;
+
+auto reset_inactiveflow_dynamic_state() -> void {
+    inactiveflow_dynamic_t::init<false>();
+    groov::test::reset_store<G>();
+}
+} // namespace
+
+TEST_CASE("dynamic init does not enable with inactive flow",
+          "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_inactiveflow_dynamic_state();
+    using active_flows_t = boost::mp11::mp_list<test_flow_0_t>;
+    inactiveflow_dynamic_t::init<true, active_flows_t>();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    REQUIRE(v);
+    CHECK(*v == EN0::mask<std::uint32_t>);
 
     v = groov::test::get_value<G>("enable_top"_r);
     REQUIRE(v);
@@ -314,12 +386,17 @@ using shared_sub_config_t = interrupt::root<interrupt::shared_sub_irq<
 
 using shared_sub_dynamic_t =
     interrupt::dynamic_controller<shared_sub_config_t, test_hal<G>>;
+
+auto reset_shared_dynamic_state() -> void {
+    shared_sub_dynamic_t::init<false>();
+    groov::test::reset_store<G>();
+}
 } // namespace
 
 TEST_CASE("disabling one sub_irq by flow does not disable parent",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_flow_1_t>();
@@ -337,7 +414,7 @@ TEST_CASE("disabling one sub_irq by flow does not disable parent",
 TEST_CASE("disabling all sub_irqs by flow disables parent (propagate)",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_flow_1_t>();
@@ -356,7 +433,7 @@ TEST_CASE(
     "disabling all sub_irqs by flow does not disable parent (default policy)",
     "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_flow_1_t>();
@@ -374,7 +451,7 @@ TEST_CASE(
 TEST_CASE("disabling one sub_irq by resource does not disable parent",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_resource_1>(interrupt::propagate);
@@ -393,7 +470,7 @@ TEST_CASE("disabling all sub_irqs by resource disables parent without its own "
           "resources (propagate)",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_resource_1>();
@@ -412,7 +489,7 @@ TEST_CASE("disabling all sub_irqs by resource does not disable parent without "
           "its own resources (default policy)",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic_state();
     shared_sub_dynamic_t::init();
 
     shared_sub_dynamic_t::disable<test_resource_1>();
@@ -442,13 +519,18 @@ using shared_sub_config2_t = interrupt::root<interrupt::shared_sub_irq<
 
 using shared_sub_dynamic2_t =
     interrupt::dynamic_controller<shared_sub_config2_t, test_hal<G>>;
+
+auto reset_shared_dynamic2_state() -> void {
+    shared_sub_dynamic2_t::init<false>();
+    groov::test::reset_store<G>();
+}
 } // namespace
 
 TEST_CASE("disabling all sub_irqs by resource does not disable parent with its "
           "own resources",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_dynamic_state();
+    reset_shared_dynamic2_state();
     shared_sub_dynamic2_t::init();
 
     shared_sub_dynamic2_t::disable<test_resource_1>();


### PR DESCRIPTION
Problem:
- On initialization of the dynamic interrupt controller, we write all the enable bits, even for interrupts with flows that are inactive.

Solution:
- Pass in the active flows in order to set only the proper enable bits.