### PR TITLE
:bug: Log decoding fixes

### DIFF
--- a/include/log_binary/catalog/arguments.hpp
+++ b/include/log_binary/catalog/arguments.hpp
@@ -10,7 +10,7 @@ template <typename> struct encode_32;
 template <typename> struct encode_64;
 template <typename> struct encode_u32;
 template <typename> struct encode_u64;
-template <typename...> struct encode_enum;
+template <typename, typename, int> struct encode_enum;
 
 namespace logging {
 template <typename T>
@@ -65,7 +65,10 @@ template <float_packable T> struct encoding<T> {
 template <enum_packable T>
 struct encoding<T> : encoding<stdx::underlying_type_t<T>> {
     using encode_t = stdx::conditional_t<
-        std::is_scoped_enum_v<T>, encode_enum<T, stdx::underlying_type_t<T>>,
+        std::is_scoped_enum_v<T>,
+        encode_enum<T, stdx::underlying_type_t<T>,
+                    sizeof(
+                        typename encoding<stdx::underlying_type_t<T>>::pack_t)>,
         stdx::conditional_t<std::signed_integral<stdx::underlying_type_t<T>>,
                             detail::signed_encode_t<T>,
                             detail::unsigned_encode_t<T>>>;

--- a/python/cib/gen_str_catalog.py
+++ b/python/cib/gen_str_catalog.py
@@ -534,10 +534,15 @@ def arg_type_encoding(arg):
     string_re = re.compile(r"encode_(32|u32|64|u64|enum)<(.*)>")
     m = string_re.match(arg)
     if "enum" in m.group(1):
-        args_re = re.compile(r"(.*), (.*)")
+        args_re = re.compile(r"(.*), (.*), (\d+)")
         args_m = args_re.match(m.group(2))
-        return (f"encode_{m.group(1)}", args_m.group(1), args_m.group(2))
-    return (f"encode_{m.group(1)}", m.group(2), m.group(2))
+        return (
+            f"encode_{m.group(1)}",
+            args_m.group(1),
+            args_m.group(2),
+            args_m.group(3),
+        )
+    return (f"encode_{m.group(1)}", m.group(2), m.group(2), m.group(2))
 
 
 def arg_printf_spec(arg: str):
@@ -560,7 +565,7 @@ def arg_printf_spec(arg: str):
         "long long": "%lld",
         "unsigned long long": "%llu",
     }
-    enc, _, ut = arg_type_encoding(arg)
+    enc, _, ut, _ = arg_type_encoding(arg)
     return printf_dict.get(ut, printf_dict.get(enc, "%d"))
 
 
@@ -748,7 +753,7 @@ def main():
     if args.cpp_output is not None:
         for m in messages:
             for arg_type in m.args:
-                enc, enum, ut = arg_type_encoding(arg_type)
+                enc, enum, ut, _ = arg_type_encoding(arg_type)
                 if "enum" in enc:
                     scoped_enums.update({enum: ut})
 
@@ -775,7 +780,7 @@ def main():
                 }
                 for m in messages:
                     for i, arg_type in enumerate(m.args):
-                        _, enum, _ = arg_type_encoding(arg_type)
+                        _, enum, _, _ = arg_type_encoding(arg_type)
                         if enum in enums:
                             m.enum_lookup = (i + 1, enums[enum][0])
             except Exception as e:

--- a/python/cib/mipi_messages.py
+++ b/python/cib/mipi_messages.py
@@ -9,8 +9,12 @@ encoding_reader = {
     "encode_32": lambda reader: bytes(itertools.islice(reader, 4)),
     "encode_u64": lambda reader: bytes(itertools.islice(reader, 8)),
     "encode_64": lambda reader: bytes(itertools.islice(reader, 8)),
-    "encode_enum": lambda reader: bytes(itertools.islice(reader, 4)),
 }
+
+
+def enum_reader(sz, reader):
+    return bytes(itertools.islice(reader, sz))
+
 
 format_table = {
     "char": (1, "c"),
@@ -154,16 +158,19 @@ class Catalog:
     @staticmethod
     def extract_arg(db, reader, arg):
         encode_tag, spec = arg[:-1].split("<")
-        read = encoding_reader[encode_tag]
 
         if encode_tag == "encode_enum":
-            cpp_type, underlying = spec.split(",")
+            cpp_type, underlying, sz = spec.split(",")
             conv = partial(enum_converter, db, cpp_type, underlying.strip())
+            read = partial(enum_reader, int(sz))
         else:
+            read = encoding_reader[encode_tag]
             if spec in format_table:
                 conv = partial(convert, spec)
-            else:
+            elif "32" in encode_tag:
                 conv = partial(enum_converter, db, spec, "unsigned int")
+            else:
+                conv = partial(enum_converter, db, spec, "unsigned long long")
 
         return conv(read(reader))
 

--- a/python/cib/mipi_messages.py
+++ b/python/cib/mipi_messages.py
@@ -12,13 +12,39 @@ encoding_reader = {
     "encode_enum": lambda reader: bytes(itertools.islice(reader, 4)),
 }
 
-encoding_converter = {
-    "int": lambda seq: struct.unpack("<i", seq)[0],
-    "unsigned int": lambda seq: struct.unpack("<I", seq)[0],
-    "long": lambda seq: struct.unpack("<q", seq)[0],
-    "float": lambda seq: struct.unpack("<f", seq)[0],
-    "double": lambda seq: struct.unpack("<d", seq)[0],
+format_table = {
+    "char": (1, "c"),
+    "signed char": (1, "b"),
+    "unsigned char": (1, "B"),
+    "bool": (1, "b"),
+    "short": (2, "h"),
+    "unsigned short": (2, "H"),
+    "int": (4, "i"),
+    "unsigned int": (4, "I"),
+    "long": (4, "l"),
+    "unsigned long": (4, "L"),
+    "long long": (8, "q"),
+    "unsigned long long": (8, "Q"),
+    "float": (4, "f"),
+    "double": (8, "d"),
 }
+
+alt_format_table = {
+    "long": (8, "q"),
+    "unsigned long": (8, "Q"),
+}
+
+
+def convert(c_type, seq):
+    sz, fmt = format_table[c_type]
+    # if the production machine has 8-byte longs, adjust
+    if (c_type == "long" or c_type == "unsigned long") and len(seq) == 8:
+        sz, fmt = alt_format_table[c_type]
+    result = struct.unpack(f"<{fmt}", seq[:sz])[0]
+    # clang cindex reports "true" as value -1
+    if c_type == "bool" and result == 1:
+        result = -1
+    return result
 
 
 def enum_lookup(db, enum_type, value):
@@ -29,8 +55,7 @@ def enum_lookup(db, enum_type, value):
 
 
 def enum_converter(db, enum_type, underlying_type, seq):
-    convert = encoding_converter[underlying_type]
-    value = str(convert(seq))
+    value = str(convert(underlying_type, seq))
     return enum_lookup(db, enum_type, value)
 
 
@@ -124,8 +149,7 @@ class Catalog:
     @staticmethod
     def read_id(reader):
         read = encoding_reader["encode_u32"]
-        convert = encoding_converter["unsigned int"]
-        return convert(read(reader))
+        return convert("unsigned int", read(reader))
 
     @staticmethod
     def extract_arg(db, reader, arg):
@@ -134,14 +158,14 @@ class Catalog:
 
         if encode_tag == "encode_enum":
             cpp_type, underlying = spec.split(",")
-            convert = partial(enum_converter, db, cpp_type, underlying.strip())
+            conv = partial(enum_converter, db, cpp_type, underlying.strip())
         else:
-            if spec in encoding_converter:
-                convert = encoding_converter[spec]
+            if spec in format_table:
+                conv = partial(convert, spec)
             else:
-                convert = partial(enum_converter, db, spec, "unsigned int")
+                conv = partial(enum_converter, db, spec, "unsigned int")
 
-        return convert(read(reader))
+        return conv(read(reader))
 
     def __init__(self, reader, messages, modules, db):
         self.header = read_struct(HeaderStruct, reader)

--- a/test/log_binary/catalog/catalog2b_lib.cpp
+++ b/test/log_binary/catalog/catalog2b_lib.cpp
@@ -47,6 +47,12 @@ auto log_rt_32bit_enum_arg() -> void {
         stdx::ct_format<"Scoped 32-bit enum argument: {}">(E_32bit::VALUE));
 }
 
+auto log_rt_64bit_enum_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Scoped 64-bit enum argument: {}">(E_64bit::VALUE));
+}
+
 enum struct extra_enum {};
 
 auto log_rt_unnamed_enum_value_arg() -> void {

--- a/test/log_binary/catalog/catalog2b_lib.cpp
+++ b/test/log_binary/catalog/catalog2b_lib.cpp
@@ -23,6 +23,30 @@ auto log_rt_unscoped_enum_arg() -> void {
         stdx::ct_format<"Unscoped enum argument: {}">(VAL_E2));
 }
 
+auto log_rt_bool_enum_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Scoped bool enum argument: {}">(E_bool::VALUE));
+}
+
+auto log_rt_8bit_enum_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Scoped 8-bit enum argument: {}">(E_8bit::VALUE));
+}
+
+auto log_rt_16bit_enum_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Scoped 16-bit enum argument: {}">(E_16bit::VALUE));
+}
+
+auto log_rt_32bit_enum_arg() -> void {
+    using namespace ns;
+    cfg.logger.log_msg<log_env2b>(
+        stdx::ct_format<"Scoped 32-bit enum argument: {}">(E_32bit::VALUE));
+}
+
 enum struct extra_enum {};
 
 auto log_rt_unnamed_enum_value_arg() -> void {

--- a/test/log_binary/catalog/catalog_app.cpp
+++ b/test/log_binary/catalog/catalog_app.cpp
@@ -24,6 +24,7 @@ extern auto log_rt_bool_enum_arg() -> void;
 extern auto log_rt_8bit_enum_arg() -> void;
 extern auto log_rt_16bit_enum_arg() -> void;
 extern auto log_rt_32bit_enum_arg() -> void;
+extern auto log_rt_64bit_enum_arg() -> void;
 extern auto log_rt_auto_scoped_enum_arg() -> void;
 extern auto log_rt_unnamed_enum_value_arg() -> void;
 extern auto log_ct_unnamed_enum_value_arg() -> void;
@@ -199,6 +200,14 @@ TEST_CASE_PERSISTENT_FIXTURE(fixture, "catalog tests") {
         log_calls = 0;
         test_critical_section::count = 0;
         log_rt_32bit_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime 64-bit enum argument") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_64bit_enum_arg();
         CHECK(test_critical_section::count == 2);
         CHECK(log_calls == 1);
     }

--- a/test/log_binary/catalog/catalog_app.cpp
+++ b/test/log_binary/catalog/catalog_app.cpp
@@ -20,6 +20,10 @@ extern auto log_rt_named_arg() -> void;
 
 extern auto log_rt_scoped_enum_arg() -> void;
 extern auto log_rt_unscoped_enum_arg() -> void;
+extern auto log_rt_bool_enum_arg() -> void;
+extern auto log_rt_8bit_enum_arg() -> void;
+extern auto log_rt_16bit_enum_arg() -> void;
+extern auto log_rt_32bit_enum_arg() -> void;
 extern auto log_rt_auto_scoped_enum_arg() -> void;
 extern auto log_rt_unnamed_enum_value_arg() -> void;
 extern auto log_ct_unnamed_enum_value_arg() -> void;
@@ -163,6 +167,38 @@ TEST_CASE_PERSISTENT_FIXTURE(fixture, "catalog tests") {
         log_calls = 0;
         test_critical_section::count = 0;
         log_rt_unscoped_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime bool enum argument") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_bool_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime 8-bit enum argument") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_8bit_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime 16-bit enum argument") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_16bit_enum_arg();
+        CHECK(test_critical_section::count == 2);
+        CHECK(log_calls == 1);
+    }
+
+    SECTION("log runtime 32-bit enum argument") {
+        log_calls = 0;
+        test_critical_section::count = 0;
+        log_rt_32bit_enum_arg();
         CHECK(test_critical_section::count == 2);
         CHECK(log_calls == 1);
     }

