### PR TITLE
⚡ perform flow graph dsl calculations in type space

### DIFF
--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -9,18 +9,14 @@
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
+
 #include <utility>
 
 namespace flow {
 template <typename Renderer, flow::dsl::subgraph... Fragments>
 class builder_for {
-    template <typename Tag>
-    friend constexpr auto tag_invoke(Tag, builder_for const &b) {
-        return b.fragments.apply([](auto const &...frags) {
-            return stdx::tuple_cat(Tag{}(frags)...);
-        });
-    }
-
   public:
     using interface_t = typename Renderer::interface_t;
     constexpr static auto name = Renderer::name;
@@ -39,9 +35,38 @@ class builder_for {
         return Renderer::template render<BuilderValue, Nexus>();
     }
 
+    using is_builder = void;
     stdx::tuple<Fragments...> fragments;
 };
 
 template <stdx::ct_string Name = "", typename LogPolicy = log_policy_t<Name>>
 using builder = builder_for<graph_builder<Name, LogPolicy>>;
 } // namespace flow
+
+namespace flow::dsl::detail {
+// Builders aggregate parts. Just expand all of the parts.
+template <typename R, typename... Fs>
+struct initials_of<flow::builder_for<R, Fs...>> {
+    using type = boost::mp11::mp_append<initials_of_t<Fs>...>;
+};
+
+template <typename R, typename... Fs>
+struct finals_of<flow::builder_for<R, Fs...>> {
+    using type = boost::mp11::mp_append<finals_of_t<Fs>...>;
+};
+
+template <typename R, typename... Fs>
+struct all_mentioned_of<flow::builder_for<R, Fs...>> {
+    using type = boost::mp11::mp_append<all_mentioned_of_t<Fs>...>;
+};
+
+template <typename R, typename... Fs>
+struct nodes_of<flow::builder_for<R, Fs...>> {
+    using type = boost::mp11::mp_append<nodes_of_t<Fs>...>;
+};
+
+template <typename R, typename... Fs>
+struct edges_of<flow::builder_for<R, Fs...>> {
+    using type = boost::mp11::mp_append<edges_of_t<Fs>...>;
+};
+} // namespace flow::dsl::detail

--- a/include/flow/dsl/par.hpp
+++ b/include/flow/dsl/par.hpp
@@ -3,7 +3,8 @@
 #include <flow/dsl/subgraph_identity.hpp>
 #include <flow/dsl/walk.hpp>
 
-#include <stdx/tuple_algorithms.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
 
 namespace flow::dsl {
 template <subgraph Lhs, subgraph Rhs,
@@ -13,44 +14,50 @@ struct par {
     Rhs rhs;
 
     using is_subgraph = void;
+    using is_composite = void;
 
     constexpr auto operator*() const {
         return par<Lhs, Rhs, subgraph_identity::VALUE>{Lhs{}, Rhs{}};
     }
-
-  private:
-    friend constexpr auto tag_invoke(get_initials_t, par const &p) {
-        return stdx::tuple_cat(get_initials(p.lhs), get_initials(p.rhs));
-    }
-
-    friend constexpr auto tag_invoke(get_finals_t, par const &p) {
-        return stdx::tuple_cat(get_finals(p.lhs), get_finals(p.rhs));
-    }
-
-    friend constexpr auto tag_invoke(get_nodes_t, par const &p) {
-        if constexpr (Identity == subgraph_identity::VALUE) {
-            auto all_nodes = stdx::to_unsorted_set(
-                stdx::tuple_cat(get_all_mentioned_nodes(p.lhs),
-                                get_all_mentioned_nodes(p.rhs)));
-
-            return stdx::transform([](auto const &n) { return *n; }, all_nodes);
-
-        } else {
-            return stdx::tuple_cat(get_nodes(p.lhs), get_nodes(p.rhs));
-        }
-    }
-
-    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, par const &p) {
-        return stdx::tuple_cat(get_all_mentioned_nodes(p.lhs),
-                               get_all_mentioned_nodes(p.rhs));
-    }
-
-    friend constexpr auto tag_invoke(get_edges_t, par const &p) {
-        return stdx::tuple_cat(get_edges(p.lhs), get_edges(p.rhs));
-    }
 };
 
 template <subgraph Lhs, subgraph Rhs> par(Lhs, Rhs) -> par<Lhs, Rhs>;
