### PR TITLE
:arrow_down: Revert python deps to previous requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@
 /CMakePresets.json
 /toolchains
 /mull.yml
-/requirements.txt
 /docs/puppeteer_config.json
 /docs/mermaid.conf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(
         "A header-only C++ library for composing modular firmware at compile-time."
     HOMEPAGE_URL "https://github.com/intel/compile-time-init-build")
 
+set(INFRA_PROVIDE_PYTEST_REQS OFF)
+
 include(cmake/get_cpm.cmake)
 if(PROJECT_IS_TOP_LEVEL)
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# The contents of this file can be generated at latest versions available by running:
+#
+# $ python3 -m venv ./test_venv
+# $ source ./test_venv/bin/activate
+# $ pip install pytest pytest-xdist hypothesis | tail -n1 | cut -d' ' -f 3- | tr ' ' '\n' | sed 's/\(.*\)-\(.*\)/\1==\2/'
+#
+attrs==24.2.0
+execnet==2.1.1
+hypothesis==6.115.3
+iniconfig==2.0.0
+packaging==24.1
+pluggy==1.5.0
+pytest==9.0.3
+pytest-xdist==3.6.1
+sortedcontainers==2.4.0


### PR DESCRIPTION
Problem:
- The `cpp20` branch does not have the same python environment and build process as current `main`; it also requires the build to work with Ubuntu 22.04.

Solution:
- Fix the python `requirements.txt` to the old version.