### PR TITLE
Work around clang python binding enum_value bug

### DIFF
--- a/python/cib/gen_str_catalog.py
+++ b/python/cib/gen_str_catalog.py
@@ -441,7 +441,13 @@ def extract_enums(filename: str):
     for node in translation_unit.cursor.walk_preorder():
         if node.kind == CursorKind.ENUM_DECL:
             new_decl = {
-                e.spelling: e.enum_value
+                # workaround for https://github.com/llvm/llvm-project/issues/221326
+                e.spelling: 1
+                if (
+                    e.type.get_declaration().enum_type.spelling == "bool"
+                    and e.enum_value == -1
+                )
+                else e.enum_value
                 for e in node.walk_preorder()
                 if e.kind == CursorKind.ENUM_CONSTANT_DECL
             }

--- a/python/cib/mipi_messages.py
+++ b/python/cib/mipi_messages.py
@@ -45,9 +45,6 @@ def convert(c_type, seq):
     if (c_type == "long" or c_type == "unsigned long") and len(seq) == 8:
         sz, fmt = alt_format_table[c_type]
     result = struct.unpack(f"<{fmt}", seq[:sz])[0]
-    # clang cindex reports "true" as value -1
-    if c_type == "bool" and result == 1:
-        result = -1
     return result
 
 

--- a/test/log_binary/catalog/catalog_output_test.py
+++ b/test/log_binary/catalog/catalog_output_test.py
@@ -61,7 +61,7 @@ def test_binary_logs():
             "TRACE [default] Unscoped enum argument: static_cast<ns::E2>(23)"
         )
         expected_lines.add(
-            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_bool>(-1)"
+            "TRACE [default] Scoped bool enum argument: static_cast<ns::E_bool>(1)"
         )
         expected_lines.add(
             "TRACE [default] Scoped 8-bit enum argument: static_cast<ns::E_8bit>(18)"


### PR DESCRIPTION
At the moment, bool enums with an underlying value of true are given a value of -1 rather than +1 by the clang Python bindings. See https://github.com/llvm/llvm-project/issues/221326 for details.

This workaround intercepts -1 values returned by enum_value when the underlying type is bool, and replaces them with +1.

If merged this will fix #964 