### PR TITLE
:art: Adjust python code according to linting

### DIFF
--- a/test/log_binary/catalog/catalog_output_test.py
+++ b/test/log_binary/catalog/catalog_output_test.py
@@ -1,7 +1,9 @@
+import importlib.util
 import json
-import log_decode as decode
+import sys
 from pathlib import Path
 
+import log_decode as decode
 
 catalog_output = Path("./catalog_test.bin")
 json_filename = Path("./strings.json")
@@ -35,13 +37,15 @@ def test_files_exist():
     assert json_filename.is_file()
 
 
-def test_binary_logs():
-    try:
-        import clang.cindex
+def module_available(name):
+    return (name in sys.modules) or (importlib.util.find_spec(name) is not None)
 
+
+def test_binary_logs():
+    if module_available("clang"):
         expected_lines.add("TRACE [default] Scoped enum argument: VAL_E1")
         expected_lines.add("TRACE [default] Unscoped enum argument: VAL_E2")
-    except ModuleNotFoundError:
+    else:
         expected_lines.add(
             "TRACE [default] Scoped enum argument: static_cast<ns::E1>(19)"
         )

--- a/test/msg/gen_handler_data.py
+++ b/test/msg/gen_handler_data.py
@@ -1,6 +1,5 @@
 import random
 
-
 big_vals = [int(random.expovariate(10) * (1 << 28)) & 0xFFFFFFFF for i in range(0, 100)]
 med_vals = [int(random.expovariate(10) * (1 << 14)) & 0xFFFF for i in range(0, 50)]
 small_vals = [int(random.expovariate(10) * (1 << 6)) & 0xFF for i in range(0, 25)]
@@ -11,30 +10,22 @@ combos = [
 ]
 
 
-print(
-    """
+print("""
 template<typename T>
 struct test_project {
     constexpr static auto config = cib::config(
         cib::exports<T>, 
-        cib::extend<T>("""
-)
+        cib::extend<T>(""")
 for c in combos:
     print(f"            cb<{c[0]}, {c[1]}, {c[2]}>,")
-print(
-    """        )
+print("""        )
     );
 };
-"""
-)
+""")
 
-print(
-    """
-    auto msgs = std::array{"""
-)
+print("""
+    auto msgs = std::array{""")
 for c in combos:
     print(f"        m<{c[0]}, {c[1]}, {c[2]}>,")
-print(
-    """    };
-"""
-)
+print("""    };
+""")

--- a/tools/benchmark/gen_map_data.py
+++ b/tools/benchmark/gen_map_data.py
@@ -61,15 +61,13 @@ def main():
     args = parse_cmdline()
 
     with open(args.output, "w") as f:
-        f.write(
-            """#pragma once
+        f.write("""#pragma once
 
 #include <array>
 #include <cstdint>
 #include <utility>
 
-"""
-        )
+""")
         gen_table(
             args.size,
             args.type,

--- a/tools/gen_release_header.py
+++ b/tools/gen_release_header.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import sys
 import os
 
-
 version = os.popen("git describe --tags").read().strip()
 visited_includes = set()
 root = Path(sys.argv[1]).parent.parent

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -332,9 +332,8 @@ def assign_ids(messages, modules, stable_data, reserved_ids):
 
 
 def read_input(filenames: list[str], stable_data, reserved_ids):
-    line_re = re.compile(r"^.*unsigned (?:int|long) (catalog|module)<(.+?)>\(\)$")
-
     def read_file(filename):
+        line_re = re.compile(r"^.*unsigned (?:int|long) (catalog|module)<(.+?)>\(\)$")
         with open(filename, "r") as f:
             matching_lines = filter(
                 lambda p: p[1] is not None,
@@ -562,7 +561,7 @@ def serialize_messages(
             m = re.search(r"{:([^}]+)}", fmt_string)
             if m:
                 fmt_string = (
-                    f"{fmt_string[:m.start()]}%{m.group(1)}{fmt_string[m.end():]}"
+                    f"{fmt_string[: m.start()]}%{m.group(1)}{fmt_string[m.end() :]}"
                 )
             else:
                 fmt_string = re.sub(r"{}", arg_printf_spec(arg), fmt_string, count=1)
@@ -728,7 +727,7 @@ def main():
     scoped_enums = {}
     if args.cpp_output is not None:
         for m in messages:
-            for i, arg_type in enumerate(m.args):
+            for arg_type in m.args:
                 enc, enum, ut = arg_type_encoding(arg_type)
                 if "enum" in enc:
                     scoped_enums.update({enum: ut})

--- a/tools/mipi_messages.py
+++ b/tools/mipi_messages.py
@@ -1,8 +1,7 @@
-from ctypes import LittleEndianStructure, c_uint32, c_uint64, sizeof
-from functools import partial
 import itertools
 import struct
-
+from ctypes import LittleEndianStructure, c_uint32, c_uint64, sizeof
+from functools import partial
 
 encoding_reader = {
     "encode_u32": lambda reader: bytes(itertools.islice(reader, 4)),
@@ -67,7 +66,7 @@ def read_struct(struct, reader):
 
 
 class Short32:
-    def __init__(self, reader, messages, modules, db):
+    def __init__(self, reader, messages, *_):
         self.struct = read_struct(Short32Struct, reader)
         assert (
             self.struct.id in messages
@@ -79,7 +78,7 @@ class Short32:
 
 
 class Short64:
-    def __init__(self, reader, messages, modules, db):
+    def __init__(self, reader, messages, *_):
         self.struct = read_struct(Short64Struct, reader)
         assert (
             self.struct.id in messages
@@ -148,5 +147,5 @@ class Catalog:
 
     def __str__(self):
         return (
-            f'{self.severity} [{self.module}] {self.msg_spec["msg"].format(*self.args)}'
+            f"{self.severity} [{self.module}] {self.msg_spec['msg'].format(*self.args)}"
         )


### PR DESCRIPTION
Problem:
- Python linting reveals a better way to check for the existence of the clang module.

Solution:
- Use `importlib.util` to check for the clang module.