### PR TITLE
:zap: Calculate exports in type space

### DIFF
--- a/include/nexus/detail/components.hpp
+++ b/include/nexus/detail/components.hpp
@@ -4,6 +4,8 @@
 
 #include <stdx/tuple_algorithms.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+
 namespace cib::detail {
 template <typename... Components>
 struct components : public detail::config_item {
@@ -11,8 +13,9 @@ struct components : public detail::config_item {
         return stdx::tuple_cat(Components::config.extends_tuple()...);
     }
 
-    [[nodiscard]] constexpr auto exports_tuple() const {
-        return stdx::tuple_cat(Components::config.exports_tuple()...);
+    [[nodiscard]] constexpr static auto get_exports() -> boost::mp11::mp_append<
+        decltype(Components::config.get_exports())...> {
+        return {};
     }
 };
 } // namespace cib::detail

--- a/include/nexus/detail/config_details.hpp
+++ b/include/nexus/detail/config_details.hpp
@@ -5,6 +5,8 @@
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+
 #include <type_traits>
 
 namespace cib::detail {
@@ -24,10 +26,9 @@ template <typename... ConfigTs> struct config : public detail::config_item {
         });
     }
 
-    [[nodiscard]] constexpr auto exports_tuple() const {
-        return configs_tuple.apply([&](auto const &...configs_pack) {
-            return stdx::tuple_cat(configs_pack.exports_tuple()...);
-        });
+    [[nodiscard]] constexpr static auto get_exports()
+        -> boost::mp11::mp_append<decltype(ConfigTs::get_exports())...> {
+        return {};
     }
 };
 

--- a/include/nexus/detail/config_item.hpp
+++ b/include/nexus/detail/config_item.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdx/tuple.hpp>
+#include <stdx/type_traits.hpp>
 
 namespace cib::detail {
 struct config_item {
@@ -8,7 +9,7 @@ struct config_item {
         return {};
     }
 
-    [[nodiscard]] constexpr static auto exports_tuple() -> stdx::tuple<> {
+    [[nodiscard]] constexpr static auto get_exports() -> stdx::type_list<> {
         return {};
     }
 };

--- a/include/nexus/detail/constexpr_conditional.hpp
+++ b/include/nexus/detail/constexpr_conditional.hpp
@@ -7,6 +7,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
+#include <stdx/type_traits.hpp>
 
 namespace cib::detail {
 template <typename Cond, typename... Configs>
@@ -24,12 +25,11 @@ struct constexpr_conditional : config_item {
         }
     }
 
-    [[nodiscard]] constexpr auto exports_tuple() const {
-        if constexpr (Cond{}) {
-            return body.exports_tuple();
-        } else {
-            return stdx::tuple<>{};
-        }
+    [[nodiscard]] constexpr static auto get_exports() -> stdx::conditional_t<
+        static_cast<bool>(Cond{}),
+        decltype(detail::config<Configs...>::get_exports()),
+        stdx::type_list<>> {
+        return {};
     }
 };
 

--- a/include/nexus/detail/exports.hpp
+++ b/include/nexus/detail/exports.hpp
@@ -4,6 +4,7 @@
 #include <nexus/detail/extend.hpp>
 
 #include <stdx/tuple.hpp>
+#include <stdx/type_traits.hpp>
 
 namespace cib::detail {
 template <typename ServiceT, typename BuilderT> struct service_entry {
@@ -17,8 +18,8 @@ template <typename... Services> struct exports : public detail::config_item {
         return {type_extend<Services>{}...};
     }
 
-    [[nodiscard]] constexpr auto exports_tuple() const
-        -> stdx::tuple<Services...> {
+    [[nodiscard]] constexpr static auto get_exports()
+        -> stdx::type_list<Services...> {
         return {};
     }
 };

--- a/include/nexus/detail/nexus_details.hpp
+++ b/include/nexus/detail/nexus_details.hpp
@@ -27,7 +27,7 @@ template <stdx::ct_string Name> struct matching_name {
 template <typename Exports, typename T>
 constexpr auto locate_service_by_type() {
     using Idx = boost::mp11::mp_find<Exports, typename T::service_type>;
-    if constexpr (Idx::value == stdx::tuple_size_v<Exports>) {
+    if constexpr (Idx::value == boost::mp11::mp_size<Exports>::value) {
         if constexpr (requires { T::name; }) {
             STATIC_ASSERT(
                 false, "Trying to extend a service ({}) that is not exported",
@@ -45,7 +45,7 @@ constexpr auto locate_service_by_type() {
 template <typename Exports, typename T>
 constexpr auto locate_service_by_name() {
     using Idx = boost::mp11::mp_find_if_q<Exports, matching_name<T::name>>;
-    if constexpr (Idx::value == stdx::tuple_size_v<Exports>) {
+    if constexpr (Idx::value == boost::mp11::mp_size<Exports>::value) {
         STATIC_ASSERT(false,
                       "Trying to extend a service ({}) that is not exported",
                       T::name);
@@ -78,9 +78,9 @@ template <typename Exports> struct get_service {
 template <typename Config>
 constexpr static auto initialized_builders = transform<extract_service_tag>(
     []<typename Ext>(Ext extensions) {
-        using exports_tuple = decltype(Config::config.exports_tuple());
+        using exports_t = decltype(Config::config.get_exports());
         using svc = stdx::tuple_element_t<0, Ext>;
-        using service = detail::locate_service_t<exports_tuple, svc>;
+        using service = detail::locate_service_t<exports_t, svc>;
 
         constexpr auto initial_builder = builder_t<service>{};
 
@@ -94,7 +94,7 @@ constexpr static auto initialized_builders = transform<extract_service_tag>(
             built_service};
     },
     stdx::gather_by<detail::get_service<
-        decltype(Config::config.exports_tuple())>::template fn>(
+        decltype(Config::config.get_exports())>::template fn>(
         Config::config.extends_tuple()));
 
 template <typename Config, typename Tag> struct initialized {

--- a/include/nexus/detail/runtime_conditional.hpp
+++ b/include/nexus/detail/runtime_conditional.hpp
@@ -41,8 +41,9 @@ struct runtime_conditional : config_item {
             body.extends_tuple());
     }
 
-    [[nodiscard]] constexpr auto exports_tuple() const {
-        return body.exports_tuple();
+    [[nodiscard]] constexpr static auto get_exports()
+        -> decltype(detail::config<Configs...>::get_exports()) {
+        return {};
     }
 };
 

--- a/include/nexus/nexus.hpp
+++ b/include/nexus/nexus.hpp
@@ -32,10 +32,10 @@ template <typename Config> struct nexus {
     }
 
     template <stdx::ct_string Name> constexpr static auto service() {
-        using Exports = decltype(Config::config.exports_tuple());
+        using Exports = decltype(Config::config.get_exports());
         using Idx =
             boost::mp11::mp_find_if_q<Exports, detail::matching_name<Name>>;
-        if constexpr (Idx::value == stdx::tuple_size_v<Exports>) {
+        if constexpr (Idx::value == boost::mp11::mp_size<Exports>::value) {
             STATIC_ASSERT(
                 false, "Trying to invoke a service ({}) that is not exported",
                 Name);


### PR DESCRIPTION
Problem:
- CIB exports have no state and don't need to use `stdx::tuple_cat` to be calculated.

Solution:
- Use type list concatenation instead of `stdx::tuple_cat`.