### PR TITLE
:white_check_mark: :bug: Fix interrupt test thread safety

### DIFF
--- a/test/interrupt/common.hpp
+++ b/test/interrupt/common.hpp
@@ -13,6 +13,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstddef>
+#include <cstdint>
+#include <mutex>
 #include <vector>
 
 using interrupt::operator""_irq;
@@ -29,10 +31,16 @@ template <stdx::ct_string S> using en_field_t = stdx::cts_t<"enable."_cts + S>;
 template <stdx::ct_string S> using st_field_t = stdx::cts_t<"status."_cts + S>;
 
 template <typename Group> struct test_hal {
-    static auto init() -> void { calls.push_back(call::init); }
+    static inline auto mtx = std::mutex{};
+
+    static auto init() -> void {
+        std::lock_guard lk{mtx};
+        calls.push_back(call::init);
+    }
 
     template <bool Enable, interrupt::irq_num_t IrqNumber, std::size_t Priority>
     static auto irq_init() -> void {
+        std::lock_guard lk{mtx};
         calls.push_back(call::irq_init);
         enabled<IrqNumber> = Enable;
         priority<IrqNumber> = Priority;
@@ -58,10 +66,12 @@ template <typename Group> struct test_hal {
 
     template <groov::pathlike P>
     static auto write(P p, auto raw_value) -> void {
+        std::lock_guard lk{mtx};
         calls.push_back(call::write);
         groov::sync_write(Group{}(p = raw_value));
     }
     template <groov::pathlike P> static auto read(P p) -> bool {
+        std::lock_guard lk{mtx};
         calls.push_back(call::read);
         auto const value = groov::test::get_value<Group>(groov::parent(p));
         REQUIRE(value);
@@ -69,6 +79,7 @@ template <typename Group> struct test_hal {
         return Field::extract(*value);
     }
     template <groov::pathlike P> static auto clear(P p) -> void {
+        std::lock_guard lk{mtx};
         calls.push_back(call::clear);
         groov::sync_write(Group{}(p = groov::clear));
     }


### PR DESCRIPTION
Problem:
- Interrupt tests track calls to the `test_hal` with a vector, but don't mediate thread-safe access to it.

Solution:
- Use a lock for thread-safe access to the vector.