### PR TITLE
:bug: Fix calculation of lookup storage size

### DIFF
--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -6,6 +6,7 @@
 
 #include <stdx/bit.hpp>
 #include <stdx/bitset.hpp>
+#include <stdx/iterator.hpp>
 #include <stdx/utility.hpp>
 
 #include <algorithm>
@@ -417,7 +418,9 @@ struct pseudo_pext_lookup {
                 return s;
             }();
 
-            using lookup_idx_t = detail::uint_for_<storage.size()>;
+            constexpr auto storage_size =
+                stdx::ct_capacity_v<decltype(storage)>;
+            using lookup_idx_t = detail::uint_for_<storage_size>;
             constexpr auto lookup_table =
                 [&]() -> std::array<lookup_idx_t, lookup_table_size> {
                 std::array<lookup_idx_t, lookup_table_size> t{};


### PR DESCRIPTION
Problem:
- A local variable with automatic storage (even if `constexpr`) cannot be used to compute a type in this way.
- GCC 16 rightly complains.

Solution:
- Use `stdx::ct_capacity_v` to compute the storage size.

Note:
- Using `constexpr static` would also be an option, but only post-C++23.