### PR TITLE
Normalize signed zero lookup keys

### DIFF
--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -26,6 +26,7 @@ constexpr auto as_raw_integral(auto v) {
     static_assert(sizeof(v) <= 8);
 
     if constexpr (std::is_floating_point_v<decltype(v)>) {
+        // Normalize signed zero so +0.0 and -0.0 have the same key bits.
         if (v == 0) {
             v = 0;
         }

--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -17,12 +17,19 @@
 #include <iterator>
 #include <limits>
 #include <tuple>
+#include <type_traits>
 
 namespace lookup {
 
 namespace detail {
 constexpr auto as_raw_integral(auto v) {
     static_assert(sizeof(v) <= 8);
+
+    if constexpr (std::is_floating_point_v<decltype(v)>) {
+        if (v == 0) {
+            v = 0;
+        }
+    }
 
     if constexpr (sizeof(v) == 1) {
         return std::bit_cast<std::uint8_t>(v);

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -58,6 +58,22 @@ TEMPLATE_TEST_CASE("lookup with non-integral values", "[pseudo pext lookup]",
     CHECK(lookup[91] == 0.41);
 }
 
+TEMPLATE_TEST_CASE("lookup with signed zero keys", "[pseudo pext lookup]",
+                   pseudo_pext_direct, pseudo_pext_indirect_1,
+                   pseudo_pext_indirect_2, pseudo_pext_indirect_3,
+                   pseudo_pext_indirect_4) {
+    constexpr auto lookup =
+        TestType::make(CX_VALUE(lookup::input<float, int, 5>{
+            -1, std::array{lookup::entry{-0.0f, 13}, lookup::entry{1.0f, 42},
+                           lookup::entry{2.0f, 10}, lookup::entry{3.0f, 76},
+                           lookup::entry{4.0f, 25}}}));
+
+    CHECK(lookup[0.0f] == 13);
+    CHECK(lookup[-0.0f] == 13);
+    CHECK(lookup[1.0f] == 42);
+    CHECK(lookup[5.0f] == -1);
+}
+
 TEMPLATE_TEST_CASE("lookup with uint8_t entries", "[pseudo pext lookup]",
                    pseudo_pext_direct, pseudo_pext_indirect_1,
                    pseudo_pext_indirect_2, pseudo_pext_indirect_3,


### PR DESCRIPTION
Normalize floating-point zero before hashing so +0 and -0 match.