### PR TITLE
Require Python 3.12 to support backslashes in f-strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
 endif()
 
 find_package(
-    Python3
+    Python3 3.12
     COMPONENTS Interpreter
     REQUIRED)
 


### PR DESCRIPTION
gen_str_catalog.py uses a newer feature from PEP 701 starting in commit 1e08177 that permits backslashes in f-strings. This feature is first supported in Python 3.12 from 2023. Explicitly calling out the version requirement may save users with older installations some time.