+
+namespace detail {
+template <typename L, typename R, subgraph_identity I>
+struct initials_of<par<L, R, I>> {
+    using type = boost::mp11::mp_append<initials_of_t<L>, initials_of_t<R>>;
+};
+
+template <typename L, typename R, subgraph_identity I>
+struct finals_of<par<L, R, I>> {
+    using type = boost::mp11::mp_append<finals_of_t<L>, finals_of_t<R>>;
+};
+
+template <typename L, typename R, subgraph_identity I>
+struct all_mentioned_of<par<L, R, I>> {
+    using type =
+        boost::mp11::mp_append<all_mentioned_of_t<L>, all_mentioned_of_t<R>>;
+};
+
+template <typename L, typename R>
+struct nodes_of<par<L, R, subgraph_identity::VALUE>> {
+    using type = boost::mp11::mp_transform<
+        star_t, boost::mp11::mp_unique<
+                    all_mentioned_of_t<par<L, R, subgraph_identity::VALUE>>>>;
+};
+
+template <typename L, typename R>
+struct nodes_of<par<L, R, subgraph_identity::REFERENCE>> {
+    using type = boost::mp11::mp_append<nodes_of_t<L>, nodes_of_t<R>>;
+};
+
+template <typename L, typename R, subgraph_identity I>
+struct edges_of<par<L, R, I>> {
+    using type = boost::mp11::mp_append<edges_of_t<L>, edges_of_t<R>>;
+};
+} // namespace detail
+
 } // namespace flow::dsl
 
 template <flow::dsl::subgraph Lhs, flow::dsl::subgraph Rhs>

--- a/include/flow/dsl/seq.hpp
+++ b/include/flow/dsl/seq.hpp
@@ -4,7 +4,8 @@
 #include <flow/dsl/walk.hpp>
 #include <nexus/detail/runtime_conditional.hpp>
 
-#include <stdx/tuple_algorithms.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
 
 namespace flow::dsl {
 template <subgraph Lhs, subgraph Rhs,
@@ -15,54 +16,52 @@ struct seq {
     Rhs rhs;
 
     using is_subgraph = void;
+    using is_composite = void;
 
     constexpr auto operator*() const {
         return seq<Lhs, Rhs, subgraph_identity::VALUE, Cond>{Lhs{}, Rhs{}};
     }
-
-  private:
-    friend constexpr auto tag_invoke(get_initials_t, seq const &s) {
-        return get_initials(s.lhs);
-    }
-
-    friend constexpr auto tag_invoke(get_finals_t, seq const &s) {
-        return get_finals(s.rhs);
-    }
-
-    friend constexpr auto tag_invoke(get_nodes_t, seq const &s) {
-        if constexpr (Identity == subgraph_identity::VALUE) {
-            auto all_nodes = stdx::to_unsorted_set(
-                stdx::tuple_cat(get_all_mentioned_nodes(s.lhs),
-                                get_all_mentioned_nodes(s.rhs)));
-
-            return stdx::transform([](auto const &n) { return *n; }, all_nodes);
-
-        } else {
-            return stdx::tuple_cat(get_nodes(s.lhs), get_nodes(s.rhs));
-        }
-    }
-
-    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, seq const &s) {
-        return stdx::tuple_cat(get_all_mentioned_nodes(s.lhs),
-                               get_all_mentioned_nodes(s.rhs));
-    }
-
-    friend constexpr auto tag_invoke(get_edges_t, seq const &s) {
-        auto is = get_initials(s.rhs);
-        auto fs = get_finals(s.lhs);
-
-        return stdx::tuple_cat(
-            get_edges(s.lhs), get_edges(s.rhs),
-            transform(
-                []<typename P>(P const &) {
-                    return edge<stdx::tuple_element_t<0, P>,
-                                stdx::tuple_element_t<1, P>, Cond>{};
-                },
-                cartesian_product_copy(fs, is)));
-    }
 };
 
 template <subgraph Lhs, subgraph Rhs> seq(Lhs, Rhs) -> seq<Lhs, Rhs>;
