### PR TITLE
Respect the lookup search limit

### DIFF
--- a/include/lookup/pseudo_pext_lookup.hpp
+++ b/include/lookup/pseudo_pext_lookup.hpp
@@ -243,7 +243,7 @@ constexpr auto calc_pseudo_pext_mask(std::array<entry<T, V>, S> const &pairs,
     while (max_search_len > 1 && std::popcount(mask) > 4) {
         auto try_mask = remove_cheapest_bit(mask, keys);
         auto current_longest_run = count_longest_run(with_mask(try_mask, keys));
-        if (current_longest_run <= max_search_len) {
+        if (current_longest_run < max_search_len) {
             mask = try_mask;
             prev_longest_run = current_longest_run;
         } else {

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -134,3 +134,19 @@ TEST_CASE("pbt regression 1", "[pseudo pext lookup]") {
     CHECK(lookup[30] == 0);
     CHECK(lookup[31] == 1);
 }
+
+TEST_CASE("lookup respects the maximum search length", "[pseudo pext lookup]") {
+    constexpr auto lookup = pseudo_pext_indirect_2::make(CX_VALUE([] {
+        lookup::input<std::uint32_t, std::uint32_t, 33> i{};
+        for (auto key = std::uint32_t{}; key < i.entries.size(); ++key) {
+            i.entries[key] = {key, key + 1};
+        }
+        return i;
+    }()));
+
+    CHECK(decltype(lookup)::search_len <= 2);
+    for (auto key = std::uint32_t{}; key < 33; ++key) {
+        CHECK(lookup[key] == key + 1);
+    }
+    CHECK(lookup[33] == 0);
+}

--- a/test/lookup/pseudo_pext_lookup.cpp
+++ b/test/lookup/pseudo_pext_lookup.cpp
@@ -137,15 +137,15 @@ TEST_CASE("pbt regression 1", "[pseudo pext lookup]") {
 
 TEST_CASE("lookup respects the maximum search length", "[pseudo pext lookup]") {
     constexpr auto lookup = pseudo_pext_indirect_2::make(CX_VALUE([] {
-        lookup::input<std::uint32_t, std::uint32_t, 33> i{};
-        for (auto key = std::uint32_t{}; key < i.entries.size(); ++key) {
-            i.entries[key] = {key, key + 1};
+        std::array<lookup::entry<std::uint8_t, int>, 33> entries{};
+        for (auto key = std::uint8_t{}; key < entries.size(); ++key) {
+            entries[key] = {key, key + 1};
         }
-        return i;
+        return lookup::input{0, entries};
     }()));
 
     CHECK(decltype(lookup)::search_len <= 2);
-    for (auto key = std::uint32_t{}; key < 33; ++key) {
+    for (auto key = std::uint8_t{}; key < 33; ++key) {
         CHECK(lookup[key] == key + 1);
     }
     CHECK(lookup[33] == 0);


### PR DESCRIPTION
Account for the run-length offset when enforcing MaxSearchLen.