### PR TITLE
:art: Relax the custom log builder/writer interface

### DIFF
--- a/include/log_binary/catalog/encoder.hpp
+++ b/include/log_binary/catalog/encoder.hpp
@@ -68,10 +68,22 @@ struct to_message_t {
     template <typename... Args>
     using fn = decltype(to_message<S, NamedArgs, Id, Tag, Args...>());
 };
+
+constexpr auto to_span(auto const &msg) -> auto & { return msg; }
+
+template <typename T>
+concept cib_message_like = requires(T const &t) { t.as_const_view().data(); };
+
+constexpr auto to_span(cib_message_like auto const &msg) {
+    return msg.as_const_view().data();
+}
+
+template <typename W, typename Pkt>
+concept writer_for = requires(W &w, Pkt const &pkt) { w(to_span(pkt)); };
 } // namespace detail
 
 template <typename Destinations> struct log_writer {
-    auto operator()(auto msg) -> void {
+    auto operator()(auto const &msg) -> void {
         stdx::for_each(
             [&]<typename Dest>(Dest &dest) {
                 conc::call_in_critical_section<Dest>([&] { dest(msg); });
@@ -83,7 +95,7 @@ template <typename Destinations> struct log_writer {
 };
 template <typename T> log_writer(T) -> log_writer<T>;
 
-template <writer_like Writer> struct log_handler {
+template <typename Writer> struct log_handler {
     template <typename Env, typename FilenameStringType,
               typename LineNumberType, typename FmtResult>
     auto log(FilenameStringType, LineNumberType, FmtResult const &fr) -> void {
@@ -93,7 +105,7 @@ template <writer_like Writer> struct log_handler {
     template <typename Env, typename FmtResult>
     auto log_msg(FmtResult const &fr) -> void {
         auto builder = get_builder(Env{});
-        writer_like auto writer = stdx::query<Env>(get_writer, w);
+        auto writer = stdx::query<Env>(get_writer, w);
         fr.args.apply([&]<typename... Args>(Args &&...args) {
             constexpr auto L = stdx::to_underlying(get_level(Env{}));
             using Message = typename decltype(builder)::template convert_args<
@@ -109,22 +121,28 @@ template <writer_like Writer> struct log_handler {
             auto const pkt =
                 builder.template build<L>(catalog<Message>(), module<Module>(),
                                           unit, std::forward<Args>(args)...);
-            writer(pkt.as_const_view().data());
+            static_assert(
+                detail::writer_for<decltype(writer), decltype(pkt)>,
+                "Writer cannot write the log message built by the builder");
+            writer(detail::to_span(pkt));
         });
     }
 
     template <typename Env, auto Version, stdx::ct_string S = "">
     auto log_version() -> void {
         auto builder = get_builder(Env{});
-        writer_like auto writer = stdx::query<Env>(get_writer, w);
+        auto writer = stdx::query<Env>(get_writer, w);
         auto const pkt = builder.template build_version<Version, S>();
-        writer(pkt.as_const_view().data());
+        static_assert(
+            detail::writer_for<decltype(writer), decltype(pkt)>,
+            "Writer cannot write the log version message built by the builder");
+        writer(detail::to_span(pkt));
     }
 
     Writer w;
 };
 
-template <writer_like... Dests> struct config {
+template <typename... Dests> struct config {
     using destinations_tuple_t = stdx::tuple<Dests...>;
     constexpr explicit config(Dests... dests)
         : logger{log_writer{stdx::tuple{std::move(dests)...}}} {}

--- a/include/log_binary/catalog/writer.hpp
+++ b/include/log_binary/catalog/writer.hpp
@@ -8,10 +8,6 @@
 #include <utility>
 
 namespace logging::binary {
-template <typename T>
-concept writer_like =
-    requires(T &t, stdx::span<std::uint32_t const, 1> data) { t(data); };
-
 [[maybe_unused]] constexpr inline struct get_writer_t {
     template <typename T>
     consteval auto operator()(T &&t) const noexcept(

--- a/test/log_binary/encoder.cpp
+++ b/test/log_binary/encoder.cpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
 #include <utility>
 
 namespace {
@@ -424,4 +425,38 @@ TEST_CASE("log with overridden writer", "[mipi]") {
 
     cfg.logger.log_msg<catalog_env>(stdx::ct_format<"Hello">());
     CHECK(num_custom_writer_calls == 1);
+}
+
+namespace {
+std::string_view built_nonmsg_payload{};
+
+struct nonmsg_builder : logging::mipi::default_builder<> {
+    template <auto Level, logging::packable... Ts>
+    static auto build(string_id, module_id, logging::mipi::unit_t, Ts...)
+        -> std::string_view {
+        return built_nonmsg_payload;
+    }
+};
+
+std::string_view written_nonmsg_payload{};
+
+struct nonmsg_writer {
+    auto operator()(std::string_view sv) const -> void {
+        written_nonmsg_payload = sv;
+    }
+};
+} // namespace
+
+TEST_CASE("log with custom non-message format", "[mipi]") {
+    using catalog_env =
+        stdx::make_env_t<logging::get_level, logging::level::TRACE,
+                         logging::binary::get_builder, nonmsg_builder{},
+                         logging::binary::get_writer, nonmsg_writer{}>;
+
+    static auto cfg =
+        logging::binary::config{test_log_destination<logging::level::TRACE>{}};
+
+    built_nonmsg_payload = "Hello, world!";
+    cfg.logger.log_msg<catalog_env>(stdx::ct_format<"">());
+    CHECK(written_nonmsg_payload == built_nonmsg_payload);
 }


### PR DESCRIPTION
Problem:
- The current code constrains the log writer to accepting a `stdx::span`, and assumes that the log builder will return an owning message. This makes it difficult to create variable-length messages.

Solution:
- Relax the constraints on the log writer. All the log writer needs to be able to do is accept the packet type built by the builder. If that is a variable length format, so be it.
- The conventional usage still uses an owning message which is converted to a `stdx::span`. Anything which is not a message is left alone and passed through by reference.