+
+namespace detail {
+template <typename L, typename R, subgraph_identity I, typename C>
+struct initials_of<seq<L, R, I, C>> {
+    using type = typename initials_of<L>::type;
+};
+
+template <typename L, typename R, subgraph_identity I, typename C>
+struct finals_of<seq<L, R, I, C>> {
+    using type = typename finals_of<R>::type;
+};
+
+template <typename L, typename R, subgraph_identity I, typename C>
+struct all_mentioned_of<seq<L, R, I, C>> {
+    using type =
+        boost::mp11::mp_append<all_mentioned_of_t<L>, all_mentioned_of_t<R>>;
+};
+
+template <typename L, typename R, typename C>
+struct nodes_of<seq<L, R, subgraph_identity::VALUE, C>> {
+    using type =
+        boost::mp11::mp_transform<star_t,
+                                  boost::mp11::mp_unique<all_mentioned_of_t<
+                                      seq<L, R, subgraph_identity::VALUE, C>>>>;
+};
+
+template <typename L, typename R, typename C>
+struct nodes_of<seq<L, R, subgraph_identity::REFERENCE, C>> {
+    using type = boost::mp11::mp_append<nodes_of_t<L>, nodes_of_t<R>>;
+};
+
+template <typename L, typename R, subgraph_identity I, typename C>
+struct edges_of<seq<L, R, I, C>> {
+    using cross = boost::mp11::mp_product_q<make_edge_q<C>, finals_of_t<L>,
+                                            initials_of_t<R>>;
+    using type = boost::mp11::mp_append<edges_of_t<L>, edges_of_t<R>, cross>;
+};
+} // namespace detail
 
 } // namespace flow::dsl
 

--- a/include/flow/dsl/walk.hpp
+++ b/include/flow/dsl/walk.hpp
@@ -3,9 +3,16 @@
 #include <flow/dsl/subgraph_identity.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
+
+#include <cstddef>
+#include <type_traits>
 #include <utility>
 
 namespace flow::dsl {
@@ -18,86 +25,123 @@ template <typename Source, typename Dest, typename Cond> struct edge {
     using cond_t = Cond;
 };
 
-constexpr inline class get_initials_t {
-    template <subgraph N>
-    friend constexpr auto tag_invoke(get_initials_t, N &&n) {
-        return stdx::make_tuple(std::forward<N>(n));
-    }
+template <stdx::ct_string Name> struct node_reference {
+    using is_subgraph = void;
+    constexpr static auto identity = subgraph_identity::REFERENCE;
+    using name_t = stdx::cts_t<Name>;
+};
 
-  public:
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<get_initials_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
-    }
-} get_initials{};
+namespace literals {
+template <stdx::ct_string S> [[nodiscard]] constexpr auto operator""_ref() {
+    return node_reference<S>{};
+}
+} // namespace literals
+} // namespace flow::dsl
 
-constexpr inline class get_finals_t {
-    template <subgraph N>
-    friend constexpr auto tag_invoke(get_finals_t, N &&n) {
-        return stdx::make_tuple(std::forward<N>(n));
-    }
+namespace flow::dsl::detail {
 
-  public:
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<get_finals_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
-    }
-} get_finals{};
+template <typename E> struct initials_of {
+    using type = boost::mp11::mp_list<E>;
+};
 
-constexpr inline class get_nodes_t {
-    template <subgraph N> friend constexpr auto tag_invoke(get_nodes_t, N &&n) {
-        if constexpr (std::remove_cvref_t<N>::identity ==
-                      subgraph_identity::REFERENCE) {
-            return stdx::tuple{};
-        } else {
-            return stdx::make_tuple(std::forward<N>(n));
-        }
-    }
+template <typename... T> using initials_of_t = typename initials_of<T...>::type;
 
-  public:
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<get_nodes_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
-    }
-} get_nodes{};
+template <typename E> struct finals_of {
+    using type = boost::mp11::mp_list<E>;
+};
 
-constexpr inline class get_all_mentioned_nodes_t {
-    template <subgraph N>
-    friend constexpr auto tag_invoke(get_all_mentioned_nodes_t, N &&n) {
-        return stdx::make_tuple(std::forward<N>(n));
-    }
+template <typename... T> using finals_of_t = typename finals_of<T...>::type;
 
-  public:
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<get_all_mentioned_nodes_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
-    }
-} get_all_mentioned_nodes{};
+template <typename E> struct all_mentioned_of {
+    using type = boost::mp11::mp_list<E>;
+};
 
