### PR TITLE
:art: Log: look up unknown compile-time formatted enum values

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-mypy_lint(FILES test/gen_str_catalog.py)
+mypy_lint(FILES cib/gen_str_catalog.py)
 
 add_unit_test(
     "gen_str_catalog_test" PYTEST FILES "test/gen_str_catalog_test.py"

--- a/python/cib/mipi_messages.py
+++ b/python/cib/mipi_messages.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 import struct
 from ctypes import LittleEndianStructure, c_uint32, c_uint64, sizeof
 from functools import partial
@@ -20,13 +21,29 @@ encoding_converter = {
 }
 
 
-def enum_converter(db, enum_type, underlying_type, seq):
-    convert = encoding_converter[underlying_type]
-    value = str(convert(seq))
+def enum_lookup(db, enum_type, value):
     if enum_type in db["enums"] and value in db["enums"][enum_type]:
         return db["enums"][enum_type][value]
     else:
         return f"static_cast<{enum_type}>({value})"
+
+
+def enum_converter(db, enum_type, underlying_type, seq):
+    convert = encoding_converter[underlying_type]
+    value = str(convert(seq))
+    return enum_lookup(db, enum_type, value)
+
+
+def convert_ct_enums(msg, db):
+    enum_re = re.compile(r"\(([a-zA-Z0-9_]+)\)([0-9]+)\b")
+    m = re.search(enum_re, msg)
+    while m:
+        enum_type = m.group(1)
+        value = m.group(2)
+        s = enum_lookup(db, enum_type, value)
+        msg = re.sub(enum_re, s, msg)
+        m = re.search(enum_re, msg)
+    return msg
 
 
 class HeaderStruct(LittleEndianStructure):
@@ -66,24 +83,26 @@ def read_struct(struct, reader):
 
 
 class Short32:
-    def __init__(self, reader, messages, *_):
+    def __init__(self, reader, messages, _, db):
         self.struct = read_struct(Short32Struct, reader)
         assert self.struct.id in messages, (
             f"Message ID {self.struct.id} not found in JSON"
         )
         self.msg_spec = messages[self.struct.id]
+        self.msg_spec["msg"] = convert_ct_enums(self.msg_spec["msg"], db)
 
     def __str__(self):
         return self.msg_spec["msg"]
 
 
 class Short64:
-    def __init__(self, reader, messages, *_):
+    def __init__(self, reader, messages, _, db):
         self.struct = read_struct(Short64Struct, reader)
         assert self.struct.id in messages, (
             f"Message ID {self.struct.id} not found in JSON"
         )
         self.msg_spec = messages[self.struct.id]
+        self.msg_spec["msg"] = convert_ct_enums(self.msg_spec["msg"], db)
 
     def __str__(self):
         return self.msg_spec["msg"]
@@ -140,6 +159,7 @@ class Catalog:
         self.id = Catalog.read_id(reader)
         assert self.id in messages, f"Message ID {self.id} not found in JSON"
         self.msg_spec = messages[self.id]
+        self.msg_spec["msg"] = convert_ct_enums(self.msg_spec["msg"], db)
 
         self.args = [
             Catalog.extract_arg(db, reader, arg) for arg in self.msg_spec["arg_types"]

--- a/test/log_binary/catalog/catalog1_lib.cpp
+++ b/test/log_binary/catalog/catalog1_lib.cpp
@@ -13,20 +13,6 @@ namespace {
 using log_env1 = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
-auto log_zero_args() -> void;
-auto log_one_ct_arg() -> void;
-auto log_one_32bit_rt_arg() -> void;
-auto log_one_64bit_rt_arg() -> void;
-auto log_one_formatted_rt_arg() -> void;
-auto log_with_default_module() -> void;
-auto log_with_non_default_module() -> void;
-auto log_with_fixed_module() -> void;
-auto log_with_fixed_string_id() -> void;
-auto log_with_fixed_unsigned_string_id() -> void;
-auto log_with_fixed_module_id() -> void;
-auto log_with_fixed_unsigned_module_id() -> void;
-auto log_with_tag() -> void;
-
 auto log_zero_args() -> void {
     cfg.logger.log_msg<log_env1>(stdx::ct_format<"Zero arguments">());
 }

--- a/test/log_binary/catalog/catalog2a_lib.cpp
+++ b/test/log_binary/catalog/catalog2a_lib.cpp
@@ -14,10 +14,6 @@ namespace {
 using log_env2a = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
-auto log_two_rt_args() -> void;
-auto log_ct_named_arg() -> void;
-auto log_rt_named_arg() -> void;
-
 auto log_two_rt_args() -> void {
     cfg.logger.log_msg<log_env2a>(
         stdx::ct_format<"Two runtime arguments: uint32_t {} and int64_t {}">(

--- a/test/log_binary/catalog/catalog2b_lib.cpp
+++ b/test/log_binary/catalog/catalog2b_lib.cpp
@@ -11,12 +11,6 @@ namespace {
 using log_env2b = stdx::make_env_t<logging::get_level, logging::level::TRACE>;
 } // namespace
 
-auto log_rt_scoped_enum_arg() -> void;
-auto log_rt_unscoped_enum_arg() -> void;
-auto log_rt_auto_scoped_enum_arg() -> void;
-auto log_rt_float_arg() -> void;
-auto log_rt_double_arg() -> void;
-
 auto log_rt_scoped_enum_arg() -> void {
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
@@ -27,6 +21,21 @@ auto log_rt_unscoped_enum_arg() -> void {
     using namespace ns;
     cfg.logger.log_msg<log_env2b>(
         stdx::ct_format<"Unscoped enum argument: {}">(VAL_E2));
+}
+
+enum struct extra_enum {};
+
+auto log_rt_unnamed_enum_value_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Runtime unnamed enum argument: {}">(extra_enum{1}));
+}
+
+auto log_ct_unnamed_enum_value_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Compile-time unnamed enum argument: {}">(
+            stdx::ct<extra_enum{1}>()));
 }
 
 namespace some_ns {

--- a/test/log_binary/catalog/catalog_app.cpp
+++ b/test/log_binary/catalog/catalog_app.cpp
@@ -18,9 +18,11 @@ extern auto log_two_rt_args() -> void;
 extern auto log_ct_named_arg() -> void;
 extern auto log_rt_named_arg() -> void;
 
-auto log_rt_scoped_enum_arg() -> void;
-auto log_rt_unscoped_enum_arg() -> void;
+extern auto log_rt_scoped_enum_arg() -> void;
+extern auto log_rt_unscoped_enum_arg() -> void;
 extern auto log_rt_auto_scoped_enum_arg() -> void;
+extern auto log_rt_unnamed_enum_value_arg() -> void;
+extern auto log_ct_unnamed_enum_value_arg() -> void;
 
 extern auto log_rt_float_arg() -> void;
 extern auto log_rt_double_arg() -> void;
@@ -161,6 +163,22 @@ TEST_CASE_PERSISTENT_FIXTURE(fixture, "catalog tests") {
         log_calls = 0;
         test_critical_section::count = 0;
         log_rt_unscoped_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime unnamed enum argument", "[catalog]") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_unnamed_enum_value_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log compile-time unnamed enum argument", "[catalog]") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_ct_unnamed_enum_value_arg();
         CHECK(test_critical_section::count == 2);
         CHECK(log_calls == 1);
     }

--- a/test/log_binary/catalog/catalog_output_test.py
+++ b/test/log_binary/catalog/catalog_output_test.py
@@ -29,6 +29,8 @@ expected_lines = {
     'TRACE [fixed_id6] Fixed module_id (6) and module ("fixed_id6") with runtime argument: 17',
     'TRACE [fixed_id7] Fixed unsigned module_id (7) and module ("fixed_id7") with runtime argument: 17',
     "TRACE [default] Auto-declared scoped enum argument: static_cast<some_ns::E>(17)",
+    "TRACE [default] Runtime unnamed enum argument: value",
+    "Compile-time unnamed enum argument: value",
 }
 
 


### PR DESCRIPTION
Problem:
- When an enumeration value is not named, but formatted at compile time, the resulting log string can potentially be post-processed by the decoder to recover the actual named enumeration value.

Solution:
- Post-process the log string during decoding and look up an enumeration values that are available.

For example, given the C++ code:

```cpp
enum struct E {}; // no values
LOG("Value is {}", stdx::ct<E{42}>);
```

The resulting log string is `"Value is (E)42"`.

Even though `E` has no values known to C++, if there is extra information in the JSON that the decoder can use:

```js
"enums": {
  "E": {
    "42": "the_answer"
  }
}
```

Then the log string can be post-processed during decoding to read `"Value is the_answer"`