--- a/test/log_binary/catalog/catalog_enums.hpp
+++ b/test/log_binary/catalog/catalog_enums.hpp
@@ -10,4 +10,5 @@ enum struct E_bool : bool { VALUE = true };
 enum struct E_8bit : std::uint8_t { VALUE = 0x12U };
 enum struct E_16bit : std::uint16_t { VALUE = 0x1234U };
 enum struct E_32bit : std::uint32_t { VALUE = 0x1234'5678U };
+enum struct E_64bit : std::uint64_t { VALUE = 0x1234'5678'90ab'cdefULL };
 } // namespace ns

--- a/test/log_binary/catalog/catalog_enums.hpp
+++ b/test/log_binary/catalog/catalog_enums.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
+#include <cstdint>
+
 namespace ns {
 enum struct E1 { VAL_E1 = 19 };
 enum E2 { VAL_E2 = 23 };
+
+enum struct E_bool : bool { VALUE = true };
+enum struct E_8bit : std::uint8_t { VALUE = 0x12U };
+enum struct E_16bit : std::uint16_t { VALUE = 0x1234U };
+enum struct E_32bit : std::uint32_t { VALUE = 0x1234'5678U };
 } // namespace ns

--- a/test/log_binary/catalog/catalog_output_test.py
+++ b/test/log_binary/catalog/catalog_output_test.py
@@ -52,6 +52,7 @@ def test_binary_logs():
         expected_lines.add("TRACE [default] Scoped 8-bit enum argument: VALUE")
         expected_lines.add("TRACE [default] Scoped 16-bit enum argument: VALUE")
         expected_lines.add("TRACE [default] Scoped 32-bit enum argument: VALUE")
+        expected_lines.add("TRACE [default] Scoped 64-bit enum argument: VALUE")
     else:
         expected_lines.add(
             "TRACE [default] Scoped enum argument: static_cast<ns::E1>(19)"
@@ -70,6 +71,9 @@ def test_binary_logs():
         )
         expected_lines.add(
             "TRACE [default] Scoped bool enum argument: static_cast<ns::E_32bit>(305419896)"
+        )
+        expected_lines.add(
+            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_64bit>(1311768467294899695)"
         )
 
     with open(json_filename, "r") as f:

--- a/test/log_binary/catalog/catalog_output_test.py
+++ b/test/log_binary/catalog/catalog_output_test.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from cib import log_decode as decode
 
 catalog_output = Path("./catalog_test.bin")
+decoded_catalog_output = Path("./catalog_test.txt")
 json_filename = Path("./strings.json")
 
 
@@ -47,6 +48,10 @@ def test_binary_logs():
     if module_available("clang"):
         expected_lines.add("TRACE [default] Scoped enum argument: VAL_E1")
         expected_lines.add("TRACE [default] Unscoped enum argument: VAL_E2")
+        expected_lines.add("TRACE [default] Scoped bool enum argument: VALUE")
+        expected_lines.add("TRACE [default] Scoped 8-bit enum argument: VALUE")
+        expected_lines.add("TRACE [default] Scoped 16-bit enum argument: VALUE")
+        expected_lines.add("TRACE [default] Scoped 32-bit enum argument: VALUE")
     else:
         expected_lines.add(
             "TRACE [default] Scoped enum argument: static_cast<ns::E1>(19)"
@@ -54,10 +59,24 @@ def test_binary_logs():
         expected_lines.add(
             "TRACE [default] Unscoped enum argument: static_cast<ns::E2>(23)"
         )
+        expected_lines.add(
+            "TRACE [default] Scoped enum argument: static_cast<ns::E_bool>(1)"
+        )
+        expected_lines.add(
+            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_8bit>(18)"
+        )
+        expected_lines.add(
+            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_16bit>(4660)"
+        )
+        expected_lines.add(
+            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_32bit>(305419896)"
+        )
 
     with open(json_filename, "r") as f:
         db = json.load(f)
-    for log_line in decode.read_logs(catalog_output, db):
-        assert log_line in expected_lines
-        expected_lines.remove(log_line)
+    with open(decoded_catalog_output, "w") as of:
+        for log_line in decode.read_logs(catalog_output, db):
+            of.write(f"{log_line}\n")
+            assert log_line in expected_lines
+            expected_lines.remove(log_line)
     assert not expected_lines

--- a/test/log_binary/encoder.cpp
+++ b/test/log_binary/encoder.cpp
@@ -191,8 +191,8 @@ TEST_CASE("argument encoding", "[mipi]") {
     STATIC_REQUIRE(std::same_as<P::encode_as_t<double>, encode_u64<double>>);
     STATIC_REQUIRE(
         std::same_as<P::encode_as_t<UnscopedE>, encode_u32<UnscopedE>>);
-    STATIC_REQUIRE(
-        std::same_as<P::encode_as_t<ScopedE>, encode_enum<ScopedE, int>>);
+    STATIC_REQUIRE(std::same_as<P::encode_as_t<ScopedE>,
+                                encode_enum<ScopedE, int, sizeof(int)>>);
 }
 
 TEST_CASE("log zero arguments", "[mipi]") {


### PR DESCRIPTION
Problem:
- C++ encodes a `long int` differently on different platforms: either 4 bytes or 8 bytes. The Python decoding expects it to be 8 bytes.
- Generic handling of the underlying type of an enum is not implemented.
- An enumeration value that has an underlying type of `std::uint64_t` is assumed to be 4 bytes by the log decoder.

Solution:
- Handle an enum's underlying type properly in decoding.
- Allow a `long int` to be either 4 bytes or 8 bytes (the encoding gives the size).
- Add tests for enumerations of various underlying types.
- Treat 64-bit enumeration values properly.

Note:
- `clang` reports that the `true` enumerator of an `enum` with underlying type `bool` has value `-1`. Python decodes it as `1`. So we handle this as a special case in order for `enum` lookup to work.
- It is not enough to output the underlying type of the enumeration, because `unsigned long int` might be 4 bytes or might be 8 bytes, depending on platform. Instead, use the last argument of `encode_enum` to signal the number of bytes.

Closes #954 