-constexpr inline class get_edges_t {
-    friend constexpr auto tag_invoke(get_edges_t, subgraph auto const &) {
-        return stdx::tuple{};
-    }
+template <typename... T>
+using all_mentioned_of_t = typename all_mentioned_of<T...>::type;
 
-  public:
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<get_edges_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
+template <typename E> struct nodes_of {
+    using type =
+        std::conditional_t<E::identity == subgraph_identity::VALUE,
+                           boost::mp11::mp_list<E>, boost::mp11::mp_list<>>;
+};
+
+template <typename... T> using nodes_of_t = typename nodes_of<T...>::type;
+
+template <typename E> struct edges_of {
+    using type = boost::mp11::mp_list<>;
+};
+
+template <typename... T> using edges_of_t = typename edges_of<T...>::type;
+
+template <typename N>
+using star_t = std::remove_cvref_t<decltype(*std::declval<N>())>;
+
+template <typename Cond> struct make_edge_q {
+    template <typename A, typename B> using fn = edge<A, B, Cond>;
+};
+
+template <typename List>
+constexpr auto to_tuple_v = boost::mp11::mp_apply<stdx::tuple, List>{};
+
+template <typename T>
+concept builder_like = requires { typename T::is_builder; };
+
+template <typename T>
+concept composite_like = requires { typename T::is_composite; };
+
+template <typename N> constexpr auto collect_node_values(N const &);
+
+[[nodiscard]] constexpr auto collect_node_values(builder_like auto const &b) {
+    return b.fragments.apply([](auto const &...fs) {
+        return stdx::tuple_cat(collect_node_values(fs)...);
+    });
+}
+
+[[nodiscard]] constexpr auto collect_node_values(composite_like auto const &c) {
+    return stdx::tuple_cat(collect_node_values(c.lhs),
+                           collect_node_values(c.rhs));
+}
+
+template <typename Leaf>
+[[nodiscard]] constexpr auto collect_node_values(Leaf const &l) {
+    return stdx::make_tuple(l);
+}
+
+// Find the node in the existing leaf instantiations
+template <typename N, typename Leaves>
+[[nodiscard]] constexpr auto pick_node(Leaves const &leaves) {
+    using leaves_t = stdx::remove_cvref_t<Leaves>;
+    using leaf_instance_list =
+        boost::mp11::mp_apply<boost::mp11::mp_list,
+                              boost::mp11::mp_transform<star_t, leaves_t>>;
+    constexpr auto idx = boost::mp11::mp_find<leaf_instance_list, N>::value;
+    if constexpr (idx < stdx::tuple_size_v<leaves_t>) {
+        return *stdx::get<idx>(leaves);
+    } else {
+        return N{};
     }
-} get_edges{};
+}
+
+template <typename... Ns, typename Leaves>
+[[nodiscard]] constexpr auto pick_nodes(boost::mp11::mp_list<Ns...>,
+                                        Leaves const &leaves) {
+    return stdx::make_tuple(pick_node<Ns>(leaves)...);
+}
+} // namespace flow::dsl::detail
+
+namespace flow::dsl {
+template <typename T> [[nodiscard]] constexpr auto get_nodes(T const &t) {
+    return detail::pick_nodes(detail::nodes_of_t<stdx::remove_cvref_t<T>>{},
+                              detail::collect_node_values(t));
+}
+
+template <typename T>
+[[nodiscard]] constexpr auto get_all_mentioned_nodes(T const &) {
+    return detail::to_tuple_v<
+        detail::all_mentioned_of_t<stdx::remove_cvref_t<T>>>;
+}
+
+template <typename T> [[nodiscard]] constexpr auto get_edges(T const &) {
+    return detail::to_tuple_v<detail::edges_of_t<stdx::remove_cvref_t<T>>>;
+}
 } // namespace flow::dsl


### PR DESCRIPTION
Problem:
- Some projects that heavily use flow can take considerable time to compile
- get_edges_t CPO is effectively cubic growth in the front-end: O(N³)

Solution:
- Don't recursively tuple_cat at each of the expression (>>) levels of the graph
- We don't need the intermediate tuple values. Materialize the tuple as late as possible but doing the calculations in type space.
- Replace CPO mechanism with simpler calls