### PR TITLE
:art: On dynamic interrupt init, enable only for active resources

### DIFF
--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -163,18 +163,29 @@ concept dynamic_hal_for =
             value);
     };
 
-template <typename Cfg, typename Rsrcs>
-[[nodiscard]] auto on_by_resource(Rsrcs const &resource_enables) -> bool {
-    constexpr auto resources_bs = Rsrcs{typename Cfg::resources_t{}};
-    if constexpr (resources_bs.none() and
-                  Cfg::resource_children_t::size() > 0) {
-        return stdx::any_of(
-            [&]<typename Child>(Child) {
-                return on_by_resource<Child>(resource_enables);
-            },
-            typename Cfg::resource_children_t{});
-    }
-    return (resource_enables & resources_bs) == resources_bs;
+template <typename Cfg, typename Rsrcs, typename Flows>
+[[nodiscard]] auto recursively_on(Rsrcs const &resource_enables,
+                                  Flows const &flow_enables) -> bool {
+    // An IRQ is on if:
+    // ANY of its flows are on and ALL of its resources are on
+    auto const on_per_se = [&] {
+        constexpr auto resources_bs = Rsrcs{typename Cfg::resources_t{}};
+        constexpr auto flows_bs = Flows{typename Cfg::flows_t{}};
+
+        auto const on_by_flows = (flow_enables & flows_bs).any();
+        auto const on_by_resources =
+            (resource_enables & resources_bs) == resources_bs;
+        return (on_by_flows and on_by_resources);
+    }();
+
+    // or ANY of its children are on (by the same reasoning)
+    auto const on_by_children = stdx::any_of(
+        [&]<typename Child>(Child) {
+            return recursively_on<Child>(resource_enables, flow_enables);
+        },
+        Cfg::children);
+
+    return on_per_se or on_by_children;
 }
 } // namespace detail
 
@@ -343,13 +354,8 @@ struct dynamic_controller {
             Hal::template mask<Reg, typename Irq::enable_field_t>;
         mask |= field_mask;
 
-        auto const on_by_flows = [] {
-            constexpr auto flows_bs = flows_t{typename Irq::all_flows_t{}};
-            return (flow_enables & flows_bs) != flows_t{};
-        }();
-
-        if (detail::on_by_resource<Irq>(resource_enables) and on_by_flows and
-            named_enables[stdx::type_identity_v<typename Irq::name_t>]) {
+        if (named_enables[stdx::type_identity_v<typename Irq::name_t>] and
+            detail::recursively_on<Irq>(resource_enables, flow_enables)) {
             new_value |= field_mask;
         }
     }
@@ -403,12 +409,17 @@ struct dynamic_controller {
             [] { update<force_write>(update_irqs_t{}); });
     }
 
-    // reset: mark all resources, flows and named irqs enabled
+    // reset: mark resources, flows and all named irqs enabled
     // and clear all cached state
