### PR TITLE
:art: Policize interrupt init & enable

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   configure:
     name: Configure Github Pages Publishing
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
     outputs:
       enable_publish: ${{ steps.check.outputs.isfork == 'NO' }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   build:
     needs: configure
     name: Build Documentation
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     steps:
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          test $(cmake --build build -v -t docs | grep -c ERROR) == 0
+          test "$(cmake --build build -v -t docs | grep -c ERROR)" == 0
           touch ./build/docs/.nojekyll
           ls -la ./build/docs
 
@@ -95,7 +95,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     steps:
       - name: Deploy to github pages
         id: deployment

--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -392,26 +392,11 @@ struct dynamic_controller {
 
     // reset: mark resources, flows and all named irqs enabled
     // and clear all cached state
-    template <bool Enable, typename ActiveFlows, typename ActiveResources,
-              typename IrqList>
+    template <typename ActiveResources, typename ActiveFlows, typename IrqList>
     static auto reset_internal_state() -> void {
-        if constexpr (Enable) {
-            if constexpr (std::is_void_v<ActiveResources>) {
-                resource_enables = resources_t{stdx::all_bits};
-            } else {
-                resource_enables = resources_t{ActiveResources{}};
-            }
-            if constexpr (std::is_void_v<ActiveFlows>) {
-                flow_enables = flows_t{stdx::all_bits};
-            } else {
-                flow_enables = flows_t{ActiveFlows{}};
-            }
-            named_enables = irq_names_t{stdx::all_bits};
-        } else {
-            resource_enables.reset();
-            flow_enables.reset();
-            named_enables.reset();
-        }
+        resource_enables = resources_t{ActiveResources{}};
+        flow_enables = flows_t{ActiveFlows{}};
+        named_enables = irq_names_t{stdx::all_bits};
 
         constexpr auto by_registers =
             stdx::gather_by<detail::get_register_q<Hal>::template from_irq>(
@@ -422,20 +407,7 @@ struct dynamic_controller {
                     decltype(detail::register_for<
                              typename I::enable_field_t>::template fn<Hal>());
                 if constexpr (not is_no_register_v<reg_t>) {
-                    // if we are enabling, the cached (register) value should
-                    // be all OFF, ready for updating
-                    cached_enable<reg_t> = register_t<reg_t>{};
-
-                    // if we are NOT enabling, the cached (register) value
-                    // should be all ON, ready for updating
-                    if constexpr (not Enable) {
-                        cached_enable<reg_t> = (mask_for<reg_t, I>() | ... |
-                                                mask_for<reg_t, Is>());
-
-                        auto value = register_t<reg_t>{};
-                        (compute_register<reg_t, I>(value), ...,
-                         compute_register<reg_t, Is>(value));
-                    }
+                    cached_enable<reg_t> = {};
                 }
             },
             by_registers);
@@ -445,8 +417,19 @@ struct dynamic_controller {
     using hal_t = Hal;
     struct mutex_t;
 
-    template <bool Enable = true, typename ActiveFlows = void,
-              typename ActiveResources = void, typename... AlreadyEnabled>
+    static auto reset() -> void {
+        resource_enables.reset();
+        flow_enables.reset();
+        named_enables.reset();
+
+        using enable_irqs_t =
+            boost::mp11::mp_copy_if<detail::descendants_t<Root>,
+                                    detail::has_enable_field>;
+        update<force_write>(enable_irqs_t{});
+    }
+
+    template <typename Policy = dynamic_init::default_policy,
+              typename... AlreadyEnabled>
     static auto init() -> void {
         using potential_enable_irqs_t =
             boost::mp11::mp_copy_if<detail::descendants_t<Root>,
@@ -455,8 +438,12 @@ struct dynamic_controller {
             potential_enable_irqs_t,
             stdx::tuple<typename AlreadyEnabled::config_t...>>;
 
+        using active_resources_t =
+            Policy::template active_resources_t<resources_t>;
+        using active_flows_t = Policy::template active_flows_t<flows_t>;
+
         conc::call_in_critical_section<mutex_t>([] {
-            reset_internal_state<Enable, ActiveFlows, ActiveResources,
+            reset_internal_state<active_resources_t, active_flows_t,
                                  potential_enable_irqs_t>();
             update(enable_irqs_t{});
         });

--- a/include/interrupt/dynamic_controller.hpp
+++ b/include/interrupt/dynamic_controller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <interrupt/concepts.hpp>
+#include <interrupt/policies.hpp>
 
 #include <stdx/bitset.hpp>
 #include <stdx/concepts.hpp>
@@ -162,31 +163,6 @@ concept dynamic_hal_for =
                 template fn<Hal>(),
             value);
     };
-
-template <typename Cfg, typename Rsrcs, typename Flows>
-[[nodiscard]] auto recursively_on(Rsrcs const &resource_enables,
-                                  Flows const &flow_enables) -> bool {
-    // An IRQ is on if:
-    // ANY of its flows are on and ALL of its resources are on
-    auto const on_per_se = [&] {
-        constexpr auto resources_bs = Rsrcs{typename Cfg::resources_t{}};
-        constexpr auto flows_bs = Flows{typename Cfg::flows_t{}};
-
-        auto const on_by_flows = (flow_enables & flows_bs).any();
-        auto const on_by_resources =
-            (resource_enables & resources_bs) == resources_bs;
-        return (on_by_flows and on_by_resources);
-    }();
-
-    // or ANY of its children are on (by the same reasoning)
-    auto const on_by_children = stdx::any_of(
-        [&]<typename Child>(Child) {
-            return recursively_on<Child>(resource_enables, flow_enables);
-        },
-        Cfg::children);
-
-    return on_per_se or on_by_children;
-}
 } // namespace detail
 
 // Whether to propagate resource/flow enables & disables
@@ -272,7 +248,8 @@ using select_propagate_policy_t =
     select_policy_t<Default, is_propagate_policy, Ps...>;
 } // namespace detail
 
-template <typename Root, detail::dynamic_hal_for<Root> Hal>
+template <typename Root, detail::dynamic_hal_for<Root> Hal,
+          typename EnablePolicy = dynamic_enable_policy>
 struct dynamic_controller {
   private:
     // keep track of which resources/flows/irqs have been manually
@@ -347,16 +324,18 @@ struct dynamic_controller {
         return affected_irqs_t{};
     }
 
-    // compute changing value/mask for register
-    template <typename Reg, typename Irq, typename T>
-    static auto compute_register(T &new_value, T &mask) -> void {
-        constexpr auto field_mask =
-            Hal::template mask<Reg, typename Irq::enable_field_t>;
-        mask |= field_mask;
+    // register mask for irq
+    template <typename Reg, typename Irq>
+    consteval static auto mask_for() -> register_t<Reg> {
+        return Hal::template mask<Reg, typename Irq::enable_field_t>;
+    }
 
-        if (named_enables[stdx::type_identity_v<typename Irq::name_t>] and
-            detail::recursively_on<Irq>(resource_enables, flow_enables)) {
-            new_value |= field_mask;
+    // compute value for register
+    template <typename Reg, typename Irq, typename T>
+    static auto compute_register(T &new_value) -> void {
+        if (EnablePolicy::template is_on<Irq>(named_enables, resource_enables,
+                                              flow_enables)) {
+            new_value |= mask_for<Reg, Irq>();
         }
     }
 
@@ -388,10 +367,12 @@ struct dynamic_controller {
                 if constexpr (not is_no_register_v<decltype(r)>) {
 
                     using reg_t = decltype(r);
-                    auto mask = register_t<reg_t>{};
+                    constexpr auto mask =
+                        (mask_for<reg_t, I>() | ... | mask_for<reg_t, Is>());
+
                     auto value = register_t<reg_t>{};
-                    (compute_register<reg_t, I>(value, mask), ...,
-                     compute_register<reg_t, Is>(value, mask));
+                    (compute_register<reg_t, I>(value), ...,
+                     compute_register<reg_t, Is>(value));
 
                     auto &cached_value = cached_enable<reg_t>;
                     auto new_value = (cached_value & ~mask) | value;
@@ -448,10 +429,12 @@ struct dynamic_controller {
                     // if we are NOT enabling, the cached (register) value
                     // should be all ON, ready for updating
                     if constexpr (not Enable) {
+                        cached_enable<reg_t> = (mask_for<reg_t, I>() | ... |
+                                                mask_for<reg_t, Is>());
+
                         auto value = register_t<reg_t>{};
-                        auto &mask = cached_enable<reg_t>;
-                        (compute_register<reg_t, I>(value, mask), ...,
-                         compute_register<reg_t, Is>(value, mask));
+                        (compute_register<reg_t, I>(value), ...,
+                         compute_register<reg_t, Is>(value));
                     }
                 }
             },

--- a/include/interrupt/manager.hpp
+++ b/include/interrupt/manager.hpp
@@ -2,6 +2,7 @@
 
 #include <interrupt/concepts.hpp>
 #include <interrupt/dynamic_controller.hpp>
+#include <interrupt/policies.hpp>
 
 #include <stdx/ct_format.hpp>
 #include <stdx/tuple.hpp>
@@ -9,19 +10,32 @@
 #include <stdx/udls.hpp>
 #include <stdx/utility.hpp>
 
+#include <boost/mp11/list.hpp>
+
 #include <algorithm>
 #include <type_traits>
 
 namespace interrupt {
 namespace detail {
+template <typename Flows>
+struct default_dyn_init_policy
+    : dynamic_init::no_resources_policy,
+      boost::mp11::mp_apply<dynamic_init::flows_policy, Flows>,
+      dynamic_init::all_irqs_policy {
+    constexpr static auto dynamic_enable_top_level = false;
+};
+
 template <typename Dynamic, irq_interface... Impls> struct manager {
     using hal_t = typename Dynamic::hal_t;
     using dynamic_t = Dynamic;
+    using default_init_policy_t = default_dyn_init_policy<
+        boost::mp11::mp_append<typename Impls::active_flows_t...>>;
 
-    template <bool DynamicEnableTopLevel = false> static auto init() -> void {
+    template <typename Policy = default_init_policy_t>
+    static auto init() -> void {
         init_mcu();
         init_top_level();
-        init_dynamic<DynamicEnableTopLevel>();
+        init_dynamic<Policy>();
     }
 
     static auto init_mcu() -> void { hal_t::init(); }
@@ -30,20 +44,15 @@ template <typename Dynamic, irq_interface... Impls> struct manager {
         (Impls::template init<hal_t>(), ...);
     }
 
-    template <bool DynamicEnableTopLevel = false>
+    template <typename Policy = default_dyn_init_policy<
+                  boost::mp11::mp_append<typename Impls::active_flows_t...>>>
     static auto init_dynamic() -> void {
-        using namespace stdx::literals;
-        using active_flows_t =
-            boost::mp11::mp_append<typename Impls::active_flows_t...>;
-
-        if constexpr (DynamicEnableTopLevel) {
-            dynamic_t::template init<"enable"_true, active_flows_t,
-                                     stdx::type_list<>>();
+        if constexpr (Policy::dynamic_enable_top_level) {
+            dynamic_t::template init<Policy>();
         } else {
-            // if init_top_level also enabled the top level interrupts, we don't
-            // want to rewrite the enables
-            dynamic_t::template init<"enable"_true, active_flows_t,
-                                     stdx::type_list<>, Impls...>();
+            // if we have statically enabled the top level interrupts, we don't
+            // want to rewrite those enables dynamically
+            dynamic_t::template init<Policy, Impls...>();
         }
     }
 

--- a/include/interrupt/policies.hpp
+++ b/include/interrupt/policies.hpp
@@ -2,8 +2,11 @@
 
 #include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
+
+#include <boost/mp11/list.hpp>
 
 namespace interrupt {
 template <typename T>
@@ -74,5 +77,43 @@ template <typename... Policies> struct policies {
 
     template <typename PolicyType, typename Default>
     using type = decltype(get<PolicyType, Default>());
+};
+
+struct dynamic_enable_policy {
+    template <typename Irq, typename Names, typename Rsrcs, typename Flows>
+    [[nodiscard]] constexpr static auto is_on(Names const &named_enables,
+                                              Rsrcs const &resource_enables,
+                                              Flows const &flow_enables)
+        -> bool {
+        // an IRQ is OFF if it is disabled by name
+        if (not named_enables[stdx::type_identity_v<typename Irq::name_t>]) {
+            return false;
+        }
+
+        // or if it has resources and any are OFF
+        constexpr auto has_resources =
+            not boost::mp11::mp_empty<typename Irq::resources_t>::value;
+        if constexpr (has_resources) {
+            constexpr auto resources_bs = Rsrcs{typename Irq::resources_t{}};
+            if ((resource_enables & resources_bs) != resources_bs) {
+                return false;
+            }
+        }
+
+        // otherwise, an IRQ is ON if:
+        // ANY of its flows are ON
+        constexpr auto flows_bs = Flows{typename Irq::flows_t{}};
+        auto const on_by_flows = (flow_enables & flows_bs).any();
+
+        // or ANY of its children are ON (by the same reasoning)
+        auto const on_by_children = stdx::any_of(
+            [&]<typename Child>(Child) {
+                return is_on<Child>(named_enables, resource_enables,
+                                    flow_enables);
+            },
+            Irq::children);
+
+        return on_by_flows or on_by_children;
+    }
 };
 } // namespace interrupt

--- a/include/interrupt/policies.hpp
+++ b/include/interrupt/policies.hpp
@@ -116,4 +116,39 @@ struct dynamic_enable_policy {
         return on_by_flows or on_by_children;
     }
 };
+
+namespace dynamic_init {
+struct all_resources_policy {
+    template <typename Resources>
+    using active_resources_t =
+        boost::mp11::mp_apply<stdx::type_list, Resources>;
+};
+struct all_flows_policy {
+    template <typename Flows>
+    using active_flows_t = boost::mp11::mp_apply<stdx::type_list, Flows>;
+};
+struct all_irqs_policy {
+    template <typename Irqs>
+    using active_irqs_t = boost::mp11::mp_apply<stdx::type_list, Irqs>;
+};
+
+template <typename... Resources> struct resources_policy {
+    template <typename>
+    using active_resources_t = stdx::type_list<Resources...>;
+};
+template <typename... Flows> struct flows_policy {
+    template <typename> using active_flows_t = stdx::type_list<Flows...>;
+};
+template <typename... Irqs> struct irqs_policy {
+    template <typename> using active_irqs_t = stdx::type_list<Irqs...>;
+};
+
+using no_resources_policy = resources_policy<>;
+using no_flows_policy = flows_policy<>;
+using no_irqs_policy = irqs_policy<>;
+
+struct default_policy : all_resources_policy,
+                        all_flows_policy,
+                        all_irqs_policy {};
+} // namespace dynamic_init
 } // namespace interrupt

--- a/test/interrupt/dynamic_controller.cpp
+++ b/test/interrupt/dynamic_controller.cpp
@@ -81,7 +81,7 @@ using config_t = interrupt::root<interrupt::shared_irq<
 using dynamic_t = interrupt::dynamic_controller<config_t, test_hal<G>>;
 
 auto reset_dynamic_state() -> void {
-    dynamic_t::init<false>();
+    dynamic_t::reset();
     groov::test::reset_store<G>();
 }
 } // namespace
@@ -116,7 +116,7 @@ using noflows_dynamic_t =
     interrupt::dynamic_controller<noflows_config_t, test_hal<G>>;
 
 auto reset_noflows_dynamic_state() -> void {
-    noflows_dynamic_t::init<false>();
+    noflows_dynamic_t::reset();
     groov::test::reset_store<G>();
 }
 } // namespace
@@ -151,17 +151,31 @@ using inactive_dynamic_t =
     interrupt::dynamic_controller<inactive_config_t, test_hal<G>>;
 
 auto reset_inactive_dynamic_state() -> void {
-    inactive_dynamic_t::init<false>();
+    inactive_dynamic_t::reset();
     groov::test::reset_store<G>();
 }
+
+struct only_flow0_policy_t
+    : interrupt::dynamic_init::all_resources_policy,
+      interrupt::dynamic_init::flows_policy<test_flow_0_t>,
+      interrupt::dynamic_init::all_irqs_policy {};
+
+struct only_resource0_policy_t
+    : interrupt::dynamic_init::resources_policy<test_resource_0>,
+      interrupt::dynamic_init::all_flows_policy,
+      interrupt::dynamic_init::all_irqs_policy {};
+
+struct flow0_resource1_policy_t
+    : interrupt::dynamic_init::resources_policy<test_resource_1>,
+      interrupt::dynamic_init::flows_policy<test_flow_0_t>,
+      interrupt::dynamic_init::all_irqs_policy {};
 } // namespace
 
 TEST_CASE("dynamic init does not enable with all flows inactive",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_inactive_dynamic_state();
-    using active_flows_t = boost::mp11::mp_list<test_flow_0_t>;
-    inactive_dynamic_t::init<true, active_flows_t>();
+    inactive_dynamic_t::init<only_flow0_policy_t>();
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
@@ -176,9 +190,7 @@ TEST_CASE("dynamic init does not enable with any resource inactive",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_inactive_dynamic_state();
-    using active_flows_t = boost::mp11::mp_list<test_flow_0_t, test_flow_1_t>;
-    inactive_dynamic_t::init<true, active_flows_t,
-                             stdx::type_list<test_resource_0>>();
+    inactive_dynamic_t::init<only_resource0_policy_t>();
 
     auto v = groov::test::get_value<G>("enable"_r);
     REQUIRE(v);
@@ -193,9 +205,7 @@ TEST_CASE("dynamic init does not enable with all children inactive",
           "[dynamic controller]") {
     using namespace groov::literals;
     reset_inactive_dynamic_state();
-    using active_flows_t = boost::mp11::mp_list<test_flow_0_t>;
-    inactive_dynamic_t::init<true, active_flows_t,
-                             stdx::type_list<test_resource_1>>();
+    inactive_dynamic_t::init<flow0_resource1_policy_t>();
 
     auto v = groov::test::get_value<G>("enable"_r);
     CHECK(not v);
@@ -371,11 +381,11 @@ TEST_CASE("IRQ is enabled only when all its contingencies are enabled",
 
     dynamic_t::enable<"sub0">();
     auto v = groov::test::get_value<G>("enable"_r);
-    REQUIRE(not v);
+    CHECK(not v);
 
     dynamic_t::enable<test_resource_0>();
     v = groov::test::get_value<G>("enable"_r);
-    REQUIRE(not v);
+    CHECK(not v);
 
     dynamic_t::enable<test_flow_0_t>();
     v = groov::test::get_value<G>("enable"_r);
@@ -418,7 +428,7 @@ using shared_sub_dynamic_t =
     interrupt::dynamic_controller<shared_sub_config_t, test_hal<G>>;
 
 auto reset_shared_dynamic_state() -> void {
-    shared_sub_dynamic_t::init<false>();
+    shared_sub_dynamic_t::reset();
     groov::test::reset_store<G>();
 }
 } // namespace
@@ -551,7 +561,7 @@ using shared_sub_dynamic2_t =
     interrupt::dynamic_controller<shared_sub_config2_t, test_hal<G>>;
 
 auto reset_shared_dynamic2_state() -> void {
-    shared_sub_dynamic2_t::init<false>();
+    shared_sub_dynamic2_t::reset();
     groov::test::reset_store<G>();
 }
 } // namespace

--- a/test/interrupt/manager.cpp
+++ b/test/interrupt/manager.cpp
@@ -163,11 +163,17 @@ TEST_CASE("init does not re-enable top-level interrupts by default",
     REQUIRE(calls.size() == 4); // only the 33 register was written
 }
 
+namespace {
+struct dyn_reinit_policy : interrupt::dynamic_init::default_policy {
+    constexpr static auto dynamic_enable_top_level = true;
+};
+} // namespace
+
 TEST_CASE("init can re-enable top-level dynamic interrupts", "[manager]") {
     calls.clear();
 
     auto m = interrupt::manager<config_shared, test_hal<G>, test_nexus>{};
-    m.init<true>();
+    m.init<dyn_reinit_policy>();
     REQUIRE(calls.size() == 5);
     CHECK(calls[3] == call::write);
     CHECK(calls[4] == call::write); // 33 and 38 registers were written

--- a/test/interrupt/policies.cpp
+++ b/test/interrupt/policies.cpp
@@ -1,5 +1,9 @@
 #include <interrupt/policies.hpp>
 
+#include <stdx/bitset.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/tuple.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("policies get", "[policies]") {
@@ -43,4 +47,185 @@ TEST_CASE("policy with required resources", "[policies]") {
     STATIC_CHECK(interrupt::policy<P>);
     STATIC_CHECK(
         std::is_same_v<typename P::resources, interrupt::resource_list<int>>);
+}
+
+namespace {
+using P = interrupt::dynamic_enable_policy;
+
+template <stdx::ct_string Irq> struct flow;
+template <stdx::ct_string Irq> struct resource;
+
+struct grandchild {
+    constexpr static auto name = stdx::ct_string{"gc"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{};
+    using resources_t = interrupt::resource_list<resource<name>>;
+    using flows_t = stdx::type_list<flow<name>>;
+};
+
+struct child_a {
+    constexpr static auto name = stdx::ct_string{"ca"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{grandchild{}};
+    using resources_t =
+        interrupt::resource_list<resource<"ca1">, resource<"ca2">>;
+    using flows_t = stdx::type_list<flow<name>>;
+};
+
+struct child_b {
+    constexpr static auto name = stdx::ct_string{"cb"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{};
+    using resources_t = interrupt::resource_list<resource<name>>;
+    using flows_t = stdx::type_list<flow<"cb1">, flow<"cb2">>;
+};
+
+struct parent {
+    constexpr static auto name = stdx::ct_string{"p"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{child_a{}, child_b{}};
+    using resources_t = interrupt::resource_list<resource<name>>;
+    using flows_t = stdx::type_list<flow<name>>;
+};
+
+using name_enables_t = stdx::type_bitset<parent::name_t, child_a::name_t,
+                                         child_b::name_t, grandchild::name_t>;
+using flow_enables_t = boost::mp11::mp_apply<
+    stdx::type_bitset,
+    boost::mp11::mp_append<parent::flows_t, child_a::flows_t, child_b::flows_t,
+                           grandchild::flows_t>>;
+
+using resource_enables_t = boost::mp11::mp_apply<
+    stdx::type_bitset,
+    boost::mp11::mp_append<parent::resources_t, child_a::resources_t,
+                           child_b::resources_t, grandchild::resources_t>>;
+} // namespace
+
+TEST_CASE("dynamic_enable_policy: is_on (all enables)", "[policies]") {
+    constexpr auto name_enables = name_enables_t{stdx::all_bits};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    constexpr auto flow_enables = flow_enables_t{stdx::all_bits};
+    STATIC_CHECK(P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+    STATIC_CHECK(P::is_on<child_a>(name_enables, rsrc_enables, flow_enables));
+    STATIC_CHECK(P::is_on<child_b>(name_enables, rsrc_enables, flow_enables));
+    STATIC_CHECK(
+        P::is_on<grandchild>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (turned off by name)", "[policies]") {
+    // everything enabled except parent name
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<child_a::name_t, child_b::name_t,
+                                       grandchild::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    constexpr auto flow_enables = flow_enables_t{stdx::all_bits};
+    STATIC_CHECK(
+        not P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (turned off by resource)",
+          "[policies]") {
+    // everything enabled except parent resource
+    constexpr auto name_enables = name_enables_t{stdx::all_bits};
+    constexpr auto rsrc_enables =
+        resource_enables_t{stdx::type_list<resource<"ca1">, resource<"ca2">,
+                                           resource<"cb">, resource<"gc">>{}};
+    constexpr auto flow_enables = flow_enables_t{stdx::all_bits};
+    STATIC_CHECK(
+        not P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (by flows)", "[policies]") {
+    // only parent name enabled; children off
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<parent::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    constexpr auto flow_enables = flow_enables_t{stdx::all_bits};
+    STATIC_CHECK(P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (by one flow)", "[policies]") {
+    // only child_b enabled
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<child_b::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    // only one of child_b's flows enabled
+    constexpr auto flow_enables =
+        flow_enables_t{stdx::type_list<flow<"cb1">>{}};
+    STATIC_CHECK(P::is_on<child_b>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (by children)", "[policies]") {
+    constexpr auto name_enables = name_enables_t{
+        stdx::type_list<parent::name_t, child_a::name_t, child_b::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    // parent flow not enabled, but children are
+    constexpr auto flow_enables =
+        flow_enables_t{stdx::type_list<flow<"ca">, flow<"cb1">>{}};
+    STATIC_CHECK(P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (by one child)", "[policies]") {
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<parent::name_t, child_a::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    // parent flow not enabled, but child_a's is
+    constexpr auto flow_enables = flow_enables_t{stdx::type_list<flow<"ca">>{}};
+    STATIC_CHECK(P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+TEST_CASE("dynamic_enable_policy: is_on (by grandchild)", "[policies]") {
+    constexpr auto name_enables = name_enables_t{
+        stdx::type_list<parent::name_t, child_a::name_t, grandchild::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{stdx::all_bits};
+    // grandchild on => child_a on => parent on
+    constexpr auto flow_enables = flow_enables_t{stdx::type_list<flow<"gc">>{}};
+    STATIC_CHECK(P::is_on<child_a>(name_enables, rsrc_enables, flow_enables));
+    STATIC_CHECK(P::is_on<parent>(name_enables, rsrc_enables, flow_enables));
+}
+
+namespace {
+struct alt_grandchild {
+    constexpr static auto name = stdx::ct_string{"gc"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{};
+    using resources_t = interrupt::resource_list<>;
+    using flows_t = stdx::type_list<flow<name>>;
+};
+} // namespace
+
+TEST_CASE("dynamic_enable_policy: is_on (no resources)", "[policies]") {
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<alt_grandchild::name_t>{}};
+    constexpr auto rsrc_enables = resource_enables_t{};
+    constexpr auto flow_enables = flow_enables_t{stdx::type_list<flow<"gc">>{}};
+    STATIC_CHECK(
+        P::is_on<alt_grandchild>(name_enables, rsrc_enables, flow_enables));
+}
+
+namespace {
+struct alt_parent {
+    constexpr static auto name = stdx::ct_string{"p"};
+    using name_t = stdx::cts_t<name>;
+
+    constexpr static auto children = stdx::tuple{child_a{}};
+    using resources_t = interrupt::resource_list<>;
+    using flows_t = stdx::type_list<>;
+};
+} // namespace
+
+TEST_CASE("dynamic_enable_policy: is_on (parent with no resources/flows)",
+          "[policies]") {
+    constexpr auto name_enables =
+        name_enables_t{stdx::type_list<alt_parent::name_t, child_a::name_t>{}};
+    constexpr auto rsrc_enables =
+        resource_enables_t{stdx::type_list<resource<"ca1">, resource<"ca2">>{}};
+    constexpr auto flow_enables = flow_enables_t{stdx::type_list<flow<"ca">>{}};
+    STATIC_CHECK(
+        P::is_on<alt_parent>(name_enables, rsrc_enables, flow_enables));
 }


### PR DESCRIPTION
Problem:
- The algorithm for dynamically deciding whether or not an IRQ is on is baked into the dynamic interrupt controller, and tested through it, instead of being a separate component.
- The dynamic initialization of interrupts is complicated, with flows, resources, and IRQ enables all used as positional arguments.

Solution:
- Separate the policy for deciding whether an IRQ is on dynamically, and fix the logic.
- Pass a single init policy which controls (filters) which flows/resources/IRQs are considered active at initialization.