### PR TITLE
:art: Add git URL for python deps for pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "intel-compile-time-init-build"
 version = "0.0.1"
 requires-python = ">=3.12"
 dependencies = [
-  "intel-cicd-repo-infrastructure",
+  "intel-cicd-repo-infrastructure@git+https://github.com/intel/cicd-repo-infrastructure@dev",
   "libclang"
 ]
 license = "BSL-1.0"


### PR DESCRIPTION
Problem:
- `uv` dependency sources are listed in the `pyproject.toml` but we shouldn't prevent `pip` usage if it's easy.

Solution:
- Add the github source for CICD so that `pip` can install it.