-    template <bool Enable, typename ActiveFlows, typename IrqList>
+    template <bool Enable, typename ActiveFlows, typename ActiveResources,
+              typename IrqList>
     static auto reset_internal_state() -> void {
         if constexpr (Enable) {
-            resource_enables = resources_t{stdx::all_bits};
+            if constexpr (std::is_void_v<ActiveResources>) {
+                resource_enables = resources_t{stdx::all_bits};
+            } else {
+                resource_enables = resources_t{ActiveResources{}};
+            }
             if constexpr (std::is_void_v<ActiveFlows>) {
                 flow_enables = flows_t{stdx::all_bits};
             } else {
@@ -452,7 +463,7 @@ struct dynamic_controller {
     struct mutex_t;
 
     template <bool Enable = true, typename ActiveFlows = void,
-              typename... AlreadyEnabled>
+              typename ActiveResources = void, typename... AlreadyEnabled>
     static auto init() -> void {
         using potential_enable_irqs_t =
             boost::mp11::mp_copy_if<detail::descendants_t<Root>,
@@ -462,7 +473,7 @@ struct dynamic_controller {
             stdx::tuple<typename AlreadyEnabled::config_t...>>;
 
         conc::call_in_critical_section<mutex_t>([] {
-            reset_internal_state<Enable, ActiveFlows,
+            reset_internal_state<Enable, ActiveFlows, ActiveResources,
                                  potential_enable_irqs_t>();
             update(enable_irqs_t{});
         });

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -6,6 +6,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/type_traits.hpp>
+#include <stdx/udls.hpp>
 #include <stdx/utility.hpp>
 
 #include <algorithm>
@@ -31,15 +32,18 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
 
     template <bool DynamicEnableTopLevel = false>
     static auto init_dynamic() -> void {
+        using namespace stdx::literals;
         using active_flows_t =
             boost::mp11::mp_append<typename Impls::active_flows_t...>;
 
         if constexpr (DynamicEnableTopLevel) {
-            dynamic_t::template init<true, active_flows_t>();
+            dynamic_t::template init<"enable"_true, active_flows_t,
+                                     stdx::type_list<>>();
         } else {
             // if init_top_level also enabled the top level interrupts, we don't
             // want to rewrite the enables
-            dynamic_t::template init<true, active_flows_t, Impls...>();
+            dynamic_t::template init<"enable"_true, active_flows_t,
+                                     stdx::type_list<>, Impls...>();
         }
     }
 

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -135,35 +135,33 @@ TEST_CASE("dynamic init does not enable with no flows",
 }
 
 namespace {
-struct inactive_test_flow_1_t : std::false_type {};
-
-using inactiveflow_config_t = interrupt::root<interrupt::shared_irq<
+using inactive_config_t = interrupt::root<interrupt::shared_irq<
     "shared", 0_irq, 0, stdx::cts_t<"enable_top.top"_cts>,
     interrupt::policies<>,
     interrupt::sub_irq<
         "sub0", en_field_t<"0">, st_field_t<"0">,
         interrupt::policies<interrupt::required_resources<test_resource_0>>,
         test_flow_0_t>,
-    interrupt::sub_irq<
-        "sub1", en_field_t<"1">, st_field_t<"1">,
-        interrupt::policies<interrupt::required_resources<test_resource_1>>,
-        inactive_test_flow_1_t>>>;
+    interrupt::sub_irq<"sub1", en_field_t<"1">, st_field_t<"1">,
+                       interrupt::policies<interrupt::required_resources<
+                           test_resource_0, test_resource_1>>,
+                       test_flow_1_t, test_flow_2_t>>>;
 
-using inactiveflow_dynamic_t =
-    interrupt::dynamic_controller<inactiveflow_config_t, test_hal<G>>;
+using inactive_dynamic_t =
+    interrupt::dynamic_controller<inactive_config_t, test_hal<G>>;
 
-auto reset_inactiveflow_dynamic_state() -> void {
-    inactiveflow_dynamic_t::init<false>();
+auto reset_inactive_dynamic_state() -> void {
+    inactive_dynamic_t::init<false>();
     groov::test::reset_store<G>();
 }
 } // namespace
 
-TEST_CASE("dynamic init does not enable with inactive flow",
+TEST_CASE("dynamic init does not enable with all flows inactive",
           "[dynamic controller]") {
     using namespace groov::literals;
-    reset_inactiveflow_dynamic_state();
+    reset_inactive_dynamic_state();
     using active_flows_t = boost::mp11::mp_list<test_flow_0_t>;
-    inactiveflow_dynamic_t::init<true, active_flows_t>();
+    inactive_dynamic_t::init<true, active_flows_t>();
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
@@ -172,6 +170,38 @@ TEST_CASE("dynamic init does not enable with inactive flow",
     v = groov::test::get_value<G>("enable_top"_r);
     REQUIRE(v);
     CHECK(*v == EN_TOP::mask<std::uint32_t>);
+}
+
+TEST_CASE("dynamic init does not enable with any resource inactive",
+          "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_inactive_dynamic_state();
+    using active_flows_t = boost::mp11::mp_list<test_flow_0_t, test_flow_1_t>;
+    inactive_dynamic_t::init<true, active_flows_t,
+                             stdx::type_list<test_resource_0>>();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    REQUIRE(v);
+    CHECK(*v == EN0::mask<std::uint32_t>);
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    REQUIRE(v);
+    CHECK(*v == EN_TOP::mask<std::uint32_t>);
+}
+
+TEST_CASE("dynamic init does not enable with all children inactive",
+          "[dynamic controller]") {
+    using namespace groov::literals;
+    reset_inactive_dynamic_state();
+    using active_flows_t = boost::mp11::mp_list<test_flow_0_t>;
+    inactive_dynamic_t::init<true, active_flows_t,
+                             stdx::type_list<test_resource_1>>();
+
+    auto v = groov::test::get_value<G>("enable"_r);
+    CHECK(not v);
+
+    v = groov::test::get_value<G>("enable_top"_r);
+    CHECK(not v);
 }
 
 TEST_CASE("dynamic init refresh all enables", "[dynamic controller]") {


### PR DESCRIPTION
Problem:
 - On initialization of the dynamic interrupt controller, we assume all resources are active, enabling interrupts that should not be.

Solution:
- Pass in the active resources in order to set only the proper enable bits.