### PR TITLE
:art: Use `for_each` member function on `stdx::bitset`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(cmake/string_catalog.cmake)
 add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)
 fmt_recipe(12.1.0)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#b8a486a")
-add_versioned_package("gh:intel/cpp-std-extensions#2ce9eab")
+add_versioned_package("gh:intel/cpp-std-extensions#6d2776f")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#3e3c8aa")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -194,21 +194,19 @@ constexpr auto remove_cheapest_bit(detail::raw_integral_t<T> mask,
     auto cheapest_bit = std::size_t{};
     auto min_num_dups = std::numeric_limits<std::size_t>::max();
 
-    for_each(
-        [&](auto i) {
-            auto btry_mask = bmask;
-            btry_mask.reset(i);
+    bmask.for_each([&](auto i) {
+        auto btry_mask = bmask;
+        btry_mask.reset(i);
 
-            std::array<raw_t, S> try_keys =
-                with_mask(btry_mask.template to<raw_t>(), keys);
+        std::array<raw_t, S> try_keys =
+            with_mask(btry_mask.template to<raw_t>(), keys);
 
-            auto num_dups = count_duplicates(try_keys);
-            if (num_dups < min_num_dups) {
-                min_num_dups = num_dups;
-                cheapest_bit = i;
-            }
-        },
-        bmask);
+        auto num_dups = count_duplicates(try_keys);
+        if (num_dups < min_num_dups) {
+            min_num_dups = num_dups;
+            cheapest_bit = i;
+        }
+    });
 
     bmask.reset(cheapest_bit);
     return bmask.template to<raw_t>();


### PR DESCRIPTION
Problem:
- Using a free function `for_each` on `stdx::bitset` can cause compilers to get confused in `constexpr` evaluation.

Solution:
- Use member function `for_each`.