### PR TITLE
:sparkles: Enable callback with move-only types

### DIFF
--- a/include/nexus/callback.hpp
+++ b/include/nexus/callback.hpp
@@ -35,7 +35,17 @@ template <typename Funcs = stdx::tuple<>, typename... ArgTypes> struct builder {
     constexpr static void run(ArgTypes... args) {
         constexpr auto b = BuilderValue::value;
         [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-            (invoke_with<Ts...>(b.funcs[stdx::index<Is>], args...), ...);
+            if constexpr ((... and std::is_copy_constructible_v<ArgTypes>)) {
+                (invoke_with<Ts...>(b.funcs[stdx::index<Is>], args...), ...);
+            } else {
+                static_assert(sizeof...(Is) <= 1,
+                              "Callback service has more than one callback "
+                              "requiring a move-only arg: would result in a "
+                              "potential use-after-move.");
+                (invoke_with<Ts...>(b.funcs[stdx::index<Is>],
+                                    std::move(args)...),
+                 ...);
+            }
         }(std::make_index_sequence<b.size()>{});
     }
 

--- a/test/nexus/CMakeLists.txt
+++ b/test/nexus/CMakeLists.txt
@@ -8,3 +8,5 @@ add_tests(
     LIBRARIES
     warnings
     cib_nexus)
+
+add_subdirectory(fail)

--- a/test/nexus/callback.cpp
+++ b/test/nexus/callback.cpp
@@ -1,8 +1,11 @@
+#include "special_members.hpp"
+
 #include <nexus/callback.hpp>
 #include <nexus/service.hpp>
 
 #include <stdx/tuple.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <type_traits>
@@ -203,4 +206,27 @@ TEST_CASE("callback with args with multiple extensions", "[callback]") {
                 CallbackWithArgsWithMultipleExtensions::service>(
             built_callback));
     }
+}
+
+template <typename T> struct CallbackWithMoveOnlyArg {
+    using service = callback::service<T>;
+
+    constexpr static auto value = []() {
+        auto const builder = cib::builder_t<service>{};
+        return builder.add([](T mo) {
+            is_callback_invoked<0> = true;
+            callback_args<0, int> = stdx::make_tuple(mo.value);
+        });
+    }();
+};
+
+TEMPLATE_TEST_CASE("callback handles move-only args", "[callback]", move_only,
+                   move_only &&) {
+    constexpr auto built_callback = build<CallbackWithMoveOnlyArg<TestType>>();
+
+    is_callback_invoked<0> = false;
+    built_callback(std::remove_cvref_t<TestType>{42});
+
+    REQUIRE(is_callback_invoked<0>);
+    CHECK(get<0>(callback_args<0, int>) == 42);
 }

--- a/test/nexus/fail/CMakeLists.txt
+++ b/test/nexus/fail/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_compile_fail_test(moveonly_multiple_callbacks.cpp LIBRARIES cib_nexus)

--- a/test/nexus/fail/moveonly_multiple_callbacks.cpp
+++ b/test/nexus/fail/moveonly_multiple_callbacks.cpp
@@ -1,0 +1,31 @@
+#include <nexus/callback.hpp>
+#include <nexus/service.hpp>
+
+// EXPECT: service has more than one callback requiring a move-only arg
+
+namespace {
+struct move_only {
+    constexpr move_only() = default;
+    constexpr move_only(move_only &&) = default;
+    constexpr auto operator=(move_only &&) noexcept -> move_only & = default;
+};
+
+template <typename BuilderValue, typename T = void>
+constexpr static auto build() {
+    return BuilderValue::value.template build<BuilderValue, T>();
+}
+
+struct CallbackWithRValueRefArg {
+    using service = callback::service<move_only>;
+
+    constexpr static auto value = []() {
+        auto const builder = cib::builder_t<service>{};
+        return builder.add([](move_only) {}).add([](move_only) {});
+    }();
+};
+} // namespace
+
+auto main() -> int {
+    constexpr auto built_callback = build<CallbackWithRValueRefArg>();
+    built_callback(move_only{});
+}

--- a/test/nexus/special_members.hpp
+++ b/test/nexus/special_members.hpp
@@ -2,7 +2,7 @@
 
 struct move_only {
     constexpr move_only() = default;
-    constexpr move_only(int i) : value{i} {}
+    constexpr explicit(true) move_only(int i) : value{i} {}
     constexpr move_only(move_only &&) = default;
     constexpr auto operator=(move_only &&) noexcept -> move_only & = default;
 


### PR DESCRIPTION
Problem:
- It's not possible to use the callback service with move-only types.

Solution:
- Make it possible: if the types passed in are not copy constructible, move them instead.
- If move is necessary, limit the callbacks to 1 to prevent use-after-move.