### PR TITLE
Guard lookup table sizing

### DIFF
--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -364,11 +364,17 @@ struct pseudo_pext_lookup {
         using search_len_t = smuggler<search_len>;
 
         constexpr auto p = detail::pseudo_pext_t(mask);
-        constexpr auto lookup_table_size = 1 << std::popcount(mask);
+        constexpr auto lookup_table_size =
+            std::popcount(mask) < std::numeric_limits<int>::digits
+                ? std::size_t{1} << std::popcount(mask)
+                : std::size_t{};
 
         using default_value = default_value_smuggler<decltype(i)>;
 
-        if constexpr (input.entries.empty()) {
+        if constexpr (lookup_table_size == 0) {
+            return strategy_failed_t{};
+
+        } else if constexpr (input.entries.empty()) {
             return empty_impl<key_type, value_type, default_value>{};
 
         } else if constexpr (use_indirect_strategy) {

--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -364,9 +364,10 @@ struct pseudo_pext_lookup {
         using search_len_t = smuggler<search_len>;
 
         constexpr auto p = detail::pseudo_pext_t(mask);
+        constexpr auto num_mask_bits = std::popcount(mask);
         constexpr auto lookup_table_size =
-            std::popcount(mask) < std::numeric_limits<int>::digits
-                ? std::size_t{1} << std::popcount(mask)
+            num_mask_bits < std::numeric_limits<int>::digits
+                ? std::size_t{1} << num_mask_bits
                 : std::size_t{};
 
         using default_value = default_value_smuggler<decltype(i)>;

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -6,8 +6,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <limits>
-
 using pseudo_pext_direct = lookup::pseudo_pext_lookup<>;
 using pseudo_pext_indirect_1 = lookup::pseudo_pext_lookup<true, 1>;
 using pseudo_pext_indirect_2 = lookup::pseudo_pext_lookup<true, 2>;
@@ -101,15 +99,13 @@ TEMPLATE_TEST_CASE("lookup with scoped enum entries", "[pseudo pext lookup]",
     CHECK(lookup[some_key_t::GAMMA] == 4);
 }
 
-TEMPLATE_TEST_CASE("lookup rejects oversized tables", "[pseudo pext lookup]",
-                   std::uint32_t, std::uint64_t) {
+TEST_CASE("lookup rejects oversized tables", "[pseudo pext lookup]") {
     constexpr auto input = CX_VALUE([] {
-        lookup::input<TestType, int, std::numeric_limits<TestType>::digits + 1>
-            i{};
-        for (auto bit = std::size_t{}; bit < i.entries.size() - 1; ++bit) {
-            i.entries[bit + 1].key_ = TestType{1} << bit;
+        std::array<lookup::entry<std::uint32_t, int>, 33> entries{};
+        for (auto bit = std::size_t{}; bit < entries.size() - 1; ++bit) {
+            entries[bit + 1].key_ = std::uint32_t{1} << bit;
         }
-        return i;
+        return lookup::input{0, entries};
     }());
 
     STATIC_REQUIRE(lookup::strategy_failed(pseudo_pext_direct::make(input)));

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -6,6 +6,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <limits>
+
 using pseudo_pext_direct = lookup::pseudo_pext_lookup<>;
 using pseudo_pext_indirect_1 = lookup::pseudo_pext_lookup<true, 1>;
 using pseudo_pext_indirect_2 = lookup::pseudo_pext_lookup<true, 2>;
@@ -99,9 +101,12 @@ TEMPLATE_TEST_CASE("lookup with scoped enum entries", "[pseudo pext lookup]",
     CHECK(lookup[some_key_t::GAMMA] == 4);
 }
 
-TEST_CASE("lookup rejects oversized tables", "[pseudo pext lookup]") {
+TEMPLATE_TEST_CASE_SIG("lookup rejects oversized tables",
+                       "[pseudo pext lookup]", ((std::size_t Bits), Bits),
+                       std::numeric_limits<int>::digits,
+                       std::numeric_limits<std::uint32_t>::digits) {
     constexpr auto input = CX_VALUE([] {
-        std::array<lookup::entry<std::uint32_t, int>, 33> entries{};
+        std::array<lookup::entry<std::uint32_t, int>, Bits + 1> entries{};
         for (auto bit = std::size_t{}; bit < entries.size() - 1; ++bit) {
             entries[bit + 1].key_ = std::uint32_t{1} << bit;
         }

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -6,6 +6,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <limits>
+
 using pseudo_pext_direct = lookup::pseudo_pext_lookup<>;
 using pseudo_pext_indirect_1 = lookup::pseudo_pext_lookup<true, 1>;
 using pseudo_pext_indirect_2 = lookup::pseudo_pext_lookup<true, 2>;
@@ -97,6 +99,22 @@ TEMPLATE_TEST_CASE("lookup with scoped enum entries", "[pseudo pext lookup]",
     CHECK(lookup[some_key_t::BETA] == 23);
     CHECK(lookup[some_key_t::KAPPA] == 87);
     CHECK(lookup[some_key_t::GAMMA] == 4);
+}
+
+TEMPLATE_TEST_CASE("lookup rejects oversized tables", "[pseudo pext lookup]",
+                   std::uint32_t, std::uint64_t) {
+    constexpr auto input = CX_VALUE([] {
+        lookup::input<TestType, int, std::numeric_limits<TestType>::digits + 1>
+            i{};
+        for (auto bit = std::size_t{}; bit < i.entries.size() - 1; ++bit) {
+            i.entries[bit + 1].key_ = TestType{1} << bit;
+        }
+        return i;
+    }());
+
+    STATIC_REQUIRE(lookup::strategy_failed(pseudo_pext_direct::make(input)));
+    STATIC_REQUIRE(
+        lookup::strategy_failed(pseudo_pext_indirect_1::make(input)));
 }
 
 TEST_CASE("pbt regression 0", "[pseudo pext lookup]") {


### PR DESCRIPTION
Return strategy_failed_t for masks outside the supported table-size range instead of overflowing the size expression.