### PR TITLE
:arrow_up: Update to latest dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ include(cmake/string_catalog.cmake)
 
 add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)
 fmt_recipe(12.1.0)
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#536bdd7")
-add_versioned_package("gh:intel/cpp-std-extensions#c932eba")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#f3fa596")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#b8a486a")
+add_versioned_package("gh:intel/cpp-std-extensions#2ce9eab")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#3e3c8aa")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 23)

--- a/include/flow/builder.hpp
+++ b/include/flow/builder.hpp
@@ -6,12 +6,11 @@
 
 #include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
-#include <stdx/tuple_algorithms.hpp>
-#include <stdx/type_traits.hpp>
 
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/list.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace flow {
@@ -25,7 +24,7 @@ class builder_for {
     [[nodiscard]] constexpr auto add(Ns &&...ns) {
         return fragments.apply([&](auto &...frags) {
             return builder_for<Renderer, Fragments...,
-                               stdx::remove_cvref_t<Ns>...>{
+                               std::remove_cvref_t<Ns>...>{
                 {frags..., std::forward<Ns>(ns)...}};
         });
     }

--- a/include/flow/dsl/walk.hpp
+++ b/include/flow/dsl/walk.hpp
@@ -17,7 +17,7 @@
 
 namespace flow::dsl {
 template <typename T>
-concept subgraph = requires { typename stdx::remove_cvref_t<T>::is_subgraph; };
+concept subgraph = requires { typename std::remove_cvref_t<T>::is_subgraph; };
 
 template <typename Source, typename Dest, typename Cond> struct edge {
     using source_t = Source;
@@ -116,7 +116,7 @@ template <typename Leaf>
 // Find the node in the existing leaf instantiations
 template <typename N, typename Leaves>
 [[nodiscard]] constexpr auto pick_node(Leaves const &leaves) {
-    using leaves_t = stdx::remove_cvref_t<Leaves>;
+    using leaves_t = std::remove_cvref_t<Leaves>;
     using leaf_instance_list = boost::mp11::mp_transform<star_t, leaves_t>;
     constexpr auto idx = boost::mp11::mp_find<leaf_instance_list, N>::value;
     if constexpr (idx < stdx::tuple_size_v<leaves_t>) {
@@ -135,17 +135,17 @@ template <typename... Ns, typename Leaves>
 
 namespace flow::dsl {
 template <typename T> [[nodiscard]] constexpr auto get_nodes(T const &t) {
-    return detail::pick_nodes(detail::nodes_of_t<stdx::remove_cvref_t<T>>{},
+    return detail::pick_nodes(detail::nodes_of_t<std::remove_cvref_t<T>>{},
                               detail::collect_node_values(t));
 }
 
 template <typename T>
 [[nodiscard]] constexpr auto get_all_mentioned_nodes(T const &) {
     return detail::to_tuple_v<
-        detail::all_mentioned_of_t<stdx::remove_cvref_t<T>>>;
+        detail::all_mentioned_of_t<std::remove_cvref_t<T>>>;
 }
 
 template <typename T> [[nodiscard]] constexpr auto get_edges(T const &) {
-    return detail::to_tuple_v<detail::edges_of_t<stdx::remove_cvref_t<T>>>;
+    return detail::to_tuple_v<detail::edges_of_t<std::remove_cvref_t<T>>>;
 }
 } // namespace flow::dsl

--- a/include/log_binary/catalog/arguments.hpp
+++ b/include/log_binary/catalog/arguments.hpp
@@ -65,7 +65,7 @@ template <float_packable T> struct encoding<T> {
 template <enum_packable T>
 struct encoding<T> : encoding<stdx::underlying_type_t<T>> {
     using encode_t = stdx::conditional_t<
-        stdx::is_scoped_enum_v<T>, encode_enum<T, stdx::underlying_type_t<T>>,
+        std::is_scoped_enum_v<T>, encode_enum<T, stdx::underlying_type_t<T>>,
         stdx::conditional_t<std::signed_integral<stdx::underlying_type_t<T>>,
                             detail::signed_encode_t<T>,
                             detail::unsigned_encode_t<T>>>;

--- a/test/interrupt/CMakeLists.txt
+++ b/test/interrupt/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_versioned_package("gh:intel/generic-register-operation-optimizer#d365927")
+add_versioned_package("gh:intel/generic-register-operation-optimizer#2e45cc2")
 
 add_tests(
     FILES

--- a/test/msg/CMakeLists.txt
+++ b/test/msg/CMakeLists.txt
@@ -13,11 +13,22 @@ add_tests(
     indexed_handler_uninit
     message
     relaxed_message
-    send
     LIBRARIES
     warnings
     cib_log_fmt
     cib_msg
     cib_nexus)
+
+if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
+   OR ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 19)
+    add_tests(
+        FILES
+        send
+        LIBRARIES
+        warnings
+        cib_log_fmt
+        cib_msg
+        cib_nexus)
+endif()
 
 add_subdirectory(fail)


### PR DESCRIPTION
Problem:
- CIB doesn't currently build on head of `stdx`.

Solution:
- Update dependencies; use standard versions of things that were removed from `stdx`.